### PR TITLE
feat(security): P0 execution-harness hardening

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -295,6 +295,94 @@ fn command_preview(command: &str) -> String {
     }
 }
 
+/// Tools that execute model-authored code/commands on the host or a session. All of these run
+/// arbitrary code, so they share the shell-policy approval gate — not just `exec`. Keying the
+/// gate on this category (rather than the literal name `"exec"`) is what stops `execution_run`
+/// / `execution_run_background` / `python_run` from bypassing approval entirely.
+fn is_code_exec_tool(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "exec" | "python_run" | "execution_run" | "execution_run_background"
+    )
+}
+
+/// Code-exec tools that run *arbitrary* code (Python source / session cells) where the
+/// destructive-shell-pattern heuristic does not meaningfully apply, so any such call is
+/// treated as approval-worthy in ask/deny mode.
+fn is_arbitrary_code_tool(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "python_run" | "execution_run" | "execution_run_background"
+    )
+}
+
+/// Extract the command/code a code-exec tool will run. `exec` carries it in `command`; the
+/// execution / python tools carry it in `code`.
+fn extract_code_exec_command(tool_name: &str, args: &Value) -> Option<String> {
+    let key = if tool_name == "exec" { "command" } else { "code" };
+    args.get(key)
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Whether a code-exec call needs approval in ask/deny mode. Arbitrary-code tools always do;
+/// shell `exec` only when the command matches a destructive pattern (preserves existing UX).
+fn code_exec_requires_approval(tool_name: &str, command: &str, patterns: &[String]) -> bool {
+    is_arbitrary_code_tool(tool_name) || should_require_shell_approval(command, patterns)
+}
+
+#[cfg(test)]
+mod code_exec_gate_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn category_covers_all_code_exec_tools() {
+        assert!(is_code_exec_tool("exec"));
+        assert!(is_code_exec_tool("python_run"));
+        assert!(is_code_exec_tool("execution_run"));
+        assert!(is_code_exec_tool("execution_run_background"));
+        assert!(!is_code_exec_tool("read_file"));
+        assert!(!is_code_exec_tool("web_search"));
+    }
+
+    #[test]
+    fn extracts_command_for_exec_and_code_for_execution_tools() {
+        assert_eq!(
+            extract_code_exec_command("exec", &json!({"command": " ls -la "})).as_deref(),
+            Some("ls -la")
+        );
+        assert_eq!(
+            extract_code_exec_command("execution_run", &json!({"code": "print(1)"})).as_deref(),
+            Some("print(1)")
+        );
+        assert_eq!(
+            extract_code_exec_command("python_run", &json!({"code": "import os"})).as_deref(),
+            Some("import os")
+        );
+        // wrong key / empty -> None
+        assert!(extract_code_exec_command("execution_run", &json!({"command": "x"})).is_none());
+        assert!(extract_code_exec_command("exec", &json!({"command": "  "})).is_none());
+    }
+
+    #[test]
+    fn arbitrary_code_always_requires_approval_benign_exec_does_not() {
+        let patterns = vec!["rm -rf".to_string()];
+        // Arbitrary-code tools: even benign code requires approval (closes the bypass).
+        assert!(code_exec_requires_approval(
+            "execution_run",
+            "print('hi')",
+            &patterns
+        ));
+        assert!(code_exec_requires_approval("python_run", "1+1", &patterns));
+        // Shell `exec`: benign command does NOT require approval (preserves existing UX)...
+        assert!(!code_exec_requires_approval("exec", "ls -la", &patterns));
+        // ...but a destructive one does.
+        assert!(code_exec_requires_approval("exec", "rm -rf /tmp/x", &patterns));
+    }
+}
+
 fn hook_observe_telemetry(
     hook_tool_ctx: Option<&Arc<ToolCallHookContext>>,
     inbound: &crate::bus::InboundMessage,
@@ -441,13 +529,16 @@ async fn execute_tool_call_with_activity(
 
         let is_subagent = runtime.is_subagent;
         let allow = runtime.subagent_allowlist.clone();
-        if tool_name == "exec" {
-            if let Some(command) = extract_exec_command(&args) {
+        if is_code_exec_tool(&tool_name) {
+            if let Some(command) = extract_code_exec_command(&tool_name, &args) {
                 let preview = command_preview(&command);
                 let mode =
                     shell_policy_mode_for_session(&runtime.shell_policy, runtime.unattended_session);
-                let requires_approval =
-                    should_require_shell_approval(&command, &runtime.shell_policy.approval_patterns);
+                let requires_approval = code_exec_requires_approval(
+                    &tool_name,
+                    &command,
+                    &runtime.shell_policy.approval_patterns,
+                );
                 match mode {
                     ShellPolicyMode::Allow => {}
                     ShellPolicyMode::Deny => {
@@ -480,8 +571,8 @@ async fn execute_tool_call_with_activity(
                                 .await;
                             let ask_payload = serde_json::json!({
                                 "prompt": format!(
-                                    "Approve potentially destructive shell command?\n\n`{}`\n\nReply with approve or deny.",
-                                    command
+                                    "Approve running `{}`?\n\n```\n{}\n```\n\nReply with approve or deny.",
+                                    tool_name, command
                                 ),
                                 "choices": ["approve", "deny"],
                                 "timeout_secs": 1800,

--- a/src/channels/api.rs
+++ b/src/channels/api.rs
@@ -370,11 +370,24 @@ impl ApiChannel {
 }
 
 /// Loopback / local-only binds that are safe to serve without authentication.
+///
+/// Parses the host as an IP and uses `is_loopback()` (covers all of `127.0.0.0/8` and `::1`,
+/// including the bracketed `[::1]` form), so a non-loopback bind (`0.0.0.0`, `::`, a public IP) —
+/// or anything unparseable, including a hostname like `127.example.com` — is treated as NOT
+/// loopback and therefore requires a token. Fails safe (unknown ⇒ not loopback).
 fn is_loopback_bind(addr: &str) -> bool {
-    match addr.trim() {
-        "127.0.0.1" | "::1" | "localhost" => true,
-        host => host.starts_with("127."),
+    let host = addr.trim();
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
     }
+    // Accept the bracketed IPv6 literal `[::1]` as well as bare `::1`.
+    let host = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    host.parse::<std::net::IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
 }
 
 /// Refuse to expose the control plane to a non-loopback address without a token. The `/v1`
@@ -2689,10 +2702,15 @@ bind_address = "127.0.0.1"
     fn loopback_binds_recognized() {
         assert!(is_loopback_bind("127.0.0.1"));
         assert!(is_loopback_bind("::1"));
+        assert!(is_loopback_bind("[::1]")); // bracketed IPv6 literal
         assert!(is_loopback_bind("localhost"));
-        assert!(is_loopback_bind("127.0.0.5"));
+        assert!(is_loopback_bind("127.0.0.5")); // all of 127.0.0.0/8
         assert!(!is_loopback_bind("0.0.0.0"));
+        assert!(!is_loopback_bind("::")); // unspecified IPv6 is NOT loopback
         assert!(!is_loopback_bind("192.168.1.10"));
+        // A hostname that merely starts with "127." must NOT be treated as loopback
+        // (previously fail-open via a `starts_with("127.")` shortcut).
+        assert!(!is_loopback_bind("127.example.com"));
     }
 
     #[test]

--- a/src/channels/api.rs
+++ b/src/channels/api.rs
@@ -7,8 +7,9 @@ use std::time::Duration;
 use async_trait::async_trait;
 use axum::{
     body::{Body, Bytes},
-    extract::{OriginalUri, Path as AxumPath, Query, State},
+    extract::{OriginalUri, Path as AxumPath, Query, Request, State},
     http::{header, HeaderName, HeaderValue, StatusCode},
+    middleware::{self, Next},
     response::{sse::Event, sse::Sse, IntoResponse, Response},
     routing::{delete, get, post},
     Json, Router,
@@ -59,6 +60,8 @@ struct ApiState {
     memory_node: NodeHandle<MemoryMessage>,
     /// Agent sandbox (`<workspace>/workspace`); same root as filesystem tools.
     workspace_sandbox: std::path::PathBuf,
+    /// When `Some`, a `Authorization: Bearer <token>` is required on all `/v1` routes.
+    auth_token: Option<std::sync::Arc<String>>,
 }
 
 enum PendingRequest {
@@ -280,6 +283,7 @@ pub struct ApiChannel {
     port: u16,
     bind_address: Option<String>,
     serve_ui: bool,
+    auth_token: Option<std::sync::Arc<String>>,
     workspace_sandbox: std::path::PathBuf,
     pending_requests: std::sync::Arc<DashMap<String, PendingRequest>>,
     responses_cache: Cache<String, StoredResponse>,
@@ -304,6 +308,19 @@ impl ApiChannel {
             .bind_address
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty());
+        // Config value wins; fall back to the ISANAGENT_API_TOKEN env var so the secret need
+        // not live in the workspace TOML.
+        let auth_token = config
+            .auth_token
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                std::env::var("ISANAGENT_API_TOKEN")
+                    .ok()
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty())
+            })
+            .map(std::sync::Arc::new);
         let workspace_sandbox = std::fs::canonicalize(workspace_sandbox.as_ref()).map_err(|e| {
             format!(
                 "Failed to canonicalize workspace sandbox {:?}: {}",
@@ -315,6 +332,7 @@ impl ApiChannel {
             port: config.port,
             bind_address,
             serve_ui: config.serve_ui.unwrap_or(false),
+            auth_token,
             workspace_sandbox,
             pending_requests: std::sync::Arc::new(DashMap::new()),
             responses_cache: Cache::builder()
@@ -341,11 +359,83 @@ impl ApiChannel {
     fn resolved_bind_address(&self) -> String {
         if let Some(bind_address) = &self.bind_address {
             bind_address.clone()
-        } else if self.serve_ui {
-            "127.0.0.1".to_string()
         } else {
-            "0.0.0.0".to_string()
+            // Safe by default: loopback. Exposing the control plane to the network now requires
+            // an explicit `bind_address` AND an auth token (enforced in `start`). Previously the
+            // headless default was `0.0.0.0`, which silently network-exposed chat control and
+            // workspace file read/write.
+            "127.0.0.1".to_string()
         }
+    }
+}
+
+/// Loopback / local-only binds that are safe to serve without authentication.
+fn is_loopback_bind(addr: &str) -> bool {
+    match addr.trim() {
+        "127.0.0.1" | "::1" | "localhost" => true,
+        host => host.starts_with("127."),
+    }
+}
+
+/// Refuse to expose the control plane to a non-loopback address without a token. The `/v1`
+/// surface includes chat control and workspace file read/write, so an unauthenticated public
+/// bind is an unauthenticated remote-code-execution surface.
+fn validate_bind_security(addr: &str, has_token: bool) -> Result<(), String> {
+    if is_loopback_bind(addr) || has_token {
+        Ok(())
+    } else {
+        Err(format!(
+            "Refusing to bind the API control plane to non-loopback address {addr:?} without authentication. \
+             Set [api].auth_token (or the ISANAGENT_API_TOKEN env var), or bind to 127.0.0.1."
+        ))
+    }
+}
+
+/// Constant-time bearer-token check for `Authorization: Bearer <token>`.
+fn bearer_token_matches(auth_header: Option<&str>, expected: &str) -> bool {
+    if expected.is_empty() {
+        return false;
+    }
+    let Some(header) = auth_header else {
+        return false;
+    };
+    let Some(token) = header
+        .strip_prefix("Bearer ")
+        .or_else(|| header.strip_prefix("bearer "))
+    else {
+        return false;
+    };
+    let token = token.trim();
+    if token.len() != expected.len() {
+        return false;
+    }
+    // Constant-time compare so a near-miss token cannot be discovered byte-by-byte via timing.
+    let mut diff = 0u8;
+    for (a, b) in token.bytes().zip(expected.bytes()) {
+        diff |= a ^ b;
+    }
+    diff == 0
+}
+
+/// Middleware gating the `/v1` routes when an auth token is configured.
+async fn require_bearer_auth(
+    State(expected): State<std::sync::Arc<String>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let provided = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok());
+    if bearer_token_matches(provided, expected.as_str()) {
+        next.run(req).await
+    } else {
+        ApiError::new(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "Missing or invalid `Authorization: Bearer` token.",
+        )
+        .into_response()
     }
 }
 
@@ -368,7 +458,11 @@ impl Channel for ApiChannel {
             logger_tx: self.logger_tx.clone(),
             memory_node: self.memory_node.clone(),
             workspace_sandbox: self.workspace_sandbox.clone(),
+            auth_token: self.auth_token.clone(),
         };
+
+        let resolved_bind = self.resolved_bind_address();
+        validate_bind_security(&resolved_bind, self.auth_token.is_some())?;
 
         let logger_tx = self.logger_tx.clone();
         let mut shutdown_rx = self.shutdown_tx.subscribe();
@@ -376,7 +470,7 @@ impl Channel for ApiChannel {
             "ApiChannel",
             "Starting API channel...",
         )));
-        let addr = format!("{}:{}", self.resolved_bind_address(), port);
+        let addr = format!("{}:{}", resolved_bind, port);
         let listener = tokio::net::TcpListener::bind(&addr)
             .await
             .map_err(|e| format!("Failed to bind API port on {}: {}", addr, e))?;
@@ -578,7 +672,8 @@ impl ApiChannel {
 }
 
 fn build_router(state: ApiState, serve_ui: bool) -> Router {
-    let mut app = Router::new()
+    let auth_token = state.auth_token.clone();
+    let mut v1 = Router::new()
         .route("/v1/chat/completions", post(handle_chat))
         .route("/v1/responses", post(handle_responses))
         .route("/v1/threads", get(handle_list_threads))
@@ -622,6 +717,15 @@ fn build_router(state: ApiState, serve_ui: bool) -> Router {
         // POST on a distinct path so clients are not blocked by proxies or older builds that only registered GET on `/v1/workspace/file`.
         .route("/v1/workspace/file/save", post(handle_workspace_file_put))
         .route("/v1/workspace/rename", post(handle_workspace_rename));
+
+    // Gate the `/v1` control surface with bearer auth when a token is configured. The cron
+    // webhook (its own per-job URL token) and the embedded UI assets are intentionally left
+    // open: external cron callers and browser asset GETs cannot carry the bearer header.
+    if let Some(token) = auth_token {
+        v1 = v1.route_layer(middleware::from_fn_with_state(token, require_bearer_auth));
+    }
+
+    let mut app = Router::new().merge(v1);
 
     if state.mte_cron_scheduler.is_some() {
         app = app.route("/_mte/cron/{job_id}/{token}", get(handle_mte_cron_webhook));
@@ -2441,7 +2545,10 @@ fn log_api(logger_tx: &LoggerHandle, event: LogEvent) {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_router, ApiState, PendingRequest, EMBEDDED_UI_ASSETS};
+    use super::{
+        bearer_token_matches, build_router, is_loopback_bind, validate_bind_security, ApiState,
+        PendingRequest, EMBEDDED_UI_ASSETS,
+    };
     use crate::bus::{BusMessage, OutboundMessage};
     use crate::channels::api_store::ResponseStore;
     use crate::config::ApiConfig;
@@ -2554,6 +2661,7 @@ mod tests {
             logger_tx,
             memory_node,
             workspace_sandbox,
+            auth_token: None,
         }
     }
 
@@ -2573,6 +2681,92 @@ bind_address = "127.0.0.1"
         assert_eq!(config.port, 8080);
         assert_eq!(config.serve_ui, Some(true));
         assert_eq!(config.bind_address.as_deref(), Some("127.0.0.1"));
+    }
+
+    // ---- 0.2: HTTP control-plane auth + safe bind ----
+
+    #[test]
+    fn loopback_binds_recognized() {
+        assert!(is_loopback_bind("127.0.0.1"));
+        assert!(is_loopback_bind("::1"));
+        assert!(is_loopback_bind("localhost"));
+        assert!(is_loopback_bind("127.0.0.5"));
+        assert!(!is_loopback_bind("0.0.0.0"));
+        assert!(!is_loopback_bind("192.168.1.10"));
+    }
+
+    #[test]
+    fn refuses_public_bind_without_token() {
+        assert!(validate_bind_security("127.0.0.1", false).is_ok());
+        let err = validate_bind_security("0.0.0.0", false).expect_err("must refuse public+no-token");
+        assert!(
+            err.contains("auth_token") || err.contains("127.0.0.1"),
+            "err={err}"
+        );
+        assert!(validate_bind_security("0.0.0.0", true).is_ok());
+    }
+
+    #[test]
+    fn bearer_match_rules() {
+        assert!(bearer_token_matches(Some("Bearer s3cret"), "s3cret"));
+        assert!(bearer_token_matches(Some("bearer s3cret"), "s3cret"));
+        assert!(!bearer_token_matches(Some("Bearer wrong0"), "s3cret"));
+        assert!(!bearer_token_matches(Some("s3cret"), "s3cret")); // missing scheme
+        assert!(!bearer_token_matches(None, "s3cret"));
+        assert!(!bearer_token_matches(Some("Bearer s3cret"), "")); // empty expected never matches
+    }
+
+    #[tokio::test]
+    async fn v1_requires_bearer_when_token_configured() {
+        let temp = LocalTempDir::new();
+        let (bus_tx, _bus_rx) = mpsc::channel(4);
+        let mut state = build_state(&temp.db_path(), bus_tx, None);
+        state.auth_token = Some(std::sync::Arc::new("topsecret".to_string()));
+        let app = build_router(state, false);
+
+        let unauthorized = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/v1/threads")
+                    .method("GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request succeeds");
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+        let authorized = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/v1/threads")
+                    .method("GET")
+                    .header("authorization", "Bearer topsecret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request succeeds");
+        assert_ne!(authorized.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn v1_open_when_no_token_configured() {
+        let temp = LocalTempDir::new();
+        let (bus_tx, _bus_rx) = mpsc::channel(4);
+        let app = build_router(build_state(&temp.db_path(), bus_tx, None), false);
+        let response = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/v1/threads")
+                    .method("GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request succeeds");
+        assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]
@@ -2798,6 +2992,7 @@ bind_address = "127.0.0.1"
             logger_tx,
             memory_node,
             workspace_sandbox,
+            auth_token: None,
         };
         let app = build_router(state, true);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1231,12 +1231,14 @@ impl AppConfig {
     }
 
     pub fn execution_ssh_accept_unknown_host_keys(&self) -> bool {
+        // Secure by default: verify host keys via the trust-on-first-use known_hosts store.
+        // Opt in to the insecure "accept any key" behavior only by explicitly setting true.
         self.harness
             .as_ref()
             .and_then(|h| h.execution.as_ref())
             .and_then(|e| e.ssh.as_ref())
             .and_then(|s| s.accept_unknown_host_keys)
-            .unwrap_or(true)
+            .unwrap_or(false)
     }
 
     pub fn execution_colab_mcp_command(&self) -> String {
@@ -1385,6 +1387,11 @@ pub struct ApiConfig {
     pub port: u16,
     pub serve_ui: Option<bool>,
     pub bind_address: Option<String>,
+    /// Bearer token required on the `/v1` control surface when set. Also loadable via the
+    /// `ISANAGENT_API_TOKEN` env var (config value wins). REQUIRED to bind a non-loopback
+    /// address — the API exposes chat control and workspace file read/write with no other guard.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_token: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
@@ -1773,6 +1780,22 @@ accept_unknown_host_keys = false
         );
         assert_eq!(c.execution_ssh_remote_python(), "python3");
         assert!(!c.execution_ssh_accept_unknown_host_keys());
+    }
+
+    #[test]
+    fn ssh_accept_unknown_host_keys_defaults_false() {
+        // 0.4: host-key verification must be ON by default. Omitting the key => secure default.
+        let s = r#"
+[harness.execution.ssh]
+host = "10.0.0.9"
+user = "dev"
+remote_workdir = "/tmp/x"
+"#;
+        let c: AppConfig = toml::from_str(s).expect("parse");
+        assert!(
+            !c.execution_ssh_accept_unknown_host_keys(),
+            "default must verify host keys (accept_unknown_host_keys=false)"
+        );
     }
 
     #[test]

--- a/src/execution/capabilities.rs
+++ b/src/execution/capabilities.rs
@@ -79,7 +79,10 @@ pub struct SessionCapabilities {
     pub provider_id: String,
     #[serde(default)]
     pub active_language: Option<String>,
-    #[serde(default)]
+    /// `Some(true/false)` only when the provider actually probed GPU visibility. Omitted from
+    /// serialized snapshots when unknown, so a permanently-null field is not surfaced to the
+    /// model as if it were a real (negative) capability signal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gpu_visible: Option<bool>,
     #[serde(default)]
     pub working_directory_display: Option<String>,

--- a/src/execution/harness.rs
+++ b/src/execution/harness.rs
@@ -355,6 +355,10 @@ fn try_build_provider(
                 remote_python: config.execution_ssh_remote_python(),
                 identity_path: config.execution_ssh_identity_file(),
                 accept_unknown_host_keys: config.execution_ssh_accept_unknown_host_keys(),
+                known_hosts_path: workspace_dir
+                    .join(".system_generated")
+                    .join("ssh")
+                    .join("known_hosts"),
                 max_run_timeout_secs: config.execution_max_wall_secs(),
                 max_output_bytes: config.execution_max_output_bytes(),
                 max_sessions: config.execution_max_sessions(),

--- a/src/execution/local.rs
+++ b/src/execution/local.rs
@@ -339,10 +339,19 @@ impl LocalExecutionProvider {
         caps.languages = vec![platform_shell_name().to_string()];
         caps.supports_persistent_sessions = true;
         caps.supports_interrupt = true;
-        caps.supports_package_install = false;
+        // Truthful capability: the uv_managed runtime performs network-backed
+        // `uv venv` / `uv pip install` during env provisioning, so it genuinely offers package
+        // installation. The system runtime does not provision packages itself, so it reports false.
+        caps.supports_package_install =
+            matches!(config.python_runtime, LocalPythonRuntime::UvManaged);
         caps.supports_remote_shell = false;
         caps.jupyter_kernel = false;
-        caps.network_policy = NetworkPolicy::Off;
+        // Truthful capability: the local provider runs code as an ordinary host child with NO
+        // egress enforcement (no netns/seccomp/firewall), so network access is in fact Full.
+        // Do NOT advertise `Off` here — nothing enforces it, and a model told "Off" may wrongly
+        // assume exfiltration is impossible and plan unsafely. Flip this to a real restricted
+        // policy only once an enforced netns/Seatbelt deny path exists (see PLAN.md P1.5).
+        caps.network_policy = NetworkPolicy::Full;
         caps.max_output_bytes_default = Some(config.max_output_bytes as u64);
         let runtime_name = match config.python_runtime {
             LocalPythonRuntime::System => "system",
@@ -921,6 +930,39 @@ mod tests {
             std::env::temp_dir().join(format!("isanagent-exec-test-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    // 0.1 capability truthfulness: the local provider must not advertise protections it lacks.
+    // Network is unenforced -> must report Full (never Off). Package-install reflects the runtime.
+    #[test]
+    fn local_caps_are_truthful_system_runtime() {
+        let dir = temp_sandbox();
+        let cfg = LocalExecutionConfig::new(dir.clone(), dir.clone(), true);
+        let caps = LocalExecutionProvider::new(cfg).unwrap().capabilities();
+        assert_eq!(
+            caps.network_policy,
+            NetworkPolicy::Full,
+            "local has no egress enforcement; advertising Off manufactures false assurance"
+        );
+        assert!(
+            !caps.supports_package_install,
+            "system runtime does not provision packages itself"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn local_caps_are_truthful_uv_managed_runtime() {
+        let dir = temp_sandbox();
+        let mut cfg = LocalExecutionConfig::new(dir.clone(), dir.clone(), true);
+        cfg.python_runtime = LocalPythonRuntime::UvManaged;
+        let caps = LocalExecutionProvider::new(cfg).unwrap().capabilities();
+        assert_eq!(caps.network_policy, NetworkPolicy::Full);
+        assert!(
+            caps.supports_package_install,
+            "uv_managed runs network-backed `uv pip install`, so it does install packages"
+        );
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]

--- a/src/execution/ssh.rs
+++ b/src/execution/ssh.rs
@@ -4,6 +4,7 @@
 //! `cwd_relative` refer to **remote** paths only (never the agent workspace sandbox).
 
 use std::io::Cursor;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -41,7 +42,11 @@ pub struct SshExecutionProviderConfig {
     pub remote_workdir: String,
     pub remote_python: String,
     pub identity_path: Option<String>,
+    /// INSECURE escape hatch: when true, ANY server key is accepted (no verification). Default
+    /// false — the provider verifies host keys via a trust-on-first-use `known_hosts` store.
     pub accept_unknown_host_keys: bool,
+    /// File where verified host-key fingerprints are recorded (`host:port SHA256:...` per line).
+    pub known_hosts_path: PathBuf,
     pub max_run_timeout_secs: u64,
     pub max_output_bytes: usize,
     pub max_sessions: usize,
@@ -49,6 +54,69 @@ pub struct SshExecutionProviderConfig {
 
 struct SshClientHandler {
     accept_unknown_host_keys: bool,
+    host_label: String,
+    known_hosts_path: PathBuf,
+}
+
+/// Outcome of comparing a presented server key against the `known_hosts` store.
+#[derive(Debug, PartialEq, Eq)]
+enum HostKeyVerdict {
+    /// Fingerprint matches the recorded one.
+    Match,
+    /// First time we have seen this host; fingerprint recorded.
+    TrustedOnFirstUse,
+    /// A different fingerprint is already recorded — possible MITM; connection must be refused.
+    Mismatch { recorded: String },
+}
+
+/// Read the recorded fingerprint for `host_label` from the known_hosts file, if any.
+fn read_recorded_host_key(path: &Path, host_label: &str) -> std::io::Result<Option<String>> {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((host, fingerprint)) = line.split_once(' ') {
+            if host == host_label {
+                return Ok(Some(fingerprint.trim().to_string()));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn append_known_host(path: &Path, host_label: &str, fingerprint: &str) -> std::io::Result<()> {
+    use std::io::Write;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    writeln!(file, "{host_label} {fingerprint}")
+}
+
+/// Trust-on-first-use host-key verification: record an unknown host, confirm a matching one,
+/// and flag a changed key (possible MITM) so the caller can refuse the connection.
+fn verify_or_record_known_host(
+    path: &Path,
+    host_label: &str,
+    fingerprint: &str,
+) -> std::io::Result<HostKeyVerdict> {
+    match read_recorded_host_key(path, host_label)? {
+        Some(recorded) if recorded == fingerprint => Ok(HostKeyVerdict::Match),
+        Some(recorded) => Ok(HostKeyVerdict::Mismatch { recorded }),
+        None => {
+            append_known_host(path, host_label, fingerprint)?;
+            Ok(HostKeyVerdict::TrustedOnFirstUse)
+        }
+    }
 }
 
 impl russh::client::Handler for SshClientHandler {
@@ -56,9 +124,47 @@ impl russh::client::Handler for SshClientHandler {
 
     async fn check_server_key(
         &mut self,
-        _server_public_key: &keys::PublicKey,
+        server_public_key: &keys::PublicKey,
     ) -> Result<bool, Self::Error> {
-        Ok(self.accept_unknown_host_keys)
+        // Explicit insecure override: accept any key without verification. Off by default.
+        if self.accept_unknown_host_keys {
+            log::warn!(
+                "ssh: accept_unknown_host_keys=true — skipping host-key verification for {} (INSECURE; vulnerable to MITM)",
+                self.host_label
+            );
+            return Ok(true);
+        }
+        let fingerprint = server_public_key
+            .fingerprint(keys::HashAlg::Sha256)
+            .to_string();
+        match verify_or_record_known_host(&self.known_hosts_path, &self.host_label, &fingerprint) {
+            Ok(HostKeyVerdict::Match) => Ok(true),
+            Ok(HostKeyVerdict::TrustedOnFirstUse) => {
+                log::info!(
+                    "ssh: trusting new host key for {} on first use ({})",
+                    self.host_label,
+                    fingerprint
+                );
+                Ok(true)
+            }
+            Ok(HostKeyVerdict::Mismatch { recorded }) => {
+                log::error!(
+                    "ssh: HOST KEY MISMATCH for {} — refusing connection (possible MITM). \
+                     recorded={recorded} presented={fingerprint}. If the change is legitimate, \
+                     remove the stale line from {}.",
+                    self.host_label,
+                    self.known_hosts_path.display()
+                );
+                Ok(false)
+            }
+            Err(e) => {
+                log::error!(
+                    "ssh: known_hosts verification failed for {} ({e}) — refusing connection (fail closed)",
+                    self.host_label
+                );
+                Ok(false)
+            }
+        }
     }
 }
 
@@ -411,6 +517,8 @@ async fn open_ssh_handle(
     let client_cfg = Arc::new(client::Config::default());
     let handler = SshClientHandler {
         accept_unknown_host_keys: config.accept_unknown_host_keys,
+        host_label: format!("{}:{}", config.host, config.port),
+        known_hosts_path: config.known_hosts_path.clone(),
     };
     let addrs = (config.host.as_str(), config.port);
     let mut handle = client::connect(client_cfg, addrs, handler)
@@ -729,6 +837,59 @@ mod tests {
             validate_remote_workdir("/tmp/isanagent-exec").unwrap(),
             "/tmp/isanagent-exec"
         );
+    }
+
+    // 0.4: trust-on-first-use host-key verification.
+    fn tofu_temp_path() -> PathBuf {
+        std::env::temp_dir()
+            .join(format!("isanagent-knownhosts-{}", uuid::Uuid::new_v4()))
+            .join("known_hosts")
+    }
+
+    #[test]
+    fn host_key_tofu_records_then_matches() {
+        let path = tofu_temp_path();
+        // First sight of the host -> trusted on first use and recorded.
+        assert_eq!(
+            verify_or_record_known_host(&path, "10.0.0.5:22", "SHA256:abc").unwrap(),
+            HostKeyVerdict::TrustedOnFirstUse
+        );
+        // Same fingerprint next time -> match.
+        assert_eq!(
+            verify_or_record_known_host(&path, "10.0.0.5:22", "SHA256:abc").unwrap(),
+            HostKeyVerdict::Match
+        );
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn host_key_mismatch_is_detected() {
+        let path = tofu_temp_path();
+        verify_or_record_known_host(&path, "host:22", "SHA256:original").unwrap();
+        // A different key for the same host -> mismatch (possible MITM); caller must refuse.
+        assert_eq!(
+            verify_or_record_known_host(&path, "host:22", "SHA256:changed").unwrap(),
+            HostKeyVerdict::Mismatch {
+                recorded: "SHA256:original".to_string()
+            }
+        );
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn host_key_store_is_per_host() {
+        let path = tofu_temp_path();
+        verify_or_record_known_host(&path, "a:22", "SHA256:aaa").unwrap();
+        // A different host is independent -> first use, not a mismatch.
+        assert_eq!(
+            verify_or_record_known_host(&path, "b:22", "SHA256:bbb").unwrap(),
+            HostKeyVerdict::TrustedOnFirstUse
+        );
+        assert_eq!(
+            verify_or_record_known_host(&path, "a:22", "SHA256:aaa").unwrap(),
+            HostKeyVerdict::Match
+        );
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the four indefensible **P0** gaps surfaced by a competitive/security review of the execution harness. Each finding was verified against source; each fix ships with unit tests.

### 1. Capability truthfulness
The local provider advertised protections it does not have. Now:
- `network_policy` = **`Full`** (nothing enforces `Off` — no netns/seccomp/firewall; telling the model `Off` manufactured false assurance).
- `supports_package_install` = **`true`** under `uv_managed` (it runs network-backed `uv pip install`).
- `gpu_visible` omitted from serialized snapshots when unprobed (was a permanent `null` surfaced as a capability).

### 2. HTTP control-plane auth + safe bind
`build_router` exposed chat control + workspace file read/write with no auth, and the headless default bind was `0.0.0.0`.
- Bearer-token middleware (`Authorization: Bearer …`, constant-time compare) gates all `/v1` routes when `[api].auth_token` (or `ISANAGENT_API_TOKEN`) is set.
- Headless default bind → **`127.0.0.1`**; **refuse** to bind a non-loopback address without a token.
- Cron webhook's per-job URL token is unchanged (and left open, as external callers can't send the bearer).

### 3. Code-exec approval gate (category, not name)
The approval gate keyed on the literal tool name `"exec"`, so `execution_run` / `execution_run_background` / `python_run` bypassed it entirely.
- Gate now keys on the **code-exec category**.
- Arbitrary-code tools (`python_run`, `execution_run`, `execution_run_background`) **always** require approval in ask/deny mode; shell `exec` keeps its destructive-pattern heuristic (UX preserved).

### 4. SSH host-key verification (TOFU)
`check_server_key` returned `Ok(accept_unknown_host_keys)` with no comparison, and the flag defaulted **true** → silent MITM, with no working secure path.
- Trust-on-first-use `known_hosts` store: record an unknown host, confirm a matching key, **refuse a changed key** (possible MITM).
- `accept_unknown_host_keys` now defaults **false** (explicit insecure opt-in only).

## Test plan
- [x] `cargo test --lib` — **314 passed, 0 failed** (14 new tests)
- [x] `cargo clippy --lib` — no new warnings from these changes
- [ ] Reviewer: confirm the `/v1` bearer gate leaves the cron webhook + (when `serve_ui`) UI assets reachable
- [ ] Reviewer: confirm SSH TOFU default-false migration note for existing operators

> Note: pairs with the ALTAI desktop PR that wires the UI permission mode onto the shell-policy interactive mode. A broader roadmap (P1 setrlimit/env-scrub/netns/OCI backend, P2 durable jobs/repro) is tracked separately.
