### PR TITLE
fix: strip reasoning_content for non-DeepSeek providers

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -387,10 +387,9 @@ impl LLMClient {
 
         // Strip `reasoning_content` from messages for providers that reject unknown fields.
         // Only DeepSeek models use this field; others (OpenAI, Gemini, OpenRouter) return 400.
-        let model_lower = self.model.to_lowercase();
-        let supports_reasoning = model_lower.contains("deepseek");
-        if !supports_reasoning {
-            if let Some(msgs) = body.get_mut("messages").and_then(|m| m.as_array_mut()) {
+        let model_lower = self.model.to_ascii_lowercase();
+        if !model_lower.contains("deepseek") {
+            if let Some(msgs) = body["messages"].as_array_mut() {
                 for msg in msgs.iter_mut() {
                     if let Some(obj) = msg.as_object_mut() {
                         obj.remove("reasoning_content");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -385,6 +385,20 @@ impl LLMClient {
             "temperature": self.temperature
         });
 
+        // Strip `reasoning_content` from messages for providers that reject unknown fields.
+        // Only DeepSeek models use this field; others (OpenAI, Gemini, OpenRouter) return 400.
+        let model_lower = self.model.to_lowercase();
+        let supports_reasoning = model_lower.contains("deepseek");
+        if !supports_reasoning {
+            if let Some(msgs) = body.get_mut("messages").and_then(|m| m.as_array_mut()) {
+                for msg in msgs.iter_mut() {
+                    if let Some(obj) = msg.as_object_mut() {
+                        obj.remove("reasoning_content");
+                    }
+                }
+            }
+        }
+
         if let Some(t) = tools {
             if let Some(obj) = body.as_object_mut() {
                 obj.insert("tools".to_string(), t);


### PR DESCRIPTION
## Summary

- Strips `reasoning_content` from messages before sending to providers that don't support it
- Prevents 400 errors when switching from DeepSeek to OpenAI/Gemini/OpenRouter mid-conversation

## Root Cause

DeepSeek responses include `reasoning_content` which gets stored in memory. When the user switches providers via `/model`, subsequent requests include these fields. Non-DeepSeek providers reject the unknown field with `400 Bad Request: Unrecognized request argument supplied: reasoning_content`.

## Test plan

- [ ] Chat with DeepSeek model that produces reasoning_content
- [ ] Switch to OpenAI/Gemini via `/model`
- [ ] Verify subsequent messages work without 400 errors
- [ ] Verify DeepSeek still receives reasoning_content correctly