### PR TITLE
feat(agent): P1.3 — structured tool-error signal to the model (is_error)

### DIFF
--- a/src/agent/compaction.rs
+++ b/src/agent/compaction.rs
@@ -772,6 +772,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: None,
             reasoning_content: None,
+            is_error: None,
         }
     }
 
@@ -783,6 +784,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: Some("call_0".to_string()),
             reasoning_content: None,
+            is_error: None,
         }
     }
 
@@ -1045,6 +1047,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: Some(id.to_string()),
             reasoning_content: None,
+            is_error: None,
         }
     }
 
@@ -1099,6 +1102,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: None,
             reasoning_content: None,
+            is_error: None,
         }];
         let (swapped, cached) = swap_all_tool_results_in_place(&mut ctx);
         assert_eq!(swapped, 0);
@@ -1171,6 +1175,7 @@ mod tests {
                     tool_calls: None,
                     tool_call_id: None,
                     reasoning_content: None,
+                    is_error: None,
                 },
             ),
             (3, user_msg("u2")),
@@ -1204,6 +1209,7 @@ mod tests {
                     tool_calls: None,
                     tool_call_id: Some("c1".to_string()),
                     reasoning_content: None,
+                    is_error: None,
                 },
             ),
             (3, user_msg("u2")),

--- a/src/agent/doom_loop.rs
+++ b/src/agent/doom_loop.rs
@@ -145,6 +145,7 @@ mod tests {
             tool_calls: Some(calls),
             tool_call_id: None,
             reasoning_content: None,
+            is_error: None,
         }
     }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -2527,6 +2527,7 @@ impl AgentLogic {
                     tool_calls: Some(tool_calls.clone()),
                     tool_call_id: None,
                     reasoning_content: response.reasoning_content.clone(),
+                    is_error: None,
                 };
                 mem.add_message(assistant_msg).await?;
 
@@ -2665,10 +2666,11 @@ impl AgentLogic {
                         };
                         let _ = outbound_tx.send(BusMessage::Telemetry(tfin.clone())).await;
                         hook_observe_telemetry(hook_tool_ctx.as_ref(), &inbound, is_subagent, tfin);
-                        mem.add_message(crate::utils::ChatMessage::tool(
+                        mem.add_message(crate::utils::ChatMessage::tool_with_error(
                             &tool_result_text,
                             &tc.id,
                             Some(tool_name.as_str()),
+                            is_error,
                         ))
                         .await?;
                     }
@@ -2770,10 +2772,11 @@ impl AgentLogic {
                         let _ = outbound_tx.send(BusMessage::Telemetry(tfin.clone())).await;
                         hook_observe_telemetry(hook_tool_ctx.as_ref(), &inbound, is_subagent, tfin);
 
-                        mem.add_message(crate::utils::ChatMessage::tool(
+                        mem.add_message(crate::utils::ChatMessage::tool_with_error(
                             &tool_result_text,
                             &tc.id,
                             Some(tool_name.as_str()),
+                            is_error,
                         ))
                         .await?;
                         tool_invoked = true;

--- a/src/channels/terminal_ui/history_cells.rs
+++ b/src/channels/terminal_ui/history_cells.rs
@@ -110,6 +110,7 @@ mod tests {
                 tool_calls: None,
                 tool_call_id: None,
                 reasoning_content: None,
+                is_error: None,
             },
         ];
         let cells = chat_messages_to_terminal_cells(&messages);

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -886,6 +886,9 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                                 tool_calls,
                                 tool_call_id: row.get(4)?,
                                 reasoning_content: row.get(5)?,
+                                // Not persisted (skip_serializing internal field); a reloaded
+                                // message keeps only the "Error:" text already in `content`.
+                                is_error: None,
                             })
                         })
                         .map_err(|e| e.to_string())?;
@@ -1388,6 +1391,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                                     tool_calls,
                                     tool_call_id,
                                     reasoning_content,
+                                    is_error: None,
                                 },
                             ))
                         })

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -489,7 +489,11 @@ mod is_error_tests {
         ];
         let (_system, anthropic) = AnthropicProvider::convert_messages(&msgs);
         let blocks = tool_result_blocks(&anthropic);
