### PR TITLE
feat: mouse text selection and copy in transcript pane

### DIFF
--- a/src/channels/terminal_ui/app.rs
+++ b/src/channels/terminal_ui/app.rs
@@ -189,6 +189,32 @@ pub enum Cell {
     },
 }
 
+/// Mouse text-selection state for the transcript pane.
+#[derive(Debug, Clone, Copy)]
+pub struct TranscriptSelection {
+    pub anchor_line: usize,
+    pub anchor_col: usize,
+    pub end_line: usize,
+    pub end_col: usize,
+}
+
+impl TranscriptSelection {
+    /// Return `(start_line, start_col, end_line, end_col)` with start <= end.
+    pub fn normalized(&self) -> (usize, usize, usize, usize) {
+        if self.anchor_line < self.end_line
+            || (self.anchor_line == self.end_line && self.anchor_col <= self.end_col)
+        {
+            (self.anchor_line, self.anchor_col, self.end_line, self.end_col)
+        } else {
+            (self.end_line, self.end_col, self.anchor_line, self.anchor_col)
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.anchor_line == self.end_line && self.anchor_col == self.end_col
+    }
+}
+
 /// Ephemeral status-strip message (e.g. copy confirmation).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToastKind {
@@ -232,6 +258,12 @@ pub struct App {
     pub thinking: bool,
     /// Last drawn transcript widget area (for mouse wheel hit-testing).
     pub last_transcript_rect: Option<Rect>,
+    /// First visible line index in the transcript (set by renderer for mouse coordinate mapping).
+    pub last_transcript_visible_start: usize,
+    /// Active mouse text selection in the transcript pane.
+    pub transcript_selection: Option<TranscriptSelection>,
+    /// True while the left mouse button is held during a drag selection.
+    pub selecting: bool,
     /// Short-lived message shown in the status strip (not stored in the transcript).
     pub toast: Option<Toast>,
     /// Latest `execution_run` stream (Jupyter); shown in a dedicated strip below the transcript.
@@ -307,6 +339,9 @@ impl App {
             should_quit: false,
             thinking: false,
             last_transcript_rect: None,
+            last_transcript_visible_start: 0,
+            transcript_selection: None,
+            selecting: false,
             toast: None,
             execution_stream_recent: String::new(),
             execution_stream_label: None,

--- a/src/channels/terminal_ui/mod.rs
+++ b/src/channels/terminal_ui/mod.rs
@@ -17,7 +17,7 @@ mod theme;
 
 pub use app::{
     AgentTaskEntry, AgentTaskStatus, App, Cell, JobStripEntry, JobStripStatus, TerminalUiFocus,
-    TerminalUiMode, ToastKind, ToolNoticePhase, ToolRailEntry,
+    TerminalUiMode, ToastKind, ToolNoticePhase, ToolRailEntry, TranscriptSelection,
 };
 pub use theme::{init_from_env, uses_ansi_color, Theme};
 

--- a/src/channels/terminal_ui/panes/mod.rs
+++ b/src/channels/terminal_ui/panes/mod.rs
@@ -13,4 +13,4 @@ pub use executions::{
     executions_output_paragraph,
 };
 pub use tool_history::tool_history_paragraph;
-pub use transcript::transcript_paragraph;
+pub use transcript::{extract_selection_text, transcript_paragraph};

--- a/src/channels/terminal_ui/panes/transcript.rs
+++ b/src/channels/terminal_ui/panes/transcript.rs
@@ -1,16 +1,22 @@
 use ratatui::layout::Rect;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
+use unicode_width::UnicodeWidthChar;
 
 use super::cell_render::flatten_cells_to_lines;
+use crate::channels::terminal_ui::app::TranscriptSelection;
 use crate::channels::terminal_ui::Cell;
 use crate::channels::terminal_ui::Theme;
 
+/// Build the transcript widget, optionally highlighting a mouse selection.
+///
+/// Returns `(paragraph, max_scroll, visible_start_index)`.
 pub fn transcript_paragraph(
     cells: &[Cell],
     transcript_area: Rect,
     scroll_from_bottom: u16,
-) -> (Paragraph<'static>, u16) {
+    selection: Option<&TranscriptSelection>,
+) -> (Paragraph<'static>, u16, usize) {
     let inner_w = transcript_area.width.saturating_sub(2) as usize;
     let lines = flatten_cells_to_lines(cells, inner_w.max(8));
     let visible = transcript_area.height.saturating_sub(2) as usize;
@@ -20,10 +26,155 @@ pub fn transcript_paragraph(
         .saturating_sub(visible)
         .saturating_sub(scroll_from_bottom as usize);
     let take = visible.max(1);
-    let slice: Vec<Line<'static>> = lines.into_iter().skip(start).take(take).collect();
+    let mut slice: Vec<Line<'static>> = lines.into_iter().skip(start).take(take).collect();
+
+    // Apply selection highlighting if active.
+    if let Some(sel) = selection {
+        if !sel.is_empty() {
+            apply_selection_to_lines(&mut slice, start, sel);
+        }
+    }
+
     let block = Block::default()
         .borders(Borders::ALL)
         .title(Span::styled(" transcript ", Theme::dim()))
         .border_style(Theme::dim());
-    (Paragraph::new(Text::from(slice)).block(block), max_scroll)
+    (Paragraph::new(Text::from(slice)).block(block), max_scroll, start)
+}
+
+/// Extract plain text from the selected region for clipboard copy.
+pub fn extract_selection_text(
+    cells: &[Cell],
+    inner_width: usize,
+    sel: &TranscriptSelection,
+) -> String {
+    let lines = flatten_cells_to_lines(cells, inner_width.max(8));
+    let (sl, sc, el, ec) = sel.normalized();
+    let mut out = String::new();
+    for (i, line) in lines.iter().enumerate() {
+        if i < sl || i > el {
+            continue;
+        }
+        let plain: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        let start_col = if i == sl { sc } else { 0 };
+        let end_col = if i == el { ec } else { usize::MAX };
+        // Map display columns to byte offsets.
+        let mut col = 0usize;
+        let mut byte_start = plain.len();
+        let mut byte_end = plain.len();
+        for (bi, ch) in plain.char_indices() {
+            if col == start_col {
+                byte_start = bi;
+            }
+            col += ch.width().unwrap_or(0);
+            if col >= end_col && byte_end == plain.len() {
+                byte_end = bi + ch.len_utf8();
+                break;
+            }
+        }
+        if byte_start == plain.len() {
+            byte_start = plain.len();
+        }
+        if byte_end < byte_start {
+            byte_end = byte_start;
+        }
+        if i > sl {
+            out.push('\n');
+        }
+        out.push_str(&plain[byte_start..byte_end]);
+    }
+    out
+}
+
+// ── Selection highlighting ──────────────────────────────────────────
+
+fn apply_selection_to_lines(
+    visible_lines: &mut [Line<'static>],
+    visible_start: usize,
+    sel: &TranscriptSelection,
+) {
+    let (sl, sc, el, ec) = sel.normalized();
+    for (idx, line) in visible_lines.iter_mut().enumerate() {
+        let abs = visible_start + idx;
+        if abs < sl || abs > el {
+            continue;
+        }
+        let line_sc = if abs == sl { sc } else { 0 };
+        let line_ec = if abs == el { ec } else { usize::MAX };
+        if line_sc == line_ec {
+            continue;
+        }
+        *line = highlight_line_range(line, line_sc, line_ec);
+    }
+}
+
+/// Clone `line` with `Theme::selection()` patched onto the display-column range `[sc..ec)`.
+fn highlight_line_range(line: &Line<'static>, sc: usize, ec: usize) -> Line<'static> {
+    let highlight = Theme::selection();
+    let mut out_spans: Vec<Span<'static>> = Vec::new();
+    let mut col: usize = 0;
+    for span in &line.spans {
+        let span_start = col;
+        let span_w: usize = span
+            .content
+            .chars()
+            .map(|c| c.width().unwrap_or(0))
+            .sum();
+        let span_end = span_start + span_w;
+        col = span_end;
+
+        if span_end <= sc || span_start >= ec {
+            // Entirely outside selection.
+            out_spans.push(span.clone());
+            continue;
+        }
+        if span_start >= sc && span_end <= ec {
+            // Entirely inside selection.
+            out_spans.push(Span::styled(
+                span.content.clone(),
+                span.style.patch(highlight),
+            ));
+            continue;
+        }
+        // Partial overlap — split at column boundaries.
+        let mut byte_off = 0usize;
+        let mut dcol = span_start;
+        let text = span.content.as_ref();
+        let mut seg_start = 0usize;
+        let mut in_sel = dcol >= sc && dcol < ec;
+
+        for ch in text.chars() {
+            let cw = ch.width().unwrap_or(0);
+            let next_dcol = dcol + cw;
+            // Is this char inside [sc..ec)?
+            let char_inside = dcol >= sc && dcol < ec;
+            if char_inside != in_sel {
+                // Flush segment.
+                let seg = &text[seg_start..byte_off];
+                if !seg.is_empty() {
+                    let st = if in_sel {
+                        span.style.patch(highlight)
+                    } else {
+                        span.style
+                    };
+                    out_spans.push(Span::styled(seg.to_owned(), st));
+                }
+                seg_start = byte_off;
+                in_sel = char_inside;
+            }
+            byte_off += ch.len_utf8();
+            dcol = next_dcol;
+        }
+        // Flush remaining.
+        let seg = &text[seg_start..];
+        if !seg.is_empty() {
+            let st = if in_sel {
+                span.style.patch(highlight)
+            } else {
+                span.style
+            };
+            out_spans.push(Span::styled(seg.to_owned(), st));
+        }
+    }
+    Line::from(out_spans)
 }

--- a/src/channels/terminal_ui/panes/transcript.rs
+++ b/src/channels/terminal_ui/panes/transcript.rs
@@ -63,7 +63,7 @@ pub fn extract_selection_text(
         let mut byte_start = plain.len();
         let mut byte_end = plain.len();
         for (bi, ch) in plain.char_indices() {
-            if col == start_col {
+            if col >= start_col && byte_start == plain.len() {
                 byte_start = bi;
             }
             col += ch.width().unwrap_or(0);
@@ -71,12 +71,6 @@ pub fn extract_selection_text(
                 byte_end = bi + ch.len_utf8();
                 break;
             }
-        }
-        if byte_start == plain.len() {
-            byte_start = plain.len();
-        }
-        if byte_end < byte_start {
-            byte_end = byte_start;
         }
         if i > sl {
             out.push('\n');

--- a/src/channels/terminal_ui/run.rs
+++ b/src/channels/terminal_ui/run.rs
@@ -814,8 +814,8 @@ fn mouse_to_transcript_coords(
     let content_x = rect.x.saturating_add(1);
     let max_row = rect.y.saturating_add(rect.height).saturating_sub(2);
     let max_col = rect.x.saturating_add(rect.width).saturating_sub(2);
-    let row = mouse_row.clamp(content_y, max_row);
-    let col = mouse_col.clamp(content_x, max_col);
+    let row = mouse_row.clamp(content_y, content_y.max(max_row));
+    let col = mouse_col.clamp(content_x, content_x.max(max_col));
     let content_row = (row - content_y) as usize;
     let content_col = (col - content_x) as usize;
     (visible_start + content_row, content_col)

--- a/src/channels/terminal_ui/run.rs
+++ b/src/channels/terminal_ui/run.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use crossterm::{
     event::{
         self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-        Event, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind,
+        Event, KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind,
     },
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -24,7 +24,8 @@ use crate::channels::terminal_ui::history_cells;
 use crate::channels::terminal_ui::panes::{
     conversations_ensure_list_shows_selection, conversations_list_paragraph,
     executions_code_paragraph, executions_ensure_list_shows_selection, executions_list_paragraph,
-    executions_output_paragraph, tool_history_paragraph, transcript_paragraph,
+    executions_output_paragraph, extract_selection_text, tool_history_paragraph,
+    transcript_paragraph,
 };
 use crate::channels::terminal_ui::protocol::{
     ISANAGENT_AGENT_THOUGHT, ISANAGENT_EXECUTION_JOB, ISANAGENT_EXECUTION_JOB_STARTED,
@@ -39,7 +40,7 @@ use crate::channels::terminal_ui::protocol::{
 use crate::channels::terminal_ui::text_format::truncate_chars_display;
 use crate::channels::terminal_ui::{
     execution_browser, init_from_env, uses_ansi_color, AgentTaskStatus, App, Cell, JobStripStatus,
-    TerminalUiFocus, Theme, ToastKind, ToolNoticePhase, ToolRailEntry,
+    TerminalUiFocus, Theme, ToastKind, ToolNoticePhase, ToolRailEntry, TranscriptSelection,
 };
 use crate::clarification::{METADATA_CLARIFICATION, METADATA_CLARIFICATION_CHOICES};
 use crate::memory::{chat_id_from_root_thread_id, MemoryMessage, SharedReply};
@@ -101,6 +102,7 @@ Keys:
   Esc               From any pane: return to transcript
   PgUp / PgDn       Scroll the focused pane; on executions: output pane (Ctrl+Pg*: code pane)
   F5                Refresh list (executions or past-sessions pane)
+  Mouse drag         Select text in the transcript pane; copies to clipboard on release
   Ctrl+Shift+M      Toggle application mouse: on = wheel scrolls panes; off = native selection/copy
   Ctrl+Shift+Y      Copy last assistant reply
   Ctrl+W / Ctrl+U   Delete word / clear line
@@ -801,6 +803,24 @@ fn rect_contains(r: Rect, col: u16, row: u16) -> bool {
     col >= r.x && col < x1 && row >= r.y && row < y1
 }
 
+/// Map terminal (col, row) to transcript `(line_index, display_column)`.
+fn mouse_to_transcript_coords(
+    mouse_col: u16,
+    mouse_row: u16,
+    rect: Rect,
+    visible_start: usize,
+) -> (usize, usize) {
+    let content_y = rect.y.saturating_add(1);
+    let content_x = rect.x.saturating_add(1);
+    let max_row = rect.y.saturating_add(rect.height).saturating_sub(2);
+    let max_col = rect.x.saturating_add(rect.width).saturating_sub(2);
+    let row = mouse_row.clamp(content_y, max_row);
+    let col = mouse_col.clamp(content_x, max_col);
+    let content_row = (row - content_y) as usize;
+    let content_col = (col - content_x) as usize;
+    (visible_start + content_row, content_col)
+}
+
 fn clamp_executions_selection(app: &mut App) {
     if app.executions_runs.is_empty() {
         app.executions_selected_idx = None;
@@ -1313,8 +1333,14 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
 
             match app.ui_focus {
                 TerminalUiFocus::Transcript => {
-                    let (w, max_s) = transcript_paragraph(&app.cells, ch[1], app.scroll_offset);
+                    let (w, max_s, vis_start) = transcript_paragraph(
+                        &app.cells,
+                        ch[1],
+                        app.scroll_offset,
+                        app.transcript_selection.as_ref(),
+                    );
                     max_transcript_scroll_holder.set(max_s);
+                    app.last_transcript_visible_start = vis_start;
                     f.render_widget(w, ch[1]);
                     app.last_transcript_rect = Some(ch[1]);
                     app.last_tool_history_rect = None;
@@ -2137,6 +2163,74 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                 _ => {}
             },
             Event::Mouse(me) => {
+                // ── Selection: drag / release (handled even outside transcript) ──
+                if app.selecting {
+                    match me.kind {
+                        MouseEventKind::Drag(MouseButton::Left) => {
+                            if let Some(rect) = app.last_transcript_rect {
+                                let (line_idx, col) = mouse_to_transcript_coords(
+                                    me.column,
+                                    me.row,
+                                    rect,
+                                    app.last_transcript_visible_start,
+                                );
+                                if let Some(sel) = &mut app.transcript_selection {
+                                    sel.end_line = line_idx;
+                                    sel.end_col = col;
+                                }
+                            }
+                            continue;
+                        }
+                        MouseEventKind::Up(MouseButton::Left) => {
+                            // Update end position from release coordinates.
+                            if let Some(rect) = app.last_transcript_rect {
+                                let (line_idx, col) = mouse_to_transcript_coords(
+                                    me.column,
+                                    me.row,
+                                    rect,
+                                    app.last_transcript_visible_start,
+                                );
+                                if let Some(sel) = &mut app.transcript_selection {
+                                    sel.end_line = line_idx;
+                                    sel.end_col = col;
+                                }
+                            }
+                            app.selecting = false;
+                            // Copy to clipboard if non-empty.
+                            if let Some(sel) = &app.transcript_selection {
+                                if !sel.is_empty() {
+                                    let inner_w = app
+                                        .last_transcript_rect
+                                        .map(|r| r.width.saturating_sub(2) as usize)
+                                        .unwrap_or(80);
+                                    let text =
+                                        extract_selection_text(&app.cells, inner_w, sel);
+                                    match arboard::Clipboard::new()
+                                        .and_then(|mut cb| cb.set_text(text.clone()))
+                                    {
+                                        Ok(_) => {
+                                            let chars = text.chars().count();
+                                            app.set_toast(
+                                                ToastKind::Ok,
+                                                format!("Copied {chars} chars"),
+                                                Duration::from_secs(TOAST_COPY_OK_SECS),
+                                            );
+                                        }
+                                        Err(e) => {
+                                            app.set_toast(
+                                                ToastKind::Err,
+                                                format!("Copy failed: {e}"),
+                                                Duration::from_secs(TOAST_COPY_ERR_SECS),
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                            continue;
+                        }
+                        _ => {}
+                    }
+                }
                 let over_transcript = app
                     .last_transcript_rect
                     .map(|r| rect_contains(r, me.column, me.row))
@@ -2152,6 +2246,23 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                         // Trackpads: horizontal wheel maps to vertical transcript scroll.
                         MouseEventKind::ScrollLeft => app.scroll_up(MOUSE_SCROLL_LINES),
                         MouseEventKind::ScrollRight => app.scroll_down(MOUSE_SCROLL_LINES),
+                        MouseEventKind::Down(MouseButton::Left) => {
+                            if let Some(rect) = app.last_transcript_rect {
+                                let (line_idx, col) = mouse_to_transcript_coords(
+                                    me.column,
+                                    me.row,
+                                    rect,
+                                    app.last_transcript_visible_start,
+                                );
+                                app.transcript_selection = Some(TranscriptSelection {
+                                    anchor_line: line_idx,
+                                    anchor_col: col,
+                                    end_line: line_idx,
+                                    end_col: col,
+                                });
+                                app.selecting = true;
+                            }
+                        }
                         _ => {}
                     }
                 } else if over_tool_history {

--- a/src/channels/terminal_ui/theme.rs
+++ b/src/channels/terminal_ui/theme.rs
@@ -98,4 +98,9 @@ impl Theme {
     pub fn input_prompt() -> Style {
         fg_mod(Color::Green, Modifier::BOLD)
     }
+
+    /// Highlight style for mouse-selected text in the transcript.
+    pub fn selection() -> Style {
+        Style::default().add_modifier(Modifier::REVERSED)
+    }
 }


### PR DESCRIPTION
## Summary

- Adds click-and-drag mouse text selection in the Ratatui transcript pane
- Selected text is visually highlighted with a reversed style (`Modifier::REVERSED`)
- On mouse release, the selected text is automatically copied to the system clipboard via `arboard`
- Supports drag outside the transcript bounds (coordinates are clamped)
- Works even on terminals that don't emit `Drag` events (end position is updated on `MouseUp`)

## Changes

- **app.rs** — Added `TranscriptSelection` struct with `anchor`/`end` positions, `normalized()` and `is_empty()` methods; added 3 new fields to `App` (`last_transcript_visible_start`, `transcript_selection`, `selecting`)
- **theme.rs** — Added `Theme::selection()` style (`Modifier::REVERSED`)
- **panes/transcript.rs** — Extended `transcript_paragraph` to accept selection and return visible start index; added `extract_selection_text()` for clipboard copy; added `apply_selection_to_lines()` / `highlight_line_range()` for display-width-aware span splitting
- **panes/mod.rs** — Exported `extract_selection_text`
- **mod.rs** — Exported `TranscriptSelection`
- **run.rs** — Added `MouseButton` + `TranscriptSelection` imports; added `mouse_to_transcript_coords()` helper; added `MouseDown`/`Drag`/`Up(Left)` handlers for selection lifecycle; updated help text

## Test plan

- [ ] Run `cargo check` / `cargo build` — compiles cleanly with no warnings
- [ ] Launch the TUI and click-drag in the transcript pane — text should highlight
- [ ] Release mouse — selected text should be copied to clipboard (toast confirms)
- [ ] Verify drag outside transcript bounds clamps correctly
- [ ] Verify scroll + selection coordinate mapping works after scrolling up
- [ ] Test with `NO_COLOR` set — selection highlight should still work (uses `Modifier::REVERSED`)