### PR TITLE
fix: repair orphaned tool_calls in context for DeepSeek compatibility

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -127,16 +127,17 @@ fn repair_tool_call_context(context: &mut Vec<crate::utils::ChatMessage>) {
             j += 1;
         }
 
-        // Inject placeholder tool responses for any missing tool_call_ids
+        // Append placeholder tool responses for any missing tool_call_ids at end of tool block
         let missing: Vec<String> = tool_call_ids
             .into_iter()
             .filter(|id| !responded.contains(id))
             .collect();
-        for id in missing.into_iter().rev() {
+        for id in missing {
             context.insert(
-                i + 1,
+                j,
                 crate::utils::ChatMessage::tool("[Cancelled — tool execution interrupted]", &id),
             );
+            j += 1;
         }
 
         i = j;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -100,6 +100,49 @@ fn context_has_tool_call(context: &[crate::utils::ChatMessage], tool_name: &str)
     })
 }
 
+/// Repair context so every assistant message with `tool_calls` is followed by a tool-role
+/// response for each `tool_call_id`. This prevents 400 errors from strict providers (e.g.
+/// DeepSeek) when a previous reasoning loop was cancelled mid-tool-execution, leaving
+/// orphaned assistant messages in memory without their corresponding tool responses.
+fn repair_tool_call_context(context: &mut Vec<crate::utils::ChatMessage>) {
+    let mut i = 0;
+    while i < context.len() {
+        let tool_call_ids: Vec<String> = match &context[i].tool_calls {
+            Some(calls) if context[i].role == "assistant" && !calls.is_empty() => {
+                calls.iter().map(|tc| tc.id.clone()).collect()
+            }
+            _ => {
+                i += 1;
+                continue;
+            }
+        };
+
+        // Collect the set of tool_call_ids that have responses immediately following
+        let mut responded: HashSet<String> = HashSet::new();
+        let mut j = i + 1;
+        while j < context.len() && context[j].role == "tool" {
+            if let Some(ref id) = context[j].tool_call_id {
+                responded.insert(id.clone());
+            }
+            j += 1;
+        }
+
+        // Inject placeholder tool responses for any missing tool_call_ids
+        let missing: Vec<String> = tool_call_ids
+            .into_iter()
+            .filter(|id| !responded.contains(id))
+            .collect();
+        for id in missing.into_iter().rev() {
+            context.insert(
+                i + 1,
+                crate::utils::ChatMessage::tool("[Cancelled — tool execution interrupted]", &id),
+            );
+        }
+
+        i = j;
+    }
+}
+
 fn should_nudge_research_depth(
     inbound: &crate::bus::InboundMessage,
     context: &[crate::utils::ChatMessage],
@@ -1345,6 +1388,9 @@ impl AgentLogic {
 
             // Strip any legacy static system prompts that SQLite may have persisted
             context.retain(|msg| msg.role != "system");
+
+            // Repair any orphaned tool_calls (e.g. from a cancelled previous iteration)
+            repair_tool_call_context(&mut context);
 
             // Fetch short term memory summaries
             let prefix = format!("{}:{}", inbound.channel, inbound.chat_id);


### PR DESCRIPTION
## Summary

- Fixes 400 `invalid_request_error` from DeepSeek when a previous reasoning loop was cancelled mid-tool-execution, leaving orphaned assistant messages (with `tool_calls`) in SQLite memory without corresponding tool response messages
- Adds `repair_tool_call_context()` which injects placeholder tool responses for any missing `tool_call_id` before sending context to the provider
- Defensive fix that works for all OpenAI-compatible providers, not just DeepSeek

## Root Cause

When the reasoning loop is cancelled (via `/cancel`, timeout, or signal):
1. The assistant message with `tool_calls` has already been persisted to memory (`agent/mod.rs:1516`)
2. The early-return on cancellation (lines 1540, 1615, 1646, 1704) skips saving the corresponding tool response messages
3. On the next turn, `get_context_since_reflection()` loads this broken sequence
4. DeepSeek strictly validates that every `tool_call_id` has a matching `tool` response — rejects with 400

## Test plan

- [ ] Verify `cargo check` passes (confirmed locally — no new warnings)
- [ ] Trigger cancellation mid-tool-execution, then send a new message — should no longer produce 400 errors on DeepSeek
- [ ] Verify other providers (OpenAI, Gemini, Anthropic) still work correctly with the repair in place