-        assert_eq!(blocks.len(), 3, "expected 3 tool_result blocks, got {anthropic:?}");
+        assert_eq!(
+            blocks.len(),
+            3,
+            "expected 3 tool_result blocks, got {anthropic:?}"
+        );
 
         let by_id = |id: &str| {
             blocks
@@ -498,7 +502,10 @@ mod is_error_tests {
                 .unwrap_or_else(|| panic!("missing tool_result for {id}"))
         };
         // Failure -> native is_error: true.
-        assert_eq!(by_id("call_1").get("is_error"), Some(&serde_json::json!(true)));
+        assert_eq!(
+            by_id("call_1").get("is_error"),
+            Some(&serde_json::json!(true))
+        );
         // Success and legacy(None) -> NO is_error key (Anthropic treats absence as success).
         assert!(by_id("call_2").get("is_error").is_none());
         assert!(by_id("call_3").get("is_error").is_none());
@@ -513,6 +520,13 @@ mod is_error_tests {
         assert!(
             v.get("is_error").is_none(),
             "is_error leaked onto the OpenAI-compatible wire: {v}"
+        );
+        // Also assert against the real request-body shape (LLMClient::chat serializes
+        // `{"messages": [...]}` directly), not just the bare struct.
+        let body = serde_json::json!({ "messages": [msg] });
+        assert!(
+            body["messages"][0].get("is_error").is_none(),
+            "is_error leaked inside the messages array: {body}"
         );
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -229,13 +229,20 @@ impl AnthropicProvider {
                         .unwrap_or_default();
                     let tool_call_id = msg.tool_call_id.as_deref().unwrap_or("");
 
+                    let mut tool_result = json!({
+                        "type": "tool_result",
+                        "tool_use_id": tool_call_id,
+                        "content": result_text
+                    });
+                    // Surface Anthropic's native failure flag so the model gets a structured
+                    // error signal, not just an "Error:" text prefix. Only emit on failure
+                    // (Anthropic treats an absent flag as success).
+                    if msg.is_error == Some(true) {
+                        tool_result["is_error"] = json!(true);
+                    }
                     anthropic_messages.push(json!({
                         "role": "user",
-                        "content": [{
-                            "type": "tool_result",
-                            "tool_use_id": tool_call_id,
-                            "content": result_text
-                        }]
+                        "content": [tool_result]
                     }));
                 }
                 _ => {}
@@ -450,5 +457,62 @@ impl Provider for AnthropicProvider {
             reasoning_content: None,
             usage,
         })
+    }
+}
+
+#[cfg(test)]
+mod is_error_tests {
+    use super::AnthropicProvider;
+    use crate::utils::ChatMessage;
+
+    /// Collect every `tool_result` content block across the converted Anthropic messages.
+    fn tool_result_blocks(msgs: &[serde_json::Value]) -> Vec<serde_json::Value> {
+        let mut blocks = Vec::new();
+        for m in msgs {
+            if let Some(content) = m.get("content").and_then(|c| c.as_array()) {
+                for b in content {
+                    if b.get("type").and_then(|t| t.as_str()) == Some("tool_result") {
+                        blocks.push(b.clone());
+                    }
+                }
+            }
+        }
+        blocks
+    }
+
+    #[test]
+    fn anthropic_tool_result_sets_is_error_only_on_failure() {
+        let msgs = vec![
+            ChatMessage::tool_with_error("Error: boom", "call_1", Some("exec"), true),
+            ChatMessage::tool_with_error("ok output", "call_2", Some("exec"), false),
+            ChatMessage::tool("legacy output", "call_3", Some("exec")), // is_error == None
+        ];
+        let (_system, anthropic) = AnthropicProvider::convert_messages(&msgs);
+        let blocks = tool_result_blocks(&anthropic);
+        assert_eq!(blocks.len(), 3, "expected 3 tool_result blocks, got {anthropic:?}");
+
+        let by_id = |id: &str| {
+            blocks
+                .iter()
+                .find(|b| b["tool_use_id"] == id)
+                .unwrap_or_else(|| panic!("missing tool_result for {id}"))
+        };
+        // Failure -> native is_error: true.
+        assert_eq!(by_id("call_1").get("is_error"), Some(&serde_json::json!(true)));
+        // Success and legacy(None) -> NO is_error key (Anthropic treats absence as success).
+        assert!(by_id("call_2").get("is_error").is_none());
+        assert!(by_id("call_3").get("is_error").is_none());
+    }
+
+    #[test]
+    fn is_error_is_never_serialized_to_openai_wire() {
+        // The OpenAI-compatible request serializes ChatMessage directly; `is_error` must NOT
+        // appear (strict endpoints reject unknown message fields).
+        let msg = ChatMessage::tool_with_error("Error: boom", "call_1", Some("exec"), true);
+        let v = serde_json::to_value(&msg).expect("serialize");
+        assert!(
+            v.get("is_error").is_none(),
+            "is_error leaked onto the OpenAI-compatible wire: {v}"
+        );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -91,12 +91,15 @@ pub struct ChatMessage {
     /// providers that ignore the field see no change.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
-    /// For `role == "tool"` messages: whether the tool call failed. INTERNAL-ONLY — never
-    /// serialized via this struct's serde (`skip_serializing`), so the OpenAI-compatible wire
-    /// format is byte-identical and strict endpoints can't reject an unknown field. It is read
-    /// directly by the Anthropic message builder, which sets the native `is_error: true` on the
-    /// `tool_result` content block so the model gets a structured failure signal (not just an
-    /// `"Error:"` text prefix). `default` so older persisted messages still deserialize.
+    /// For `role == "tool"` messages: whether the tool call **failed at execution/transport
+    /// level** (the dispatch `Result` was `Err`). Note: a few tools report *recoverable* errors
+    /// in-band as `Ok("Error: ...")`; those are not reflected here (they still reach the model
+    /// via the `"Error:"` text in `content`) — widening this to the textual failure heuristic is
+    /// a possible follow-up. INTERNAL-ONLY — never serialized via this struct's serde
+    /// (`skip_serializing`), so the OpenAI-compatible wire format is byte-identical and strict
+    /// endpoints can't reject an unknown field. It is read directly by the Anthropic message
+    /// builder, which sets the native `is_error: true` on the `tool_result` content block so the
+    /// model gets a structured failure signal. `default` so older persisted messages deserialize.
     #[serde(default, skip_serializing)]
     pub is_error: Option<bool>,
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -91,6 +91,14 @@ pub struct ChatMessage {
     /// providers that ignore the field see no change.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
+    /// For `role == "tool"` messages: whether the tool call failed. INTERNAL-ONLY — never
+    /// serialized via this struct's serde (`skip_serializing`), so the OpenAI-compatible wire
+    /// format is byte-identical and strict endpoints can't reject an unknown field. It is read
+    /// directly by the Anthropic message builder, which sets the native `is_error: true` on the
+    /// `tool_result` content block so the model gets a structured failure signal (not just an
+    /// `"Error:"` text prefix). `default` so older persisted messages still deserialize.
+    #[serde(default, skip_serializing)]
+    pub is_error: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -145,6 +153,7 @@ impl ChatMessage {
             tool_calls: None,
             tool_call_id: None,
             reasoning_content: None,
+            is_error: None,
         }
     }
 
@@ -165,6 +174,7 @@ impl ChatMessage {
             tool_calls: None,
             tool_call_id: None,
             reasoning_content: None,
+            is_error: None,
         }
     }
 
@@ -176,6 +186,7 @@ impl ChatMessage {
             tool_calls: None,
             tool_call_id: None,
             reasoning_content: None,
+            is_error: None,
         }
     }
 
@@ -187,6 +198,7 @@ impl ChatMessage {
             tool_calls: None,
             tool_call_id: None,
             reasoning_content: None,
+            is_error: None,
         }
     }
 
