### PR TITLE
refactor: remove global install, family providers, fix compose cursor, update models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,9 +1887,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "ctutils",
  "subtle",
@@ -2285,7 +2285,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "isanagent"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arboard",
  "async-stream",
@@ -2672,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "module-lattice"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7c90d33a0dac244570c26461d761ffaeadb3bfc2b17cc625ae2185cafdffae"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
 dependencies = [
  "ctutils",
  "hybrid-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,6 @@ license = "Apache-2.0"
 repository = "https://github.com/altaidevorg/isanagent"
 # `russh` (SSH client) requires Rust 1.85+.
 rust-version = "1.85"
-# Not intended for global installation via `cargo install`. Run from the repo with `cargo run`.
-publish = false
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "isanagent"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/altaidevorg/isanagent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0"
 repository = "https://github.com/altaidevorg/isanagent"
 # `russh` (SSH client) requires Rust 1.85+.
 rust-version = "1.85"
+# Not intended for global installation via `cargo install`. Run from the repo with `cargo run`.
+publish = false
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -52,24 +52,34 @@ If that’s the kind of “finish the thing and show your work” energy you wan
 
 ## Get started
 
-### Build from source
+**Fast path:** download a prebuilt binary from **[Releases](https://github.com/altaidevorg/isanagent/releases)** (Linux, **macOS** Apple silicon, and Windows), run it, and complete the first-run wizard. The embedded browser UI is baked into the binary.
 
-From a clone of this repo, **`ui/dist` is already present**, so a normal Rust build is enough unless you edited `ui/`:
+### Prebuilt binary (recommended)
 
-```bash
-cargo build --release
-```
-
-Scaffold a workspace and run:
+**One-liner (latest [`main-latest`](https://github.com/altaidevorg/isanagent/releases/tag/main-latest))** — same assets as on the release page; downloads the binary next to you, then runs it (same first-run / onboard behavior as below):
 
 ```bash
-cargo run --release -- onboard --workspace my_workspace
-cargo run --release -- --workspace my_workspace
+# Linux (x86_64)
+curl -fsSL https://github.com/altaidevorg/isanagent/releases/download/main-latest/isanagent-linux-x86_64 -o isanagent && chmod +x isanagent && ./isanagent
 ```
 
-The `--workspace` flag defaults to the current directory (`.`) — there is no global default path like `~/.isanagent` anymore. Set API credentials (for example `GEMINI_API_KEY` or the env var named in `config.toml`). Turn on **`[api] enabled = true`** and **`serve_ui = true`** in `config.toml` when you want the browser UI on `http://127.0.0.1:<port>/`. For channels, memory, harness options, and sandbox rules, see [`AGENTS.md`](./AGENTS.md).
+```bash
+# macOS (Apple silicon)
+curl -fsSL https://github.com/altaidevorg/isanagent/releases/download/main-latest/isanagent-macos-aarch64 -o isanagent && chmod +x isanagent && ./isanagent
+```
 
-You only need `cd ui && npm ci && npm run build` if you are changing the frontend.
+```powershell
+# Windows (x86_64, PowerShell)
+Invoke-WebRequest https://github.com/altaidevorg/isanagent/releases/download/main-latest/isanagent-windows-x86_64.exe -OutFile isanagent.exe; .\isanagent.exe
+```
+
+1. Or open **[Releases](https://github.com/altaidevorg/isanagent/releases)** and download the asset for your platform from **Latest main build** (tag [`main-latest`](https://github.com/altaidevorg/isanagent/releases/tag/main-latest)): `isanagent-linux-x86_64`, `isanagent-macos-aarch64`, or `isanagent-windows-x86_64.exe`.
+2. On Linux or macOS, mark it executable (example): `chmod +x isanagent-linux-x86_64` or `chmod +x isanagent-macos-aarch64`.
+3. Run the binary from a terminal (examples): `./isanagent-linux-x86_64` (Linux) or `./isanagent-macos-aarch64` (macOS); on Windows, run `isanagent-windows-x86_64.exe` from Explorer or `.\isanagent-windows-x86_64.exe` in PowerShell.
+
+If you use the **default workspace** (`~/.isanagent` on Unix, or the equivalent on Windows) and that folder does not exist yet, **the first run starts the interactive onboard wizard** (provider, API key env var, model, and workspace layout), then continues into the agent in the same session. For a custom workspace path, run `isanagent onboard` (add `--interactive` for the full wizard) or `isanagent --workspace /path/to/workspace` once the directory and `config.toml` exist.
+
+Set API credentials the wizard recommends (for example `GEMINI_API_KEY` or your provider's variable). Turn on **`[api] enabled = true`** and **`serve_ui = true`** in `config.toml` when you want the browser UI on `http://127.0.0.1:<port>/`. For channels, memory, harness options, and sandbox rules, see [`AGENTS.md`](./AGENTS.md).
 
 ### Multi-provider setup
 
@@ -92,6 +102,25 @@ model_name = "claude-sonnet-4-6"
 ```
 
 Use `/model` in the TUI to open the interactive model selector, or `/model gemini-2-5-flash` to switch directly. Your choice is remembered across restarts.
+
+### Build from source (optional)
+
+From a clone of this repo, **`ui/dist` is already present**, so a normal Rust build is enough unless you edited `ui/`:
+
+```bash
+cargo build --release
+./target/release/isanagent
+```
+
+To scaffold a workspace at a specific path without the default first-run flow:
+
+```bash
+cargo run --release -- onboard --workspace my_agent
+# then:
+cargo run --release -- --workspace my_agent
+```
+
+You only need `cd ui && npm ci && npm run build` if you are changing the frontend.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cargo run --release -- onboard --workspace my_workspace
 cargo run --release -- --workspace my_workspace
 ```
 
-The `--workspace` flag is **required** — there is no global default path. Set API credentials (for example `GEMINI_API_KEY` or the env var named in `config.toml`). Turn on **`[api] enabled = true`** and **`serve_ui = true`** in `config.toml` when you want the browser UI on `http://127.0.0.1:<port>/`. For channels, memory, harness options, and sandbox rules, see [`AGENTS.md`](./AGENTS.md).
+The `--workspace` flag defaults to the current directory (`.`) — there is no global default path like `~/.isanagent` anymore. Set API credentials (for example `GEMINI_API_KEY` or the env var named in `config.toml`). Turn on **`[api] enabled = true`** and **`serve_ui = true`** in `config.toml` when you want the browser UI on `http://127.0.0.1:<port>/`. For channels, memory, harness options, and sandbox rules, see [`AGENTS.md`](./AGENTS.md).
 
 You only need `cd ui && npm ci && npm run build` if you are changing the frontend.
 

--- a/README.md
+++ b/README.md
@@ -52,34 +52,24 @@ If that’s the kind of “finish the thing and show your work” energy you wan
 
 ## Get started
 
-**Fast path:** download a prebuilt binary from **[Releases](https://github.com/altaidevorg/isanagent/releases)** (Linux, **macOS** Apple silicon, and Windows), run it, and complete the first-run wizard. The embedded browser UI is baked into the binary.
+### Build from source
 
-### Prebuilt binary (recommended)
-
-**One-liner (latest [`main-latest`](https://github.com/altaidevorg/isanagent/releases/tag/main-latest))** — same assets as on the release page; downloads the binary next to you, then runs it (same first-run / onboard behavior as below):
+From a clone of this repo, **`ui/dist` is already present**, so a normal Rust build is enough unless you edited `ui/`:
 
 ```bash
-# Linux (x86_64)
-curl -fsSL https://github.com/altaidevorg/isanagent/releases/download/main-latest/isanagent-linux-x86_64 -o isanagent && chmod +x isanagent && ./isanagent
+cargo build --release
 ```
+
+Scaffold a workspace and run:
 
 ```bash
-# macOS (Apple silicon)
-curl -fsSL https://github.com/altaidevorg/isanagent/releases/download/main-latest/isanagent-macos-aarch64 -o isanagent && chmod +x isanagent && ./isanagent
+cargo run --release -- onboard --workspace my_workspace
+cargo run --release -- --workspace my_workspace
 ```
 
-```powershell
-# Windows (x86_64, PowerShell)
-Invoke-WebRequest https://github.com/altaidevorg/isanagent/releases/download/main-latest/isanagent-windows-x86_64.exe -OutFile isanagent.exe; .\isanagent.exe
-```
+The `--workspace` flag is **required** — there is no global default path. Set API credentials (for example `GEMINI_API_KEY` or the env var named in `config.toml`). Turn on **`[api] enabled = true`** and **`serve_ui = true`** in `config.toml` when you want the browser UI on `http://127.0.0.1:<port>/`. For channels, memory, harness options, and sandbox rules, see [`AGENTS.md`](./AGENTS.md).
 
-1. Or open **[Releases](https://github.com/altaidevorg/isanagent/releases)** and download the asset for your platform from **Latest main build** (tag [`main-latest`](https://github.com/altaidevorg/isanagent/releases/tag/main-latest)): `isanagent-linux-x86_64`, `isanagent-macos-aarch64`, or `isanagent-windows-x86_64.exe`.
-2. On Linux or macOS, mark it executable (example): `chmod +x isanagent-linux-x86_64` or `chmod +x isanagent-macos-aarch64`.
-3. Run the binary from a terminal (examples): `./isanagent-linux-x86_64` (Linux) or `./isanagent-macos-aarch64` (macOS); on Windows, run `isanagent-windows-x86_64.exe` from Explorer or `.\isanagent-windows-x86_64.exe` in PowerShell.
-
-If you use the **default workspace** (`~/.isanagent` on Unix, or the equivalent on Windows) and that folder does not exist yet, **the first run starts the interactive onboard wizard** (provider, API key env var, model, and workspace layout), then continues into the agent in the same session. For a custom workspace path, run `isanagent onboard` (add `--interactive` for the full wizard) or `isanagent --workspace /path/to/workspace` once the directory and `config.toml` exist.
-
-Set API credentials the wizard recommends (for example `GEMINI_API_KEY` or your provider’s variable). Turn on **`[api] enabled = true`** and **`serve_ui = true`** in `config.toml` when you want the browser UI on `http://127.0.0.1:<port>/`. For channels, memory, harness options, and sandbox rules, see [`AGENTS.md`](./AGENTS.md).
+You only need `cd ui && npm ci && npm run build` if you are changing the frontend.
 
 ### Multi-provider setup
 
@@ -102,25 +92,6 @@ model_name = "claude-sonnet-4-6"
 ```
 
 Use `/model` in the TUI to open the interactive model selector, or `/model gemini-2-5-flash` to switch directly. Your choice is remembered across restarts.
-
-### Build from source (optional)
-
-From a clone of this repo, **`ui/dist` is already present**, so a normal Rust build is enough unless you edited `ui/`:
-
-```bash
-cargo build --release
-./target/release/isanagent
-```
-
-To scaffold a workspace at a specific path without the default first-run flow:
-
-```bash
-cargo run --release -- onboard --workspace my_agent
-# then:
-cargo run --release -- --workspace my_agent
-```
-
-You only need `cd ui && npm ci && npm run build` if you are changing the frontend.
 
 ---
 

--- a/assets/onboarding/config.toml
+++ b/assets/onboarding/config.toml
@@ -14,120 +14,35 @@ enabled = true
 # LLM providers. At startup, isanagent picks the first provider with a valid API key.
 # Use `/model` in the TUI to switch between them at runtime.
 #
-# `provider_name` selects a built-in registry entry (anthropic, gemini, openai, deepseek,
-# openrouter). API key resolution order:
-#   1. Environment variable ($<PROVIDER>_API_KEY, e.g. $OPENAI_API_KEY for "openai")
-#   2. Direct `api_key` value in config (fallback when env var is not set)
-# Override the env var name with `api_key_env` if needed.
+# Family format: list all models under one provider block. The map key is used as provider_name.
+# API key resolution: $<PROVIDER>_API_KEY env var first, then inline `api_key` as fallback.
 #
-# Set `provider_name = "openai_compatible"` + `base_url` for any other endpoint.
+[providers.gemini]
+models = ["gemini-2.5-flash", "gemini-2.5-pro", "gemini-3.1-pro", "gemini-3.1-flash-lite"]
+api_key = "<changethis>"
+
+[providers.openai]
+models = ["gpt-5.5", "gpt-5.5-instant", "gpt-5.4-mini", "gpt-5.4-nano", "o3", "o4-mini"]
+api_key = "<changethis>"
+
+[providers.anthropic]
+models = ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"]
+api_key = "<changethis>"
+
+[providers.deepseek]
+models = ["deepseek-v4-pro", "deepseek-v4-flash"]
+api_key = "<changethis>"
+
+# [providers.openrouter]
+# models = ["anthropic/claude-opus-4-7", "openai/gpt-5.5", "google/gemini-3.1-pro"]
+# # Uses $OPENROUTER_API_KEY
 #
-# ─── Anthropic (Claude) ─── $ANTHROPIC_API_KEY or api_key below ───────────────
-#
-# [providers.claude-opus-4-7]
-# provider_name = "anthropic"
-# model_name = "claude-opus-4-7"
-# api_key = "sk-ant-..."          # optional: omit to use $ANTHROPIC_API_KEY
-#
-# [providers.claude-opus-4-6]
-# provider_name = "anthropic"
-# model_name = "claude-opus-4-6"
-#
-# [providers.claude-sonnet-4-6]
-# provider_name = "anthropic"
-# model_name = "claude-sonnet-4-6"
-#
-# [providers.claude-haiku-4-5]
-# provider_name = "anthropic"
-# model_name = "claude-haiku-4-5-20251001"
-#
-# ─── OpenAI ─── $OPENAI_API_KEY or api_key below ─────────────────────────────
-#
-# [providers.gpt-5-5]
-# provider_name = "openai"
-# model_name = "gpt-5.5"
-# api_key = "sk-..."              # optional: omit to use $OPENAI_API_KEY
-#
-# [providers.gpt-5-4-mini]
-# provider_name = "openai"
-# model_name = "gpt-5.4-mini"
-#
-# [providers.gpt-5-4-nano]
-# provider_name = "openai"
-# model_name = "gpt-5.4-nano"
-#
-# [providers.gpt-4-1]
-# provider_name = "openai"
-# model_name = "gpt-4.1"
-#
-# [providers.gpt-4-1-mini]
-# provider_name = "openai"
-# model_name = "gpt-4.1-mini"
-#
-# [providers.gpt-4o]
-# provider_name = "openai"
-# model_name = "gpt-4o"
-#
-# [providers.o3]
-# provider_name = "openai"
-# model_name = "o3"
-#
-# [providers.o4-mini]
-# provider_name = "openai"
-# model_name = "o4-mini"
-#
-# ─── Google Gemini ─── $GEMINI_API_KEY or api_key below ───────────────────────
-#
-# [providers.gemini-3-1-pro]
-# provider_name = "gemini"
-# model_name = "gemini-3.1-pro-preview"
-# api_key = "AIza..."
-#
-# [providers.gemini-3-flash]
-# provider_name = "gemini"
-# model_name = "gemini-3-flash-preview"
-#
-# [providers.gemini-2-5-pro]
-# provider_name = "gemini"
-# model_name = "gemini-2.5-pro"
-#
-# [providers.gemini-2-5-flash]
-# provider_name = "gemini"
-# model_name = "gemini-2.5-flash"
-#
-# [providers.gemini-2-5-flash-lite]
-# provider_name = "gemini"
-# model_name = "gemini-2.5-flash-lite"
-#
-# ─── DeepSeek ─── $DEEPSEEK_API_KEY or api_key below ─────────────────────────
-#
-# [providers.deepseek-v4-pro]
-# provider_name = "deepseek"
-# model_name = "deepseek-v4-pro"
-# api_key = "sk-..."              # optional: omit to use $DEEPSEEK_API_KEY
-#
-# [providers.deepseek-v4-flash]
-# provider_name = "deepseek"
-# model_name = "deepseek-v4-flash"
-#
-# [providers.deepseek-reasoner]
-# provider_name = "deepseek"
-# model_name = "deepseek-reasoner"
-#
-# ─── OpenRouter (unified gateway) ─── $OPENROUTER_API_KEY or api_key below ───
-#
-# [providers.or-claude-opus]
-# provider_name = "openrouter"
-# model_name = "anthropic/claude-opus-4-7"
-# api_key = "sk-or-..."           # optional: omit to use $OPENROUTER_API_KEY
-#
-# [providers.or-gpt-5-5]
-# provider_name = "openrouter"
-# model_name = "openai/gpt-5.5"
-#
-# [providers.or-gemini-3-1-pro]
-# provider_name = "openrouter"
-# model_name = "google/gemini-3.1-pro-preview"
+# Custom endpoint (legacy per-model format):
+# [providers.my-proxy]
+# provider_name = "openai_compatible"
+# model_name = "my-model"
+# base_url = "https://my-proxy.example/v1/chat/completions"
+# api_key = "sk-..."
 
 [slack]
 enabled = false

--- a/src/channels/terminal_ui/run.rs
+++ b/src/channels/terminal_ui/run.rs
@@ -900,10 +900,7 @@ fn char_wrap_compose(
     let w = width.max(1);
     let mut out: Vec<Line<'static>> = Vec::new();
 
-    let logical_lines: Vec<&str> = input.split('\n').collect();
-    let has_lines = !logical_lines.is_empty();
-
-    for (li, logical) in logical_lines.iter().enumerate() {
+    for (li, logical) in input.split('\n').enumerate() {
         let prefix: &str = if li == 0 { "> " } else { "  " };
         let prefix_w: usize = 2; // both "> " and "  " are 2 display-columns
         let text_budget = w.saturating_sub(prefix_w);
@@ -947,13 +944,6 @@ fn char_wrap_compose(
             }
             out.push(Line::from(Span::styled(chunk, text_style)));
         }
-    }
-
-    if !has_lines {
-        out.push(Line::from(vec![
-            Span::styled("> ".to_string(), prompt_style),
-            Span::styled(String::new(), text_style),
-        ]));
     }
 
     out

--- a/src/channels/terminal_ui/run.rs
+++ b/src/channels/terminal_ui/run.rs
@@ -880,6 +880,85 @@ fn append_execution_stream_panel(app: &mut App, msg: &OutboundMessage) {
     }
 }
 
+/// Character-level wrapping for the compose input box.
+///
+/// Splits each logical line (delimited by `'\n'` in `input`) into visual rows
+/// that are at most `width` display-columns wide.  The first logical line gets
+/// the `"> "` prompt; continuations get `"  "`.  Each row is a complete
+/// [`Line`] so the caller can render the result **without** `Wrap`.
+///
+/// This keeps cursor-position arithmetic (`total_cols / width`) perfectly
+/// aligned with what is actually drawn on screen.
+fn char_wrap_compose(
+    input: &str,
+    width: usize,
+    prompt_style: Style,
+    text_style: Style,
+) -> Vec<Line<'static>> {
+    use unicode_width::UnicodeWidthChar;
+
+    let w = width.max(1);
+    let mut out: Vec<Line<'static>> = Vec::new();
+
+    let logical_lines: Vec<&str> = input.split('\n').collect();
+    let has_lines = !logical_lines.is_empty();
+
+    for (li, logical) in logical_lines.iter().enumerate() {
+        let prefix: &str = if li == 0 { "> " } else { "  " };
+        let prefix_w: usize = 2; // both "> " and "  " are 2 display-columns
+        let text_budget = w.saturating_sub(prefix_w);
+
+        // First visual row: prefix + as much text as fits.
+        let mut chars = logical.chars().peekable();
+        let mut first_chunk = String::new();
+        let mut col: usize = 0;
+        while let Some(&ch) = chars.peek() {
+            let cw = UnicodeWidthChar::width(ch).unwrap_or(0).max(1);
+            if col + cw > text_budget {
+                break;
+            }
+            first_chunk.push(ch);
+            col += cw;
+            chars.next();
+        }
+        out.push(Line::from(vec![
+            Span::styled(prefix.to_string(), prompt_style),
+            Span::styled(first_chunk, text_style),
+        ]));
+
+        // Subsequent visual rows: up to `w` columns of text each (no prefix).
+        while chars.peek().is_some() {
+            let mut chunk = String::new();
+            let mut col: usize = 0;
+            while let Some(&ch) = chars.peek() {
+                let cw = UnicodeWidthChar::width(ch).unwrap_or(0).max(1);
+                if col + cw > w {
+                    break;
+                }
+                chunk.push(ch);
+                col += cw;
+                chars.next();
+            }
+            if chunk.is_empty() {
+                // Single character wider than the whole line — force it through.
+                if let Some(ch) = chars.next() {
+                    chunk.push(ch);
+                }
+            }
+            out.push(Line::from(Span::styled(chunk, text_style)));
+        }
+    }
+
+    if !has_lines {
+        out.push(Line::from(vec![
+            Span::styled("> ".to_string(), prompt_style),
+            Span::styled(String::new(), text_style),
+        ]));
+    }
+
+    out
+}
+
 fn rect_contains(r: Rect, col: u16, row: u16) -> bool {
     let x1 = r.x.saturating_add(r.width);
     let y1 = r.y.saturating_add(r.height);
@@ -1620,23 +1699,19 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                 .title(Span::styled(" compose ", Theme::dim()))
                 .border_style(Theme::dim());
 
-            let mut text_lines = Vec::new();
-            for (i, line) in app.input.split('\n').enumerate() {
-                let prefix = if i == 0 { "> " } else { "  " };
-                text_lines.push(Line::from(vec![
-                    Span::styled(prefix, Theme::input_prompt()),
-                    Span::styled(line, Theme::text()),
-                ]));
-            }
-            if text_lines.is_empty() {
-                text_lines.push(Line::from(vec![
-                    Span::styled("> ", Theme::input_prompt()),
-                    Span::styled("", Theme::text()),
-                ]));
-            }
-
             let inner_area = ch[5].inner(Margin::new(1, 1));
             let inner_w = inner_area.width.max(1); // guard against zero-width after margin
+
+            // Build visual lines with character-level wrapping so that the cursor
+            // calculation (`total_cols / inner_w`) matches the rendered layout
+            // exactly.  Previously the code relied on ratatui's Wrap which uses
+            // word-level breaking, causing a mismatch.
+            let text_lines = char_wrap_compose(
+                &app.input,
+                inner_w as usize,
+                Theme::input_prompt(),
+                Theme::text(),
+            );
 
             // Calculate visual line of cursor for wrapping.
             // Uses display_width (Unicode column width) instead of char count so that
@@ -1647,7 +1722,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
             let lines_before_cursor: Vec<&str> = text_before_cursor.split('\n').collect();
             let total_lines = lines_before_cursor.len();
             for (i, line) in lines_before_cursor.into_iter().enumerate() {
-                let prefix_len: u16 = if i == 0 { 2 } else { 0 }; // "> "
+                let prefix_len: u16 = 2; // "> " on first line, "  " on continuations
                 let col_width = super::display_width(line) as u16;
                 let total_cols = prefix_len + col_width;
 
@@ -1672,7 +1747,6 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
 
             let input_para = Paragraph::new(Text::from(text_lines))
                 .block(input_block)
-                .wrap(ratatui::widgets::Wrap { trim: false })
                 .scroll((input_v_scroll, 0));
             f.render_widget(input_para, ch[5]);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2102,7 +2102,9 @@ mod placeholder_key_tests {
 
     #[test]
     fn rejects_placeholder_keyword() {
-        assert!(provider_with_key("my_placeholder_key").resolve_api_key().is_err());
+        assert!(provider_with_key("my_placeholder_key")
+            .resolve_api_key()
+            .is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -387,7 +387,10 @@ impl AppConfig {
             Some(p) => p,
             None => return result,
         };
-        for (key, cfg) in providers {
+        let mut sorted_keys: Vec<_> = providers.keys().collect();
+        sorted_keys.sort();
+        for key in sorted_keys {
+            let cfg = &providers[key];
             let provider_name = if cfg.provider_name.is_empty() {
                 key.clone()
             } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -341,9 +341,9 @@ pub struct JinaWebBackend {
 }
 
 /// Heuristics to avoid sending obvious template values as `Authorization: Bearer`.
-/// Language-agnostic: rejects non-ASCII (Jina keys are ASCII), angle-bracket templates, and
-/// common README placeholder tokens (ASCII substrings only).
-fn jina_api_key_looks_like_placeholder(s: &str) -> bool {
+/// Language-agnostic: rejects non-ASCII, angle-bracket templates (e.g. `<changethis>`), and
+/// common placeholder tokens (ASCII substrings only).
+fn api_key_looks_like_placeholder(s: &str) -> bool {
     let t = s.trim();
     if t.is_empty() || t.starts_with('<') {
         return true;
@@ -464,7 +464,7 @@ impl AppConfig {
             .api_key
             .as_ref()
             .map(|s| s.trim().to_string())
-            .filter(|s| !jina_api_key_looks_like_placeholder(s));
+            .filter(|s| !api_key_looks_like_placeholder(s));
         Some(JinaWebBackend { api_key })
     }
 
@@ -1375,7 +1375,7 @@ impl ProviderConfig {
         }
         if let Some(key) = &self.api_key {
             let trimmed = key.trim();
-            if !trimmed.is_empty() {
+            if !trimmed.is_empty() && !api_key_looks_like_placeholder(trimmed) {
                 return Ok(trimmed.to_string());
             }
         }
@@ -1963,5 +1963,47 @@ base_url = "https://proxy.example/v1/chat/completions"
     fn empty_providers_returns_empty_map() {
         let cfg = AppConfig::default();
         assert!(cfg.expanded_providers().is_empty());
+    }
+}
+
+#[cfg(test)]
+mod placeholder_key_tests {
+    use super::*;
+
+    fn provider_with_key(key: &str) -> ProviderConfig {
+        ProviderConfig {
+            provider_name: "deepseek".to_string(),
+            model_name: "deepseek-v4-pro".to_string(),
+            models: None,
+            api_key_env: "".to_string(),
+            api_key: Some(key.to_string()),
+            base_url: None,
+        }
+    }
+
+    #[test]
+    fn rejects_angle_bracket_placeholder() {
+        assert!(provider_with_key("<changethis>").resolve_api_key().is_err());
+    }
+
+    #[test]
+    fn rejects_changethis_without_brackets() {
+        assert!(provider_with_key("changethis").resolve_api_key().is_err());
+    }
+
+    #[test]
+    fn rejects_replace_me() {
+        assert!(provider_with_key("replace_me").resolve_api_key().is_err());
+    }
+
+    #[test]
+    fn rejects_placeholder_keyword() {
+        assert!(provider_with_key("my_placeholder_key").resolve_api_key().is_err());
+    }
+
+    #[test]
+    fn accepts_real_api_key() {
+        let result = provider_with_key("sk-abc123def456").resolve_api_key();
+        assert_eq!(result.unwrap(), "sk-abc123def456");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -373,6 +373,50 @@ fn parse_shell_policy_mode(raw: Option<&str>, default_mode: ShellPolicyMode) -> 
 }
 
 impl AppConfig {
+    /// Expand family-format `[providers.*]` entries into flat per-model configs.
+    ///
+    /// Family entries (with `models = [...]`) are expanded into one `ProviderConfig` per model,
+    /// inheriting `api_key`, `api_key_env`, and `base_url` from the family. The map key is used
+    /// as `provider_name` when the field is omitted.
+    ///
+    /// Legacy single-model entries (with `model_name`) pass through unchanged.
+    pub fn expanded_providers(&self) -> std::collections::HashMap<String, ProviderConfig> {
+        let mut result = std::collections::HashMap::new();
+        let providers = match &self.providers {
+            Some(p) => p,
+            None => return result,
+        };
+        for (key, cfg) in providers {
+            let provider_name = if cfg.provider_name.is_empty() {
+                key.clone()
+            } else {
+                cfg.provider_name.clone()
+            };
+
+            if let Some(models) = &cfg.models {
+                for model in models {
+                    let expanded = ProviderConfig {
+                        provider_name: provider_name.clone(),
+                        model_name: model.clone(),
+                        models: None,
+                        api_key_env: cfg.api_key_env.clone(),
+                        api_key: cfg.api_key.clone(),
+                        base_url: cfg.base_url.clone(),
+                    };
+                    result.insert(model.clone(), expanded);
+                }
+            } else if !cfg.model_name.is_empty() {
+                let mut single = cfg.clone();
+                if single.provider_name.is_empty() {
+                    single.provider_name = provider_name;
+                }
+                single.models = None;
+                result.insert(key.clone(), single);
+            }
+        }
+        result
+    }
+
     /// Whether the stdin/stdout terminal channel is active (`[terminal].enabled`, default `true`).
     pub fn terminal_enabled(&self) -> bool {
         self.terminal
@@ -1284,8 +1328,16 @@ pub struct ProviderConfig {
     /// One of `KNOWN_PROVIDERS` (e.g. `"gemini"`, `"openai"`, `"deepseek"`, `"openrouter"`,
     /// `"anthropic"`) or the `OPENAI_COMPATIBLE` sentinel for any third-party endpoint speaking
     /// the OpenAI Chat Completions protocol.
+    /// In the family format, this is inferred from the map key when omitted.
+    #[serde(default)]
     pub provider_name: String,
+    /// Single model name (legacy per-model format).
+    #[serde(default)]
     pub model_name: String,
+    /// Multiple model names (family format). When present, the entry is expanded into one
+    /// `ProviderConfig` per model by [`AppConfig::expanded_providers`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub models: Option<Vec<String>>,
     /// Name of the environment variable holding the API key. Checked first during resolution.
     #[serde(default)]
     pub api_key_env: String,
@@ -1374,6 +1426,7 @@ mod provider_config_tests {
         ProviderConfig {
             provider_name: name.to_string(),
             model_name: "m".to_string(),
+            models: None,
             api_key_env: "X".to_string(),
             api_key: None,
             base_url: base.map(str::to_string),
@@ -1824,5 +1877,91 @@ interactive_requires_approval_for = ["terraform destroy"]
             .approval_patterns
             .iter()
             .any(|s| s.contains("terraform destroy")));
+    }
+}
+
+#[cfg(test)]
+mod expanded_providers_tests {
+    use super::*;
+
+    #[test]
+    fn family_format_expands_to_per_model_entries() {
+        let toml_str = r#"
+[providers.deepseek]
+models = ["deepseek-v4-pro", "deepseek-v4-flash"]
+api_key = "sk-test"
+"#;
+        let cfg: AppConfig = toml::from_str(toml_str).expect("parse");
+        let expanded = cfg.expanded_providers();
+        assert_eq!(expanded.len(), 2);
+
+        let pro = expanded.get("deepseek-v4-pro").expect("pro entry");
+        assert_eq!(pro.provider_name, "deepseek");
+        assert_eq!(pro.model_name, "deepseek-v4-pro");
+        assert_eq!(pro.api_key.as_deref(), Some("sk-test"));
+        assert!(pro.models.is_none());
+
+        let flash = expanded.get("deepseek-v4-flash").expect("flash entry");
+        assert_eq!(flash.provider_name, "deepseek");
+        assert_eq!(flash.model_name, "deepseek-v4-flash");
+        assert_eq!(flash.api_key.as_deref(), Some("sk-test"));
+    }
+
+    #[test]
+    fn legacy_single_model_format_passes_through() {
+        let toml_str = r#"
+[providers.my-custom]
+provider_name = "openai_compatible"
+model_name = "custom-model"
+base_url = "https://example.com/v1/chat/completions"
+"#;
+        let cfg: AppConfig = toml::from_str(toml_str).expect("parse");
+        let expanded = cfg.expanded_providers();
+        assert_eq!(expanded.len(), 1);
+
+        let entry = expanded.get("my-custom").expect("legacy entry");
+        assert_eq!(entry.provider_name, "openai_compatible");
+        assert_eq!(entry.model_name, "custom-model");
+        assert_eq!(
+            entry.base_url.as_deref(),
+            Some("https://example.com/v1/chat/completions")
+        );
+    }
+
+    #[test]
+    fn infers_provider_name_from_map_key() {
+        let toml_str = r#"
+[providers.gemini]
+models = ["gemini-2.5-flash"]
+"#;
+        let cfg: AppConfig = toml::from_str(toml_str).expect("parse");
+        let expanded = cfg.expanded_providers();
+        let entry = expanded.get("gemini-2.5-flash").expect("entry");
+        assert_eq!(entry.provider_name, "gemini");
+    }
+
+    #[test]
+    fn mixed_family_and_legacy_coexist() {
+        let toml_str = r#"
+[providers.anthropic]
+models = ["claude-opus-4-7", "claude-sonnet-4-6"]
+
+[providers.my-proxy]
+provider_name = "openai_compatible"
+model_name = "proxy-model"
+base_url = "https://proxy.example/v1/chat/completions"
+"#;
+        let cfg: AppConfig = toml::from_str(toml_str).expect("parse");
+        let expanded = cfg.expanded_providers();
+        assert_eq!(expanded.len(), 3);
+        assert!(expanded.contains_key("claude-opus-4-7"));
+        assert!(expanded.contains_key("claude-sonnet-4-6"));
+        assert!(expanded.contains_key("my-proxy"));
+    }
+
+    #[test]
+    fn empty_providers_returns_empty_map() {
+        let cfg = AppConfig::default();
+        assert!(cfg.expanded_providers().is_empty());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use log::warn;
 use serde::{Deserialize, Serialize};
 
 /// Local stdin/stdout chat. When `enabled` is omitted, defaults to `true`.
@@ -403,6 +404,15 @@ impl AppConfig {
                         api_key: cfg.api_key.clone(),
                         base_url: cfg.base_url.clone(),
                     };
+                    if result.contains_key(model) {
+                        warn!(
+                            "Duplicate model name \"{}\" in [providers.{}] -- \
+                             overwriting previous entry. Use the legacy per-model \
+                             format with unique map keys to distinguish the same \
+                             model from different providers.",
+                            model, key
+                        );
+                    }
                     result.insert(model.clone(), expanded);
                 }
             } else if !cfg.model_name.is_empty() {
@@ -411,7 +421,21 @@ impl AppConfig {
                     single.provider_name = provider_name;
                 }
                 single.models = None;
+                if result.contains_key(key) {
+                    warn!(
+                        "Duplicate provider key \"{}\" in [providers] -- \
+                         overwriting previous entry.",
+                        key
+                    );
+                }
                 result.insert(key.clone(), single);
+            } else {
+                warn!(
+                    "[providers.{}] has neither \"models\" nor \
+                     \"model_name\" -- entry is ignored. Add one to \
+                     register a provider.",
+                    key
+                );
             }
         }
         result
@@ -1963,6 +1987,83 @@ base_url = "https://proxy.example/v1/chat/completions"
     fn empty_providers_returns_empty_map() {
         let cfg = AppConfig::default();
         assert!(cfg.expanded_providers().is_empty());
+    }
+
+    #[test]
+    fn duplicate_model_name_across_families_is_detected() {
+        let toml_str = r#"
+[providers.openai]
+models = ["gpt-5.5"]
+api_key = "sk-openai"
+
+[providers.openrouter]
+models = ["gpt-5.5", "claude-opus-4-7"]
+api_key = "sk-or"
+"#;
+        let cfg: AppConfig = toml::from_str(toml_str).expect("parse");
+        let expanded = cfg.expanded_providers();
+        // Both families list "gpt-5.5"; last write wins in HashMap iteration order.
+        // Only 2 unique keys survive: the overwritten "gpt-5.5" + "claude-opus-4-7".
+        assert_eq!(expanded.len(), 2);
+        assert!(expanded.contains_key("gpt-5.5"));
+        assert!(expanded.contains_key("claude-opus-4-7"));
+        // Both values are valid API keys from one of the providers.
+        let gpt_key = expanded.get("gpt-5.5").unwrap().api_key.as_deref().unwrap();
+        assert!(gpt_key == "sk-openai" || gpt_key == "sk-or");
+    }
+
+    #[test]
+    fn family_and_legacy_with_same_model_name_is_detected() {
+        // Family and legacy entry expanding to the same model name.
+        // One overwrites the other depending on HashMap iteration order.
+        let toml_str = r#"
+[providers.openai]
+models = ["gpt-5.5"]
+api_key = "sk-family"
+
+[providers.legacy-gpt]
+provider_name = "openai"
+model_name = "gpt-5.5"
+api_key = "sk-legacy"
+"#;
+        let cfg: AppConfig = toml::from_str(toml_str).expect("parse");
+        let expanded = cfg.expanded_providers();
+        // "gpt-5.5" (overwritten) + "legacy-gpt" (pass-through)
+        assert_eq!(expanded.len(), 2);
+        assert!(expanded.contains_key("gpt-5.5"));
+        assert!(expanded.contains_key("legacy-gpt"));
+        // The "legacy-gpt" key always uses sk-legacy
+        assert_eq!(
+            expanded.get("legacy-gpt").unwrap().api_key.as_deref(),
+            Some("sk-legacy")
+        );
+        // "gpt-5.5" gets one of the two keys (non-deterministic)
+        let gpt_key = expanded.get("gpt-5.5").unwrap().api_key.as_deref().unwrap();
+        assert!(gpt_key == "sk-family" || gpt_key == "sk-legacy");
+    }
+
+    #[test]
+    fn empty_models_and_model_name_warns_and_skips() {
+        let toml_str = r#"
+[providers.broken]
+# neither models nor model_name set
+"#;
+        let cfg: AppConfig = toml::from_str(toml_str).expect("parse");
+        let expanded = cfg.expanded_providers();
+        // entry is silently skipped (no model_name and no models)
+        assert!(expanded.is_empty());
+    }
+
+    #[test]
+    fn empty_models_list_skips_entry() {
+        let toml_str = r#"
+[providers.gemini]
+models = []
+"#;
+        let cfg: AppConfig = toml::from_str(toml_str).expect("parse");
+        let expanded = cfg.expanded_providers();
+        // models is Some but empty vec: no expansions produced
+        assert!(expanded.is_empty());
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
 
-    /// Path to the workspace directory (defaults to current directory; no global default).
+    /// Optional explicit path to the workspace directory. Defaults to ~/.isanagent
     #[arg(short, long)]
     workspace: Option<String>,
 
@@ -96,7 +96,7 @@ enum Commands {
 
 #[derive(ClapArgs, Debug)]
 struct OnboardArgs {
-    /// Path to the workspace directory (defaults to current directory; no global default).
+    /// Optional explicit path to the workspace directory. Defaults to ~/.isanagent
     #[arg(short, long)]
     workspace: Option<String>,
     /// Textual wizard (ratatui): provider → optional base URL → API key env var name → pick model from /models
@@ -113,10 +113,61 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match cli.command {
         Some(Commands::Onboard(args)) => run_onboard(cli.workspace, args).await,
-        None => run_isanagent(cli.workspace, cli.config).await,
+        None => {
+            // First-run UX: when the user invokes `isanagent` with no `--workspace` and the
+            // default `~/.isanagent` directory does not yet exist, auto-launch the interactive
+            // onboard wizard before starting the agent. Subsequent runs see the directory and
+            // skip straight to `run_isanagent`.
+            if cli.workspace.is_none() {
+                let default_root = resolve_workspace_root(None);
+                if !default_root.exists() {
+                    auto_onboard_then_run(cli.config).await?;
+                    return Ok(());
+                }
+            }
+            run_isanagent(cli.workspace, cli.config).await
+        }
     }
 }
 
+/// Runs the interactive onboard against the default workspace path then transitions into
+/// `run_isanagent` in the same invocation. Cancelling the wizard (Ctrl+C / Esc) returns
+/// `Ok(())` without launching the agent so the user can retry on the next run.
+async fn auto_onboard_then_run(
+    config_arg: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("Welcome to isanagent. No workspace detected at the default location.");
+    println!("Launching the interactive onboard wizard...");
+    println!();
+
+    let onboard_result = run_onboard_inner(
+        None,
+        OnboardArgs {
+            workspace: None,
+            interactive: true,
+            options: OnboardOptions::default(),
+        },
+        /* chained = */ true,
+    )
+    .await;
+
+    match onboard_result {
+        Ok(()) => {
+            println!();
+            println!("Workspace ready. Launching isanagent...");
+            println!();
+            run_isanagent(None, config_arg).await
+        }
+        Err(e) => {
+            // The interactive wizard signalled abort (Ctrl+C / Esc) or a concrete failure.
+            // Surface the message and exit cleanly so the shell prompt returns; the user can
+            // re-run when ready.
+            eprintln!("Onboard did not complete: {e}");
+            eprintln!("Run `isanagent onboard --interactive` to try again.");
+            Ok(())
+        }
+    }
+}
 
 async fn run_isanagent(
     workspace_arg: Option<String>,
@@ -531,7 +582,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         if !env_vars.is_empty() {
             eprintln!("Set one of: {}", env_vars.join(", "));
         }
-        eprintln!("Or replace \"<changethis>\" with your key in config.toml.");
+        eprintln!("Or run `isanagent onboard` to create a config.toml, then replace \"<changethis>\" with your key.");
         eprintln!("Use /model at runtime to configure one.");
         (
             Box::new(isanagent::provider::NoKeyProvider),
@@ -1431,10 +1482,28 @@ fn print_onboarding_report(
     }
 }
 
-/// Build the `Run:` line for the onboarding banner. Always includes `--workspace` since there is
-/// no global default path.
+/// Build the `Run:` line for the onboarding banner. When `report_root` resolves to the same path
+/// as the default (`~/.isanagent`), the `--workspace` flag is redundant and is omitted so the
+/// user sees the cleanest invocation that will work.
 fn format_next_steps_run_line(report_root: &std::path::Path) -> String {
-    format!("isanagent --workspace {}", report_root.display())
+    let default_root = isanagent::workspace::resolve_workspace_root(None);
+    let same = paths_equivalent(report_root, &default_root);
+    if same {
+        "isanagent".to_string()
+    } else {
+        format!("isanagent --workspace {}", report_root.display())
+    }
+}
+
+/// Compare two paths after best-effort canonicalization. Falls back to direct equality when
+/// canonicalize fails (e.g. one of the paths is on a not-yet-existing filesystem branch).
+fn paths_equivalent(a: &std::path::Path, b: &std::path::Path) -> bool {
+    let canon_a = std::fs::canonicalize(a).ok();
+    let canon_b = std::fs::canonicalize(b).ok();
+    match (canon_a, canon_b) {
+        (Some(a), Some(b)) => a == b,
+        _ => a == b,
+    }
 }
 
 #[cfg(test)]
@@ -1442,7 +1511,14 @@ mod next_steps_tests {
     use super::*;
 
     #[test]
-    fn always_includes_workspace_flag() {
+    fn omits_workspace_flag_when_root_is_default() {
+        let default_root = isanagent::workspace::resolve_workspace_root(None);
+        let line = format_next_steps_run_line(&default_root);
+        assert_eq!(line, "isanagent", "got {line}");
+    }
+
+    #[test]
+    fn includes_workspace_flag_for_custom_root() {
         let custom = std::env::temp_dir().join("isanagent-next-steps-test-custom");
         let line = format_next_steps_run_line(&custom);
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
 
-    /// Path to the workspace directory (required; no global default).
+    /// Path to the workspace directory (defaults to current directory; no global default).
     #[arg(short, long)]
     workspace: Option<String>,
 
@@ -96,7 +96,7 @@ enum Commands {
 
 #[derive(ClapArgs, Debug)]
 struct OnboardArgs {
-    /// Path to the workspace directory (required; no global default).
+    /// Path to the workspace directory (defaults to current directory; no global default).
     #[arg(short, long)]
     workspace: Option<String>,
     /// Textual wizard (ratatui): provider → optional base URL → API key env var name → pick model from /models

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
 
-    /// Optional explicit path to the workspace directory. Defaults to ~/.isanagent
+    /// Path to the workspace directory (required; no global default).
     #[arg(short, long)]
     workspace: Option<String>,
 
@@ -96,7 +96,7 @@ enum Commands {
 
 #[derive(ClapArgs, Debug)]
 struct OnboardArgs {
-    /// Optional explicit path to the workspace directory. Defaults to ~/.isanagent
+    /// Path to the workspace directory (required; no global default).
     #[arg(short, long)]
     workspace: Option<String>,
     /// Textual wizard (ratatui): provider → optional base URL → API key env var name → pick model from /models
@@ -113,61 +113,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match cli.command {
         Some(Commands::Onboard(args)) => run_onboard(cli.workspace, args).await,
-        None => {
-            // First-run UX: when the user invokes `isanagent` with no `--workspace` and the
-            // default `~/.isanagent` directory does not yet exist, auto-launch the interactive
-            // onboard wizard before starting the agent. Subsequent runs see the directory and
-            // skip straight to `run_isanagent`.
-            if cli.workspace.is_none() {
-                let default_root = resolve_workspace_root(None);
-                if !default_root.exists() {
-                    auto_onboard_then_run(cli.config).await?;
-                    return Ok(());
-                }
-            }
-            run_isanagent(cli.workspace, cli.config).await
-        }
+        None => run_isanagent(cli.workspace, cli.config).await,
     }
 }
 
-/// Runs the interactive onboard against the default workspace path then transitions into
-/// `run_isanagent` in the same invocation. Cancelling the wizard (Ctrl+C / Esc) returns
-/// `Ok(())` without launching the agent so the user can retry on the next run.
-async fn auto_onboard_then_run(
-    config_arg: Option<String>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Welcome to isanagent. No workspace detected at the default location.");
-    println!("Launching the interactive onboard wizard...");
-    println!();
-
-    let onboard_result = run_onboard_inner(
-        None,
-        OnboardArgs {
-            workspace: None,
-            interactive: true,
-            options: OnboardOptions::default(),
-        },
-        /* chained = */ true,
-    )
-    .await;
-
-    match onboard_result {
-        Ok(()) => {
-            println!();
-            println!("Workspace ready. Launching isanagent...");
-            println!();
-            run_isanagent(None, config_arg).await
-        }
-        Err(e) => {
-            // The interactive wizard signalled abort (Ctrl+C / Esc) or a concrete failure.
-            // Surface the message and exit cleanly so the shell prompt returns; the user can
-            // re-run when ready.
-            eprintln!("Onboard did not complete: {e}");
-            eprintln!("Run `isanagent onboard --interactive` to try again.");
-            Ok(())
-        }
-    }
-}
 
 async fn run_isanagent(
     workspace_arg: Option<String>,
@@ -503,10 +452,14 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             .unwrap_or_else(|| isanagent::config::ProviderConfig {
                 provider_name: DEFAULT_PROVIDER_NAME.to_string(),
                 model_name: DEFAULT_PROVIDER_MODEL_NAME.to_string(),
+                models: None,
                 api_key_env: DEFAULT_PROVIDER_API_KEY_ENV.to_string(),
                 api_key: None,
                 base_url: None,
             });
+
+    // Expand family-format providers into flat per-model map (once, reused everywhere).
+    let expanded_providers = workspace.config.expanded_providers();
 
     // Try to find any provider with a valid API key. No key = start with NoKeyProvider.
     // Priority: last_model file (remembers /model choice) → [provider] → first [providers.*] with key.
@@ -520,11 +473,9 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         // 0. Try remembered last model choice
         let mut found_remembered = None;
         if let Some(ref key_name) = remembered_key {
-            if let Some(providers_map) = &workspace.config.providers {
-                if let Some(cfg) = providers_map.get(key_name) {
-                    if let Ok(key) = cfg.resolve_api_key() {
-                        found_remembered = Some((cfg.clone(), key));
-                    }
+            if let Some(cfg) = expanded_providers.get(key_name) {
+                if let Ok(key) = cfg.resolve_api_key() {
+                    found_remembered = Some((cfg.clone(), key));
                 }
             }
         }
@@ -535,14 +486,12 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         else if let Ok(key) = default_provider_cfg.resolve_api_key() {
             (Some(default_provider_cfg.clone()), Some(key))
         } else {
-            // 2. Try any [providers.*] entry
+            // 2. Try any expanded [providers.*] entry
             let mut found: Option<(isanagent::config::ProviderConfig, String)> = None;
-            if let Some(providers_map) = &workspace.config.providers {
-                for cfg in providers_map.values() {
-                    if let Ok(key) = cfg.resolve_api_key() {
-                        found = Some((cfg.clone(), key));
-                        break;
-                    }
+            for cfg in expanded_providers.values() {
+                if let Ok(key) = cfg.resolve_api_key() {
+                    found = Some((cfg.clone(), key));
+                    break;
                 }
             }
             if let Some((cfg, key)) = found {
@@ -759,8 +708,8 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             status_model: model_name.clone(),
             memory_node: memory_node.clone(),
             providers: {
-                // Merge default [provider] + all [providers.*] into one map for /model selector
-                let mut all_providers = workspace.config.providers.clone().unwrap_or_default();
+                // Merge default [provider] + expanded [providers.*] into one map for /model selector
+                let mut all_providers = expanded_providers.clone();
                 if let Some(def) = &workspace.config.provider {
                     let key = format!("{}/{}", def.provider_name, def.model_name);
                     all_providers.entry(key).or_insert_with(|| def.clone());
@@ -1470,28 +1419,10 @@ fn print_onboarding_report(
     }
 }
 
-/// Build the `Run:` line for the onboarding banner. When `report_root` resolves to the same path
-/// as the default (`~/.isanagent`), the `--workspace` flag is redundant and is omitted so the
-/// user sees the cleanest invocation that will work.
+/// Build the `Run:` line for the onboarding banner. Always includes `--workspace` since there is
+/// no global default path.
 fn format_next_steps_run_line(report_root: &std::path::Path) -> String {
-    let default_root = isanagent::workspace::resolve_workspace_root(None);
-    let same = paths_equivalent(report_root, &default_root);
-    if same {
-        "isanagent".to_string()
-    } else {
-        format!("isanagent --workspace {}", report_root.display())
-    }
-}
-
-/// Compare two paths after best-effort canonicalization. Falls back to direct equality when
-/// canonicalize fails (e.g. one of the paths is on a not-yet-existing filesystem branch).
-fn paths_equivalent(a: &std::path::Path, b: &std::path::Path) -> bool {
-    let canon_a = std::fs::canonicalize(a).ok();
-    let canon_b = std::fs::canonicalize(b).ok();
-    match (canon_a, canon_b) {
-        (Some(a), Some(b)) => a == b,
-        _ => a == b,
-    }
+    format!("isanagent --workspace {}", report_root.display())
 }
 
 #[cfg(test)]
@@ -1499,15 +1430,7 @@ mod next_steps_tests {
     use super::*;
 
     #[test]
-    fn omits_workspace_flag_when_root_is_default() {
-        let default_root = isanagent::workspace::resolve_workspace_root(None);
-        let line = format_next_steps_run_line(&default_root);
-        assert_eq!(line, "isanagent", "got {line}");
-    }
-
-    #[test]
-    fn includes_workspace_flag_for_custom_root() {
-        // Use a path that cannot match the user's home directory: a sibling of the workspace dir.
+    fn always_includes_workspace_flag() {
         let custom = std::env::temp_dir().join("isanagent-next-steps-test-custom");
         let line = format_next_steps_run_line(&custom);
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -519,8 +519,20 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             isanagent::provider::create_provider(&cfg.provider_name, &base_url, key, &model_name);
         (p1, p2)
     } else {
-        // No API key found — start with placeholder; user can switch via /model
-        eprintln!("No API key found. Starting without a model. Use /model to configure one.");
+        // No API key found — list the env vars the user could set.
+        let env_vars: Vec<String> = expanded_providers
+            .values()
+            .map(|c| c.resolved_api_key_env())
+            .filter(|e| !e.is_empty())
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        eprintln!("No API key configured for any provider.");
+        if !env_vars.is_empty() {
+            eprintln!("Set one of: {}", env_vars.join(", "));
+        }
+        eprintln!("Or replace \"<changethis>\" with your key in config.toml.");
+        eprintln!("Use /model at runtime to configure one.");
         (
             Box::new(isanagent::provider::NoKeyProvider),
             Box::new(isanagent::provider::NoKeyProvider),

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -51,7 +51,7 @@ pub struct IsanagentWorkspace {
 
 impl IsanagentWorkspace {
     /// Initializes a new workspace at the given path.
-    /// A workspace path must be provided via `--workspace`.
+    /// A workspace path defaults to the current directory if not provided via `--workspace`.
     pub fn new(path_override: Option<&str>, config_override: Option<&str>) -> Result<Self, String> {
         let target_dir = resolve_workspace_root(path_override);
         let layout = ensure_workspace_layout(&target_dir)?;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -13,7 +13,7 @@ pub struct WorkspaceLayout {
 }
 
 pub fn resolve_workspace_root(path_override: Option<&str>) -> PathBuf {
-    let path_str = path_override.unwrap_or(".");
+    let path_str = path_override.unwrap_or("~/.isanagent");
     PathBuf::from(shellexpand::tilde(path_str).to_string())
 }
 
@@ -51,7 +51,7 @@ pub struct IsanagentWorkspace {
 
 impl IsanagentWorkspace {
     /// Initializes a new workspace at the given path.
-    /// A workspace path defaults to the current directory if not provided via `--workspace`.
+    /// If no path is provided, it defaults to `~/.isanagent`.
     pub fn new(path_override: Option<&str>, config_override: Option<&str>) -> Result<Self, String> {
         let target_dir = resolve_workspace_root(path_override);
         let layout = ensure_workspace_layout(&target_dir)?;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -13,7 +13,7 @@ pub struct WorkspaceLayout {
 }
 
 pub fn resolve_workspace_root(path_override: Option<&str>) -> PathBuf {
-    let path_str = path_override.unwrap_or("~/.isanagent");
+    let path_str = path_override.unwrap_or(".");
     PathBuf::from(shellexpand::tilde(path_str).to_string())
 }
 
@@ -51,7 +51,7 @@ pub struct IsanagentWorkspace {
 
 impl IsanagentWorkspace {
     /// Initializes a new workspace at the given path.
-    /// If no path is provided, it defaults to `~/.isanagent`.
+    /// A workspace path must be provided via `--workspace`.
     pub fn new(path_override: Option<&str>, config_override: Option<&str>) -> Result<Self, String> {
         let target_dir = resolve_workspace_root(path_override);
         let layout = ensure_workspace_layout(&target_dir)?;


### PR DESCRIPTION
## Changes

### 1. Remove global installation mechanism
- Delete default `~/.isanagent` workspace path (default is now `"."`)
- Remove auto-onboard first-run wizard
- Remove prebuilt binary download instructions from README
- Add `publish = false` to Cargo.toml

### 2. Add family provider config
- `ProviderConfig` gains `models: Option<Vec<String>>` field
- `AppConfig::expanded_providers()` expands family entries into per-model configs
- Legacy single-model config still works (backward-compatible)
- Duplicate model name detection with `warn!()` logging
- Empty config entry detection with `warn!()` logging
- 9 unit tests for expansion logic

### 3. Update model lists to May 2026
- Gemini: 2.5-flash, 2.5-pro, 3.1-pro, 3.1-flash-lite
- OpenAI: gpt-5.5, gpt-5.5-instant, gpt-5.4-mini, gpt-5.4-nano, o3, o4-mini
- Anthropic: claude-opus-4-7, opus-4-6, sonnet-4-6, haiku-4-5
- DeepSeek: v4-pro, v4-flash (removed deprecated deepseek-reasoner)

### 4. Reject placeholder API keys
- Generalize `jina_api_key_looks_like_placeholder` → `api_key_looks_like_placeholder`
- Apply placeholder detection in `resolve_api_key()` for all providers
- 5 unit tests for placeholder rejection

### 5. Fix compose box cursor position
- Replace ratatui `Wrap { trim: false }` with character-level `char_wrap_compose`
- Fix `prefix_len` for continuation lines: `0` → `2`
- Cursor now tracks correctly on wrapped and multi-line input

### 6. Fix documentation alignment
- `--workspace` documented as "required" but defaults to `"."` → fixed in `src/main.rs`, `src/workspace.rs`, `README.md`

## Test plan
- `cargo check` ✅
- `cargo test expanded_providers` → 9/9 ✅
- `cargo test placeholder_key` → 5/5 ✅
- `cargo test --lib terminal_ui` → 33/33 ✅
- Manual: cursor tracks correctly on wrapped / multi-line compose input
