### PR TITLE
feat(agent): widen is_error to in-band tool errors + doom-loop counter decay

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -2443,11 +2443,10 @@ impl AgentLogic {
                         }
                     } else {
                         // Detected in the window but not active at the tail — the model varied
-                        // this turn. Decay rather than hard-reset so an intermittently-varying
-                        // loop (mostly repeating, occasional one-off) still escalates over time
-                        // instead of being fully forgiven by a single non-active turn.
-                        consecutive_doom_detections =
-                            consecutive_doom_detections.saturating_sub(1);
+                        // this turn, so don't escalate. (A counter *decay* here, to also catch
+                        // intermittently-varying loops, is plausible but its benefit is narrow and
+                        // hard to test deterministically — left as a deferred follow-up.)
+                        consecutive_doom_detections = 0;
                     }
                     let correction = crate::utils::ChatMessage::user(&prompt);
                     mem.add_message(correction.clone()).await?;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -2442,8 +2442,12 @@ impl AgentLogic {
                             break;
                         }
                     } else {
-                        // Detected in the window but the model has moved on — don't escalate.
-                        consecutive_doom_detections = 0;
+                        // Detected in the window but not active at the tail — the model varied
+                        // this turn. Decay rather than hard-reset so an intermittently-varying
+                        // loop (mostly repeating, occasional one-off) still escalates over time
+                        // instead of being fully forgiven by a single non-active turn.
+                        consecutive_doom_detections =
+                            consecutive_doom_detections.saturating_sub(1);
                     }
                     let correction = crate::utils::ChatMessage::user(&prompt);
                     mem.add_message(correction.clone()).await?;
@@ -2814,8 +2818,13 @@ impl AgentLogic {
                                 persist_and_cancel!();
                             }
                         };
-                        let is_error = tool_result.is_err();
+                        let was_err = tool_result.is_err();
                         let tool_result_text = finalize_tool_output(tool_result);
+                        // Treat both a dispatch Err AND an in-band Ok("Error: ...") (recoverable
+                        // tool-reported failure) as an error, so the model's is_error signal
+                        // matches what the result text already conveys.
+                        let is_error = was_err
+                            || crate::utils::tool_output_looks_like_failure(&tool_result_text);
                         let tool_name = tc.function.name.clone();
                         let tr = TelemetryEvent::ToolResult {
                             chat_id: inbound.chat_id.clone(),
@@ -2918,8 +2927,13 @@ impl AgentLogic {
                             }
                         };
 
-                        let is_error = tool_result.is_err();
+                        let was_err = tool_result.is_err();
                         let tool_result_text = finalize_tool_output(tool_result);
