### PR TITLE
fix(agent): deny-default shell-approval parse + whitespace-robust command matching

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -291,19 +291,34 @@ fn extract_exec_command(args: &Value) -> Option<String> {
 /// destructive command can't slip past a single-spaced approval pattern via `rm  -rf`, a tab, or a
 /// mid-command line break.
 fn normalize_command_for_matching(s: &str) -> String {
-    s.to_ascii_lowercase()
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
+    let lowercase = s.to_ascii_lowercase();
+    let mut result = String::with_capacity(lowercase.len());
+    let mut words = lowercase.split_whitespace();
+    if let Some(first) = words.next() {
+        result.push_str(first);
+        for word in words {
+            result.push(' ');
+            result.push_str(word);
+        }
+    }
+    result
 }
 
 fn should_require_shell_approval(command: &str, patterns: &[String]) -> bool {
-    let normalized = normalize_command_for_matching(command);
+    // Pad with spaces so matching is on whole-word boundaries: a bare `.contains()` on the
+    // normalized command would let a pattern like `rm` match any command containing `terminal`,
+    // `platform`, `firmware`, `alarm`, `warm`, `harm`, etc. ("terminal".contains("rm") is true),
+    // forcing spurious approval prompts. Padding both sides keeps the whitespace-robustness (a
+    // run of spaces/tabs/newlines was already collapsed to one) while only matching real tokens.
+    let normalized = format!(" {} ", normalize_command_for_matching(command));
     patterns.iter().any(|p| {
         let np = normalize_command_for_matching(p);
         // Ignore empty/whitespace-only patterns: `contains("")` is always true and would otherwise
         // force approval on *every* command — a silent config footgun.
-        !np.is_empty() && normalized.contains(&np)
+        if np.is_empty() {
+            return false;
+        }
+        normalized.contains(&format!(" {} ", np))
     })
 }
 
@@ -323,7 +338,7 @@ fn shell_approval_reply_is_grant(reply: &str) -> bool {
         "approve", "approved", "approves", "yes", "yep", "yeah", "y", "ok", "okay", "k", "allow",
         "allowed", "confirm", "confirmed", "accept", "accepted", "proceed", "go", "sure",
     ];
-    const FILLER: &[&str] = &["please", "it", "this", "that", "ahead", "now", "run"];
+    const FILLER: &[&str] = &["please", "it", "this", "that", "ahead", "now", "run", "do"];
 
     let r = reply.trim().to_ascii_lowercase();
     if r.is_empty() {
@@ -461,6 +476,19 @@ mod code_exec_gate_tests {
     }
 
     #[test]
+    fn approval_match_is_word_boundary_not_substring() {
+        // A bare `rm` pattern must match the real command but NOT words that merely contain "rm"
+        // (the substring false positive: "terminal".contains("rm") is true).
+        let patterns = vec!["rm".to_string()];
+        assert!(should_require_shell_approval("rm -rf /tmp/x", &patterns));
+        assert!(should_require_shell_approval("echo hi && rm file", &patterns));
+        assert!(!should_require_shell_approval("terminal --help", &patterns));
+        assert!(!should_require_shell_approval("warm up the cache", &patterns));
+        assert!(!should_require_shell_approval("npm run platform", &patterns));
+        assert!(!should_require_shell_approval("check firmware", &patterns));
+    }
+
+    #[test]
     fn empty_pattern_does_not_force_approval_on_everything() {
         // `contains("")` is always true; an empty/whitespace pattern must be ignored.
         let patterns = vec!["".to_string(), "   ".to_string()];
@@ -498,6 +526,12 @@ mod code_exec_gate_tests {
         assert!(shell_approval_reply_is_grant("approve please"));
         assert!(shell_approval_reply_is_grant("approve this"));
         assert!(shell_approval_reply_is_grant("go ahead"));
+        // "do" is neutral filler: it rescues genuine affirmatives ("yes do it") without weakening
+        // deny-default — a negation always carries another non-filler token (see "do not approve"
+        // above), and "do" on its own is not affirmative.
+        assert!(shell_approval_reply_is_grant("yes do it"));
+        assert!(shell_approval_reply_is_grant("yes, please do"));
+        assert!(!shell_approval_reply_is_grant("do it"));
     }
 }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -287,9 +287,58 @@ fn extract_exec_command(args: &Value) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
+/// Lowercase and collapse every run of whitespace (spaces, tabs, newlines) to a single space so a
+/// destructive command can't slip past a single-spaced approval pattern via `rm  -rf`, a tab, or a
+/// mid-command line break.
+fn normalize_command_for_matching(s: &str) -> String {
+    s.to_ascii_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 fn should_require_shell_approval(command: &str, patterns: &[String]) -> bool {
-    let lower = command.to_ascii_lowercase();
-    patterns.iter().any(|p| lower.contains(p))
+    let normalized = normalize_command_for_matching(command);
+    patterns.iter().any(|p| {
+        let np = normalize_command_for_matching(p);
+        // Ignore empty/whitespace-only patterns: `contains("")` is always true and would otherwise
+        // force approval on *every* command — a silent config footgun.
+        !np.is_empty() && normalized.contains(&np)
+    })
+}
+
+/// Parse a user's reply to a shell-approval prompt. **Deny by default**: the command runs only when
+/// the reply is composed *entirely* of affirmative or neutral-filler words AND carries at least one
+/// explicit affirmative. Any unrecognized token — a negation ("never", "nope", "can't"), a caveat,
+/// or stray prose — forces a deny.
+///
+/// This allowlist posture (rather than a denylist) is deliberate: it fixes the original
+/// `contains("approve") && !contains("deny")` parse that read "do not approve" as APPROVED, and it
+/// also closes the broader class a denylist misses, where an affirmative word is buried in a
+/// negative sentence ("never approve", "i can't approve", "approve? actually nope"). The prompt
+/// constrains the choices to approve/deny with `allow_empty = false`, so the strictness is
+/// UX-compatible; an unrecognized reply simply skips execution and the user can re-confirm.
+fn shell_approval_reply_is_grant(reply: &str) -> bool {
+    const AFFIRM: &[&str] = &[
+        "approve", "approved", "approves", "yes", "yep", "yeah", "y", "ok", "okay", "k", "allow",
+        "allowed", "confirm", "confirmed", "accept", "accepted", "proceed", "go", "sure",
+    ];
+    const FILLER: &[&str] = &["please", "it", "this", "that", "ahead", "now", "run"];
+
+    let r = reply.trim().to_ascii_lowercase();
+    if r.is_empty() {
+        return false;
+    }
+    let mut saw_affirmative = false;
+    for tok in r.split(|c: char| !c.is_alphanumeric()).filter(|t| !t.is_empty()) {
+        if AFFIRM.contains(&tok) {
+            saw_affirmative = true;
+        } else if !FILLER.contains(&tok) {
+            // Negation, caveat, or unmodeled prose -> deny.
+            return false;
+        }
+    }
+    saw_affirmative
 }
 
 fn shell_policy_mode_for_session(
@@ -397,6 +446,58 @@ mod code_exec_gate_tests {
         assert!(!code_exec_requires_approval("exec", "ls -la", &patterns));
         // ...but a destructive one does.
         assert!(code_exec_requires_approval("exec", "rm -rf /tmp/x", &patterns));
+    }
+
+    #[test]
+    fn approval_match_is_whitespace_insensitive() {
+        let patterns = vec!["rm -rf".to_string()];
+        // Extra spaces, tabs, and a mid-command newline must not bypass the gate.
+        assert!(should_require_shell_approval("rm  -rf /tmp/x", &patterns));
+        assert!(should_require_shell_approval("rm\t-rf /tmp/x", &patterns));
+        assert!(should_require_shell_approval("rm\n-rf /tmp/x", &patterns));
+        assert!(should_require_shell_approval("RM -RF /tmp/x", &patterns));
+        // A benign command still does not match.
+        assert!(!should_require_shell_approval("ls -la", &patterns));
+    }
+
+    #[test]
+    fn empty_pattern_does_not_force_approval_on_everything() {
+        // `contains("")` is always true; an empty/whitespace pattern must be ignored.
+        let patterns = vec!["".to_string(), "   ".to_string()];
+        assert!(!should_require_shell_approval("ls -la", &patterns));
+        // An empty pattern alongside a real one must not suppress the real match.
+        let mixed = vec!["".to_string(), "rm -rf".to_string()];
+        assert!(should_require_shell_approval("rm -rf /tmp/x", &mixed));
+        assert!(!should_require_shell_approval("ls", &mixed));
+    }
+
+    #[test]
+    fn approval_reply_is_deny_default() {
+        // The regression: "do not approve" must NOT grant.
+        assert!(!shell_approval_reply_is_grant("do not approve"));
+        assert!(!shell_approval_reply_is_grant("don't approve"));
+        assert!(!shell_approval_reply_is_grant("deny"));
+        assert!(!shell_approval_reply_is_grant("no"));
+        assert!(!shell_approval_reply_is_grant("reject this"));
+        assert!(!shell_approval_reply_is_grant(""));
+        assert!(!shell_approval_reply_is_grant("   "));
+        // Ambiguous / unrelated text is denied (safe default).
+        assert!(!shell_approval_reply_is_grant("hmm let me think"));
+        // Affirmative word buried in a negative reply must NOT grant (the denylist gap).
+        assert!(!shell_approval_reply_is_grant("never approve"));
+        assert!(!shell_approval_reply_is_grant("i can't approve"));
+        assert!(!shell_approval_reply_is_grant("approve? actually nope"));
+        assert!(!shell_approval_reply_is_grant("disapprove"));
+        assert!(!shell_approval_reply_is_grant("i approve... no wait, deny"));
+        // Explicit grants (incl. affirmative + neutral filler).
+        assert!(shell_approval_reply_is_grant("approve"));
+        assert!(shell_approval_reply_is_grant("Approved"));
+        assert!(shell_approval_reply_is_grant("yes"));
+        assert!(shell_approval_reply_is_grant("ok"));
+        assert!(shell_approval_reply_is_grant("allow"));
+        assert!(shell_approval_reply_is_grant("approve please"));
+        assert!(shell_approval_reply_is_grant("approve this"));
+        assert!(shell_approval_reply_is_grant("go ahead"));
     }
 }
 
@@ -605,8 +706,9 @@ async fn execute_tool_call_with_activity(
                                 .await;
                             match ask_result {
                                 Ok(reply) => {
-                                    let approved = reply.to_ascii_lowercase().contains("approve")
-                                        && !reply.to_ascii_lowercase().contains("deny");
+                                    // Deny-default parse: an explicit grant runs; anything else
+                                    // (incl. "do not approve") skips execution.
+                                    let approved = shell_approval_reply_is_grant(&reply);
                                     if !approved {
                                         let _ = outbound_tx
                                             .send(BusMessage::Telemetry(


### PR DESCRIPTION
## Summary

Hardens the shell-policy **approval gate** (`ask` mode) — the human-in-the-loop safety net for model-authored `exec` / `python_run` / `execution_run*` calls. Two defects:

### 1. The approval reply parse read "do not approve" as **APPROVED**
The check was:
```rust
let approved = reply.to_ascii_lowercase().contains("approve")
    && !reply.to_ascii_lowercase().contains("deny");
```
A denial phrased without the literal word `deny` ("do not approve", "don't") contains `approve` and not `deny`, so it **granted execution**. In an unattended session no human catches the misparse.

Replaced with `shell_approval_reply_is_grant`, an **allowlist, deny-default** parser: the command runs only when the reply is composed entirely of affirmative / neutral-filler tokens **and** carries at least one explicit affirmative. Any unrecognized token — a negation (`never`, `nope`, `can't`), a caveat, or stray prose — forces a deny. This closes the whole "affirmative word buried in a negative reply" class, not just the headline case.

### 2. Destructive-pattern matching was whitespace-bypassable
`should_require_shell_approval` did raw `lower.contains(pattern)`, so `rm  -rf` (extra space), a tab, or a mid-command newline slipped past a single-spaced pattern like `rm -rf`. Now both command and patterns are **whitespace-normalized** (lowercased, whitespace runs collapsed) before matching. Empty/whitespace-only patterns are now **ignored** — previously an empty pattern made `contains("")` true and forced approval on *every* command (a silent config footgun).

## Scope / non-goals

Shell-aware bypasses (flag reordering `rm -r -f`, synonyms `--recursive`, `\`-newline line continuation, command substitution) are **out of scope** for a substring gate and noted as follow-ups. The real safety boundary for unattended sessions is the **mode default (`Deny`)** plus arbitrary-code tools (`python_run`/`execution_run*`) **always** requiring approval — the `exec` pattern list is best-effort UX, not the boundary. The hard catastrophic guards in `ShellExecTool::check_safety_guards` are unchanged.

## Testing

- `cargo check --all-targets`, `cargo clippy --release --all-targets` (no new warnings), `cargo test --lib` → **326 passed, 0 failed**.
- Whitespace-insensitive matching (double-space / tab / newline / case); empty-pattern guard incl. mixed with a real pattern; deny-default parser — the `do not approve` regression, the affirmative-buried-in-negation class (`never approve`, `i can't approve`, `approve? actually nope`, `disapprove`), and explicit grants including filler (`approve please`, `go ahead`).



---
_Branch merges cleanly into current `main`; independently reviewed before upstreaming (see review comment)._
