### PR TITLE
fix: UTF-8 safe truncation to prevent panics on multi-byte characters

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1330,14 +1330,11 @@ impl AgentLogic {
                 let finalize_tool_output = |res: Result<String, String>| -> String {
                     match res {
                         Ok(mut output) => {
-                            if output.len() > max_tool_output_chars {
-                                let mut end = max_tool_output_chars;
-                                while end > 0 && !output.is_char_boundary(end) {
-                                    end -= 1;
-                                }
-                                output.truncate(end);
-                                output.push_str("\n... [TRUNCATED FOR LENGTH]");
-                            }
+                            crate::utils::truncate_utf8_safe(
+                                &mut output,
+                                max_tool_output_chars,
+                                "\n... [TRUNCATED FOR LENGTH]",
+                            );
                             output
                         }
                         Err(e) => format!("Error: {}", e),

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1331,7 +1331,11 @@ impl AgentLogic {
                     match res {
                         Ok(mut output) => {
                             if output.len() > max_tool_output_chars {
-                                output.truncate(max_tool_output_chars);
+                                let mut end = max_tool_output_chars;
+                                while end > 0 && !output.is_char_boundary(end) {
+                                    end -= 1;
+                                }
+                                output.truncate(end);
                                 output.push_str("\n... [TRUNCATED FOR LENGTH]");
                             }
                             output

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -81,16 +81,8 @@ const ST_FAILED: u8 = 3;
 const ST_CANCELLED: u8 = 4;
 
 fn truncate_sqlite_field(s: String, max: usize) -> String {
-    if s.len() <= max {
-        return s;
-    }
     let mut t = s;
-    let mut end = max;
-    while end > 0 && !t.is_char_boundary(end) {
-        end -= 1;
-    }
-    t.truncate(end);
-    t.push_str("\n… [truncated for sqlite]");
+    crate::utils::truncate_utf8_safe(&mut t, max, "\n… [truncated for sqlite]");
     t
 }
 

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -85,7 +85,11 @@ fn truncate_sqlite_field(s: String, max: usize) -> String {
         return s;
     }
     let mut t = s;
-    t.truncate(max);
+    let mut end = max;
+    while end > 0 && !t.is_char_boundary(end) {
+        end -= 1;
+    }
+    t.truncate(end);
     t.push_str("\n… [truncated for sqlite]");
     t
 }

--- a/src/execution/execution_jobs.rs
+++ b/src/execution/execution_jobs.rs
@@ -417,7 +417,11 @@ impl ExecutionJobManager {
             Some(result) => {
                 let mut s = serde_json::to_string_pretty(&result).map_err(|e| e.to_string())?;
                 if s.len() > max_chars {
-                    s.truncate(max_chars);
+                    let mut end = max_chars;
+                    while end > 0 && !s.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    s.truncate(end);
                     s.push_str("\n\n… (truncated to configured max_tool_output_chars)\n");
                 }
                 Ok(s)

--- a/src/execution/execution_jobs.rs
+++ b/src/execution/execution_jobs.rs
@@ -416,14 +416,11 @@ impl ExecutionJobManager {
         match res {
             Some(result) => {
                 let mut s = serde_json::to_string_pretty(&result).map_err(|e| e.to_string())?;
-                if s.len() > max_chars {
-                    let mut end = max_chars;
-                    while end > 0 && !s.is_char_boundary(end) {
-                        end -= 1;
-                    }
-                    s.truncate(end);
-                    s.push_str("\n\n… (truncated to configured max_tool_output_chars)\n");
-                }
+                crate::utils::truncate_utf8_safe(
+                    &mut s,
+                    max_chars,
+                    "\n\n… (truncated to configured max_tool_output_chars)\n",
+                );
                 Ok(s)
             }
             None => {

--- a/src/tools/ml_domain.rs
+++ b/src/tools/ml_domain.rs
@@ -87,7 +87,11 @@ impl Tool for ArxivSearchTool {
 
         let mut out = body;
         if out.len() > self.max_output_chars {
-            out.truncate(self.max_output_chars);
+            let mut end = self.max_output_chars;
+            while end > 0 && !out.is_char_boundary(end) {
+                end -= 1;
+            }
+            out.truncate(end);
             out.push_str("\n... [TRUNCATED]");
         }
         Ok(out)
@@ -152,7 +156,11 @@ impl Tool for ArxivFetchTool {
             .await
             .map_err(|e| format!("arxiv_fetch body: {}", e))?;
         if body.len() > self.max_output_chars {
-            body.truncate(self.max_output_chars);
+            let mut end = self.max_output_chars;
+            while end > 0 && !body.is_char_boundary(end) {
+                end -= 1;
+            }
+            body.truncate(end);
             body.push_str("\n... [TRUNCATED]");
         }
         Ok(body)
@@ -272,7 +280,11 @@ impl Tool for HfHubFileFetchTool {
             .await
             .map_err(|e| format!("hf_hub_file_fetch body: {}", e))?;
         if body.len() > self.max_output_chars {
-            body.truncate(self.max_output_chars);
+            let mut end = self.max_output_chars;
+            while end > 0 && !body.is_char_boundary(end) {
+                end -= 1;
+            }
+            body.truncate(end);
             body.push_str("\n... [TRUNCATED]");
         }
         Ok(body)

--- a/src/tools/ml_domain.rs
+++ b/src/tools/ml_domain.rs
@@ -86,14 +86,7 @@ impl Tool for ArxivSearchTool {
             .map_err(|e| format!("arxiv_search body: {}", e))?;
 
         let mut out = body;
-        if out.len() > self.max_output_chars {
-            let mut end = self.max_output_chars;
-            while end > 0 && !out.is_char_boundary(end) {
-                end -= 1;
-            }
-            out.truncate(end);
-            out.push_str("\n... [TRUNCATED]");
-        }
+        crate::utils::truncate_utf8_safe(&mut out, self.max_output_chars, "\n... [TRUNCATED]");
         Ok(out)
     }
 }
@@ -155,14 +148,7 @@ impl Tool for ArxivFetchTool {
             .text()
             .await
             .map_err(|e| format!("arxiv_fetch body: {}", e))?;
-        if body.len() > self.max_output_chars {
-            let mut end = self.max_output_chars;
-            while end > 0 && !body.is_char_boundary(end) {
-                end -= 1;
-            }
-            body.truncate(end);
-            body.push_str("\n... [TRUNCATED]");
-        }
+        crate::utils::truncate_utf8_safe(&mut body, self.max_output_chars, "\n... [TRUNCATED]");
         Ok(body)
     }
 }
@@ -279,14 +265,7 @@ impl Tool for HfHubFileFetchTool {
             .text()
             .await
             .map_err(|e| format!("hf_hub_file_fetch body: {}", e))?;
-        if body.len() > self.max_output_chars {
-            let mut end = self.max_output_chars;
-            while end > 0 && !body.is_char_boundary(end) {
-                end -= 1;
-            }
-            body.truncate(end);
-            body.push_str("\n... [TRUNCATED]");
-        }
+        crate::utils::truncate_utf8_safe(&mut body, self.max_output_chars, "\n... [TRUNCATED]");
         Ok(body)
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -490,6 +490,21 @@ pub fn resolve_path(sandbox_dir: &Path, agent_path: &str) -> Option<PathBuf> {
     }
 }
 
+/// Truncate a `String` to at most `max_bytes` bytes without splitting a multi-byte
+/// UTF-8 character, then append `suffix`. The truncation point is adjusted so the
+/// **total** result (truncated content + suffix) stays within `max_bytes`.
+pub fn truncate_utf8_safe(s: &mut String, max_bytes: usize, suffix: &str) {
+    if s.len() <= max_bytes {
+        return;
+    }
+    let mut end = max_bytes.saturating_sub(suffix.len());
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s.truncate(end);
+    s.push_str(suffix);
+}
+
 /// Robustly extracts a JSON object from a raw LLM text response.
 /// Intended to handle markdown formatting (` ```json ... ``` `)
 /// or conversational wrappers around the core `{ ... }` payload.


### PR DESCRIPTION
## Summary

- `String::truncate()` panics when the byte index falls inside a multi-byte UTF-8 character (Turkish ş/ı/ü/ö/ç/ğ, currency ₺, CJK, emoji, etc.)
- Added `is_char_boundary()` guard before every bare `truncate()` call that was missing one
- 6 call sites fixed across 4 files; other truncation sites already had the guard

## Affected files

| File | Function |
|---|---|
| `src/agent/mod.rs` | `finalize_tool_output` |
| `src/agent/subagent.rs` | `truncate_sqlite_field` |
| `src/execution/execution_jobs.rs` | job result serialization |
| `src/tools/ml_domain.rs` | `arxiv_search`, `arxiv_fetch`, `hf_hub_file_fetch` |

## Reproduction

Any tool output containing multi-byte UTF-8 characters that exceeds `max_tool_output_chars` triggers the panic when the truncation index lands inside a character. Common with Turkish locale content (ş, ı, ₺) and ArXiv/HuggingFace responses containing non-ASCII.

## Test plan

- [x] `cargo check --release` passes
- [ ] Verify with non-ASCII heavy tool output (Turkish, CJK, emoji)