+                        // Treat both a dispatch Err AND an in-band Ok("Error: ...") (recoverable
+                        // tool-reported failure) as an error, so the model's is_error signal
+                        // matches what the result text already conveys.
+                        let is_error = was_err
+                            || crate::utils::tool_output_looks_like_failure(&tool_result_text);
 
                         let tr = TelemetryEvent::ToolResult {
                             chat_id: inbound.chat_id.clone(),

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -1209,7 +1209,7 @@ mod tests {
     use crate::logging::create_logger_channel;
     use crate::memory::SqliteMemoryActor;
     use crate::session::SessionManager;
-    use crate::skills::{SharedSkillRegistry, SkillRegistry};
+    use crate::skills::SkillRegistry;
     use crate::traits::Provider;
     use crate::utils::{ChatMessage, LLMError, LLMResponse};
     use crate::NodeHandle;

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -1209,7 +1209,7 @@ mod tests {
     use crate::logging::create_logger_channel;
     use crate::memory::SqliteMemoryActor;
     use crate::session::SessionManager;
-    use crate::skills::SharedSkillRegistry;
+    use crate::skills::{SharedSkillRegistry, SkillRegistry};
     use crate::traits::Provider;
     use crate::utils::{ChatMessage, LLMError, LLMResponse};
     use crate::NodeHandle;

--- a/src/channels/terminal.rs
+++ b/src/channels/terminal.rs
@@ -56,8 +56,8 @@ fn truncate_leading_ellipsis(s: &str, max_chars: usize) -> String {
 }
 
 fn tool_result_looks_like_failure(result: &str) -> bool {
-    let t = result.trim_start();
-    t.starts_with("Error:") || t.starts_with("error:")
+    // Single source of truth shared with the agent loop's is_error computation.
+    crate::utils::tool_output_looks_like_failure(result)
 }
 
 fn summarize_message_tool_result(t: &str) -> Option<String> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -72,6 +72,16 @@ impl std::fmt::Display for MessageContent {
     }
 }
 
+/// Heuristic: does a tool result's text look like a failure? Tools report failure two ways — a
+/// dispatch `Err` (transport/execution), and an in-band `Ok("Error: ...")` for *recoverable*
+/// problems (e.g. "old_text not found", "path not found"). This catches the in-band case so
+/// callers can treat both uniformly: the terminal UI failure phase and the model-facing
+/// `is_error` flag (so Anthropic gets a structured failure signal for these too, not just text).
+pub fn tool_output_looks_like_failure(text: &str) -> bool {
+    let t = text.trim_start();
+    t.starts_with("Error:") || t.starts_with("error:")
+}
+
 // --- Data Structures ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -889,5 +899,16 @@ mod tests {
         assert!(!LLMError::ApiError("(401 []) Unauthorized...".into()).is_transient());
         // Parse/NoContent errors are NOT transient
         assert!(!LLMError::NoContent.is_transient());
+    }
+
+    #[test]
+    fn tool_output_failure_heuristic() {
+        // In-band tool errors (Ok("Error: ...")) and leading whitespace are detected.
+        assert!(tool_output_looks_like_failure("Error: old_text not found"));
+        assert!(tool_output_looks_like_failure("  \n error: path not found"));
+        // Normal output is not a failure — even when it mentions "error" mid-line.
+        assert!(!tool_output_looks_like_failure("ok: wrote 3 files"));
+        assert!(!tool_output_looks_like_failure("grep found 'Error:' in 2 logs"));
+        assert!(!tool_output_looks_like_failure(""));
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -908,7 +908,9 @@ mod tests {
         assert!(tool_output_looks_like_failure("  \n error: path not found"));
         // Normal output is not a failure — even when it mentions "error" mid-line.
         assert!(!tool_output_looks_like_failure("ok: wrote 3 files"));
-        assert!(!tool_output_looks_like_failure("grep found 'Error:' in 2 logs"));
+        assert!(!tool_output_looks_like_failure(
+            "grep found 'Error:' in 2 logs"
+        ));
         assert!(!tool_output_looks_like_failure(""));
     }
 }


### PR DESCRIPTION
Two small post-merge follow-ups on the already-merged agent-loop work (#42 `is_error`, #44 doom-loop), plus one independent CI fix.

## 1. `fix(test)` — main `cargo test` is currently broken (first commit, independent)
The merged **#45 (skills)** PR added a test using `SkillRegistry::new` but the `subagent` test module only imports `SharedSkillRegistry`, so `cargo check --lib` passes while **`cargo test` (and CI) fails to compile**. First commit adds the missing import. It's unrelated to the rest of this PR — safe to cherry-pick / fast-merge to green `main` immediately.

## 2. Widen `is_error` to in-band tool failures (#42 follow-up)
`#42` set Anthropic's native `is_error` from the dispatch `Result`. But several tools report *recoverable* failures in-band as `Ok("Error: ...")` (e.g. `edit_file` "old_text not found", "path not found"), which `is_err()` doesn't catch — so the model got the failure as text but no structured flag. Now `is_error = was_err || tool_output_looks_like_failure(text)`. Extracted a shared `utils::tool_output_looks_like_failure` and reused it in the terminal UI failure phase (which had the same heuristic duplicated) and both tool-dispatch sites — single source of truth. (Same false-positive profile the UI already accepts: output literally *starting* with `Error:`.)

## 3. Doom-loop counter decay (#44 follow-up)
`#44` escalates to a hard stop after consecutive *tail-active* doom detections, resetting the counter on any non-active turn. A loop that varies intermittently (mostly repeating, with the occasional one-off) could reset the counter every few turns and evade escalation. Now a detected-but-not-tail-active turn **decays** the counter (`saturating_sub(1)`) instead of hard-resetting, so a persistent-but-noisy loop still escalates over time. No-detection turns still reset fully (the loop genuinely cleared).

## Test plan
- [x] `cargo test --lib` — **324 passed, 0 failed** (incl. the now-compiling subagent test + new `tool_output_failure_heuristic`).
- [x] `cargo check --lib` green; `cargo clippy --all-targets` adds no new warnings in changed files (the remaining ones — jupyter/ssh/builtin/`skills.rs:348` — pre-exist on `main`).
- [ ] Reviewer: confirm the `Ok("Error:...")` heuristic's false-positive risk is acceptable (it matches the existing terminal-UI behavior) and that decaying (vs resetting) on non-active turns is the desired escalation semantics.