@@ -198,6 +210,22 @@ impl ChatMessage {
             tool_calls: None,
             tool_call_id: Some(tool_call_id.to_string()),
             reasoning_content: None,
+            is_error: None,
+        }
+    }
+
+    /// Like [`ChatMessage::tool`] but records whether the tool call failed, so the Anthropic
+    /// message builder can set the native `is_error` on the `tool_result` block. `content`
+    /// still carries the human/OpenAI-readable text (typically `"Error: ..."` on failure).
+    pub fn tool_with_error(
+        content: &str,
+        tool_call_id: &str,
+        name: Option<&str>,
+        is_error: bool,
+    ) -> Self {
+        Self {
+            is_error: Some(is_error),
+            ..Self::tool(content, tool_call_id, name)
         }
     }
 }


### PR DESCRIPTION
## Context
Follow-on to the P0/P1 harness work. The review flagged a P1 ACI gap: when a tool call fails, the model only sees an **`"Error:"` text prefix** — it has to *infer* failure from prose. The `is_error` boolean is computed at dispatch (`agent/mod.rs`) and sent to telemetry/UI, but **dropped before the provider request**; even the Anthropic path never set the API's own `is_error`. Surfacing a structured failure signal is the single highest-leverage fix for **self-correction**, which is the heart of loop robustness.

## What changed, and why
- **`ChatMessage` gains an internal-only `is_error: Option<bool>`** with `#[serde(default, skip_serializing)]`. *Why internal-only:* the OpenAI-compatible request serializes `ChatMessage` directly, and strict endpoints reject unknown message fields — so this field must never hit that wire. `skip_serializing` guarantees the OpenAI-compat wire is **byte-identical**; `default` keeps older persisted messages deserializing.
- **Anthropic `convert_messages`** now sets the native **`is_error: true`** on the `tool_result` content block when the tool failed (omitted on success — Anthropic treats absence as success). This is read from the Rust field, not serde, so it's fully controlled.
- **`ChatMessage::tool_with_error(...)`** records the flag; both the parallel and sequential tool-dispatch paths in `agent/mod.rs` now use it. The existing `"Error:"` text prefix is preserved as the signal for OpenAI-compatible providers (which have no native equivalent).

## Test plan
- [x] `anthropic_tool_result_sets_is_error_only_on_failure` — failed tool → `is_error: true`; success/legacy(None) → no key.
- [x] `is_error_is_never_serialized_to_openai_wire` — serializing a failed-tool `ChatMessage` produces no `is_error` field.
- [x] `cargo test --lib` green (302 passed); `cargo check --all-targets` green; `cargo clippy` adds no new warnings.
- [ ] Reviewer: confirm OpenAI-compat behavior is intentionally unchanged (text prefix only); decide whether the resume-injection (`mod.rs:1778`) and repair-placeholder (`mod.rs:225`) tool messages should ever be marked `is_error` (currently `None`).
