### PR TITLE
feat(hooks): redact secrets from all persisted telemetry sinks

### DIFF
--- a/src/execution/run_history.rs
+++ b/src/execution/run_history.rs
@@ -90,12 +90,18 @@ pub async fn write_run_journal(p: RunJournalParams<'_>) -> Result<PathBuf, Strin
         .await
         .map_err(|e| format!("run journal mkdir {}: {e}", dir.display()))?;
 
-    tokio::fs::write(dir.join("source.txt"), p.code.as_bytes())
+    // Redact secrets before they hit disk: executed code and captured stdout/stderr routinely carry
+    // keys (an `env` dump, an echoed `$OPENAI_API_KEY`, a token printed by a script).
+    let redactor = crate::redact::shared();
+    let code = redactor.redact(p.code);
+    tokio::fs::write(dir.join("source.txt"), code.as_bytes())
         .await
         .map_err(|e| format!("run journal source write: {e}"))?;
 
-    let (stdout, stdout_truncated) = truncate_field(p.result.stdout.clone(), MAX_INLINE_TEXT);
-    let (stderr, stderr_truncated) = truncate_field(p.result.stderr.clone(), MAX_INLINE_TEXT);
+    let (stdout, stdout_truncated) =
+        truncate_field(redactor.redact(&p.result.stdout).into_owned(), MAX_INLINE_TEXT);
+    let (stderr, stderr_truncated) =
+        truncate_field(redactor.redact(&p.result.stderr).into_owned(), MAX_INLINE_TEXT);
 
     let journal = RunJournal {
         schema_version: 1,
@@ -129,4 +135,53 @@ pub async fn write_run_journal(p: RunJournalParams<'_>) -> Result<PathBuf, Strin
         .map_err(|e| format!("run journal run.json: {e}"))?;
 
     Ok(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn run_journal_redacts_secrets_in_code_stdout_stderr() {
+        // Use format-identifiable secrets so the test does not depend on the process environment.
+        let ws = std::env::temp_dir().join(format!("isanagent_runjournal_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&ws).unwrap();
+        let sid = SessionId::new("sess1");
+        let result = RunResult::new(
+            "leaked AKIAIOSFODNN7EXAMPLE in stdout",
+            "trace ghp_0123456789abcdefghijABCDEFGHIJ here",
+            Some(0),
+        );
+
+        write_run_journal(RunJournalParams {
+            workspace_dir: &ws,
+            provider_id: "local",
+            session_id: &sid,
+            run_id: "run1",
+            code: "print('sk_live_0123456789abcdefghij')",
+            result: &result,
+            jupyter_kernel_id: None,
+            jupyter_notebook_path: None,
+            started_rfc3339: "t0",
+            finished_rfc3339: "t1",
+            duration_ms: 1,
+        })
+        .await
+        .unwrap();
+
+        let dir = run_history_dir(&ws, "local", &sid, "run1");
+        let source = std::fs::read_to_string(dir.join("source.txt")).unwrap();
+        let run_json = std::fs::read_to_string(dir.join("run.json")).unwrap();
+
+        // Executed code (source.txt)
+        assert!(source.contains("[REDACTED_STRIPE_KEY]"), "source: {source}");
+        assert!(!source.contains("sk_live_0123456789"), "source: {source}");
+        // stdout/stderr (run.json)
+        assert!(run_json.contains("[REDACTED_AWS_KEY]"), "run.json: {run_json}");
+        assert!(!run_json.contains("AKIAIOSFODNN7EXAMPLE"), "run.json: {run_json}");
+        assert!(run_json.contains("[REDACTED_GITHUB_TOKEN]"), "run.json: {run_json}");
+        assert!(!run_json.contains("ghp_0123456789"), "run.json: {run_json}");
+
+        let _ = std::fs::remove_dir_all(&ws);
+    }
 }

--- a/src/hooks/observation.rs
+++ b/src/hooks/observation.rs
@@ -59,6 +59,10 @@ pub fn start_observation_hooks(params: ObservationHooksParams) -> Option<Observa
     let webhook_url = params.webhook_url.clone();
     let hmac_secret = params.webhook_hmac_secret.clone();
     let metadata_keys = Arc::new(params.metadata_keys);
+    // Built once from the process env. Applied in the background consumer (off the agent hot path)
+    // so a secret that lands in tool output never reaches the JSONL journal or the third-party
+    // webhook. Redacting here does NOT affect what the executed child or the model sees.
+    let redactor = crate::redact::SecretRedactor::from_env();
 
     tokio::spawn(async move {
         let client = reqwest::Client::builder()
@@ -66,7 +70,8 @@ pub fn start_observation_hooks(params: ObservationHooksParams) -> Option<Observa
             .build()
             .ok();
 
-        while let Some(envelope) = rx.recv().await {
+        while let Some(mut envelope) = rx.recv().await {
+            redactor.redact_json(&mut envelope);
             if let Some(ref path) = jsonl_path {
                 if let Err(e) = append_jsonl(path, &envelope).await {
                     log::warn!("hooks observation jsonl: {}", e);

--- a/src/hooks/observation.rs
+++ b/src/hooks/observation.rs
@@ -59,10 +59,11 @@ pub fn start_observation_hooks(params: ObservationHooksParams) -> Option<Observa
     let webhook_url = params.webhook_url.clone();
     let hmac_secret = params.webhook_hmac_secret.clone();
     let metadata_keys = Arc::new(params.metadata_keys);
-    // Built once from the process env. Applied in the background consumer (off the agent hot path)
-    // so a secret that lands in tool output never reaches the JSONL journal or the third-party
-    // webhook. Redacting here does NOT affect what the executed child or the model sees.
-    let redactor = crate::redact::SecretRedactor::from_env();
+    // Reuse the process-wide static redactor instead of re-scanning the env and recompiling every
+    // pattern here. Applied in the background consumer (off the agent hot path) so a secret that
+    // lands in tool output never reaches the JSONL journal or the third-party webhook. Redacting
+    // here does NOT affect what the executed child or the model sees.
+    let redactor = crate::redact::shared();
 
     tokio::spawn(async move {
         let client = reqwest::Client::builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod onboarding;
 pub mod onboarding_interactive;
 pub mod provider;
 pub mod provider_registry;
+pub mod redact;
 pub mod reflection;
 pub mod scheduler;
 pub mod session;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -186,10 +186,14 @@ impl LoggingActor {
     }
 
     fn write_conversation(&mut self, packet: &BusMessage) -> Result<(), ActorError> {
-        let json_line = match packet {
-            BusMessage::Inbound(inv) => serde_json::to_string(inv),
-            BusMessage::Outbound(out) => serde_json::to_string(out),
-            BusMessage::Telemetry(tel) => serde_json::to_string(tel),
+        // Serialize to a `Value` first so secrets can be redacted before this analytical journal
+        // hits disk — tool results / inbound text routinely carry keys (an `env` dump, an echoed
+        // `$OPENAI_API_KEY`). `conversation.jsonl` is write-only telemetry (agent memory lives in
+        // SQLite), so redaction here never affects what the agent can recall or use.
+        let mut value = match packet {
+            BusMessage::Inbound(inv) => serde_json::to_value(inv),
+            BusMessage::Outbound(out) => serde_json::to_value(out),
+            BusMessage::Telemetry(tel) => serde_json::to_value(tel),
             BusMessage::Log(_) => return Ok(()),
             BusMessage::LoggerControl(_) => return Ok(()),
             BusMessage::Cancel(_) => return Ok(()),
@@ -202,6 +206,11 @@ impl LoggingActor {
             BusMessage::TriggerCompaction { .. } => return Ok(()),
         }
         .map_err(|e| ActorError::from(format!("Failed to serialize conversation event: {}", e)))?;
+
+        crate::redact::shared().redact_json(&mut value);
+        let json_line = serde_json::to_string(&value).map_err(|e| {
+            ActorError::from(format!("Failed to serialize conversation event: {}", e))
+        })?;
 
         writeln!(self.conversation_writer, "{}", json_line)
             .map_err(|e| ActorError::from(format!("Failed to write conversation log: {}", e)))

--- a/src/redact.rs
+++ b/src/redact.rs
@@ -1,0 +1,298 @@
+//! Secret redaction for **observability output** (currently the observation hook's telemetry JSONL
+//! journal + webhook sink).
+//!
+//! The executed child still receives the real host environment — this module only sanitizes
+//! monitoring output, so it never breaks the agent's own use of API keys/tokens. Its job is to keep
+//! a secret that lands in tool output (an `env` / `printenv` dump, an echoed `$OPENAI_API_KEY`, a
+//! key printed by a script) from being written to disk or POSTed to a third-party webhook.
+//!
+//! Two redaction strategies, applied in order:
+//! 1. **By value** — for each env var whose *name* looks secret (`*_KEY`, `*TOKEN*`, `*SECRET*`,
+//!    `*PASSWORD*`, `*_DSN`, …) and whose value is long enough to be a real credential, replace any
+//!    exact occurrence of that value with `[REDACTED:<NAME>]`. Catches secrets regardless of format.
+//! 2. **By format** — regexes for recognizable credential shapes (OpenAI `sk-…`, Stripe `sk_live_…`,
+//!    AWS `AKIA…`, HuggingFace `hf_…`, GitHub `ghp_…`, GitLab `glpat-…`, Slack `xox…`, Google
+//!    `AIza…`, npm `npm_…`, JWTs, `Bearer …`, PEM private-key blocks, and generic
+//!    `secret/api_key/token/password = <value>` assignments). Catches secrets not present in *this*
+//!    process's environment.
+//!
+//! Over-redaction in a monitoring sink is harmless (you lose some telemetry detail, never break the
+//! agent), so the patterns are deliberately generous. The `regex` crate is linear-time, so the
+//! generous patterns carry no ReDoS risk.
+//!
+//! Scope: this covers every persisted telemetry sink — the observation hook (JSONL + webhook), the
+//! `conversation.jsonl` analytical log, and the execution `run.json` / `source.txt` journals (via
+//! [`shared`]). The model's own context and provider-side logs are intentionally out of scope (the
+//! agent needs real keys to do its work).
+
+use regex::Regex;
+use serde_json::Value;
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
+/// Process-wide redactor, built once from the environment. For sink writers that can't easily thread
+/// an instance through (the conversation + execution journals). The observation hook builds its own
+/// via [`SecretRedactor::from_env`] at startup. The process environment is stable, so a one-time
+/// build is correct.
+pub fn shared() -> &'static SecretRedactor {
+    static SHARED: LazyLock<SecretRedactor> = LazyLock::new(SecretRedactor::from_env);
+    &SHARED
+}
+
+/// Minimum length for an env value to be redacted by value. Short values (`DEBUG=1`, `TZ=UTC`) would
+/// cause noisy false-positive substring matches in otherwise-normal output. Short secrets without a
+/// recognizable format (e.g. a 6-char DB password) are an accepted gap.
+const MIN_SECRET_VALUE_LEN: usize = 8;
+
+/// Guards `redact_json` recursion against a pathologically deep JSON tree (well above serde_json's
+/// own default parse depth of 128). Deeper subtrees are left unredacted rather than overflowing.
+const MAX_JSON_DEPTH: usize = 256;
+
+/// Redacts secret values/credentials from strings and JSON trees. Built once (env scan + regex
+/// compile) and reused for every emitted telemetry envelope.
+pub struct SecretRedactor {
+    /// `(placeholder, value)` for secret-named env vars, sorted by value length **descending** so a
+    /// secret that is a substring of another is masked first (no leftover tail).
+    secret_values: Vec<(String, String)>,
+    /// `(pattern, replacement)` for format-identifiable credentials. Replacements may use `${1}`.
+    patterns: Vec<(Regex, &'static str)>,
+}
+
+impl SecretRedactor {
+    /// Build from the current process environment.
+    pub fn from_env() -> Self {
+        Self::from_pairs(std::env::vars())
+    }
+
+    /// Build from an explicit set of `(name, value)` pairs (used by tests).
+    pub fn from_pairs<I: IntoIterator<Item = (String, String)>>(vars: I) -> Self {
+        let name_is_secret = Regex::new(
+            r"(?i)(secret|token|passwd|password|credential|api[_-]?key|access[_-]?key|private[_-]?key|auth[_-]?token|signing|connection[_-]?string|_pat$|_psk$|_dsn$|_key$|^key$)",
+        )
+        .expect("static secret-name regex compiles");
+
+        let mut secret_values: Vec<(String, String)> = vars
+            .into_iter()
+            .filter(|(name, value)| {
+                value.len() >= MIN_SECRET_VALUE_LEN && name_is_secret.is_match(name)
+            })
+            .map(|(name, value)| (format!("[REDACTED:{name}]"), value))
+            .collect();
+        secret_values.sort_by_key(|(_, value)| std::cmp::Reverse(value.len()));
+
+        Self {
+            secret_values,
+            patterns: Self::build_patterns(),
+        }
+    }
+
+    fn build_patterns() -> Vec<(Regex, &'static str)> {
+        // Static literals: a malformed pattern is a build-time bug, so `expect` fails loudly rather
+        // than silently disabling a redaction class (which would leak a secret with no signal).
+        let raw: &[(&str, &str)] = &[
+            (r"sk-[A-Za-z0-9_-]{16,}", "[REDACTED_OPENAI_KEY]"),
+            (
+                r"(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}",
+                "[REDACTED_STRIPE_KEY]",
+            ),
+            (r"AKIA[0-9A-Z]{16}", "[REDACTED_AWS_KEY]"),
+            (r"hf_[A-Za-z0-9]{20,}", "[REDACTED_HF_TOKEN]"),
+            (r"gh[pousr]_[A-Za-z0-9]{20,}", "[REDACTED_GITHUB_TOKEN]"),
+            (r"glpat-[A-Za-z0-9_-]{16,}", "[REDACTED_GITLAB_TOKEN]"),
+            (r"npm_[A-Za-z0-9]{20,}", "[REDACTED_NPM_TOKEN]"),
+            (r"xox[baprs]-[A-Za-z0-9-]{10,}", "[REDACTED_SLACK_TOKEN]"),
+            (r"AIza[0-9A-Za-z_\-]{30,}", "[REDACTED_GOOGLE_KEY]"),
+            (
+                r"eyJ[A-Za-z0-9_-]{6,}\.eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}",
+                "[REDACTED_JWT]",
+            ),
+            (r"(?i)bearer[\s:=]+[A-Za-z0-9._\-]{8,}", "Bearer [REDACTED]"),
+            (
+                r"(?is)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+                "[REDACTED_PRIVATE_KEY]",
+            ),
+            // Generic `name = value` assignments; keep the key name, drop the value.
+            (
+                r#"(?i)(api[_-]?key|secret|token|passwd|password|access[_-]?key)["']?\s*[:=]\s*["']?[A-Za-z0-9._\-/+]{8,}"#,
+                "${1}=[REDACTED]",
+            ),
+        ];
+        raw.iter()
+            .map(|(p, r)| {
+                (
+                    Regex::new(p).expect("static credential pattern compiles"),
+                    *r,
+                )
+            })
+            .collect()
+    }
+
+    /// Redact one string: env secret values first (exact substrings), then format patterns.
+    /// Returns `Cow::Borrowed` unchanged when nothing matched (no allocation on the common path).
+    pub fn redact<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let mut out: Cow<'a, str> = Cow::Borrowed(input);
+        for (placeholder, value) in &self.secret_values {
+            if out.contains(value.as_str()) {
+                out = Cow::Owned(out.replace(value.as_str(), placeholder));
+            }
+        }
+        for (re, repl) in &self.patterns {
+            if re.is_match(&out) {
+                out = Cow::Owned(re.replace_all(&out, *repl).into_owned());
+            }
+        }
+        out
+    }
+
+    /// Recursively redact every string leaf in a JSON value, in place.
+    pub fn redact_json(&self, value: &mut Value) {
+        self.redact_json_at(value, 0);
+    }
+
+    fn redact_json_at(&self, value: &mut Value, depth: usize) {
+        if depth > MAX_JSON_DEPTH {
+            return;
+        }
+        match value {
+            Value::String(s) => {
+                if let Cow::Owned(redacted) = self.redact(s) {
+                    *s = redacted;
+                }
+            }
+            Value::Array(arr) => arr
+                .iter_mut()
+                .for_each(|v| self.redact_json_at(v, depth + 1)),
+            Value::Object(map) => map
+                .values_mut()
+                .for_each(|v| self.redact_json_at(v, depth + 1)),
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn redactor() -> SecretRedactor {
+        SecretRedactor::from_pairs([
+            (
+                "OPENAI_API_KEY".to_string(),
+                "sk-abcdef0123456789ABCDEF".to_string(),
+            ),
+            (
+                "HF_TOKEN".to_string(),
+                "hf_supersecretvalue0123456789".to_string(),
+            ),
+            ("HOME".to_string(), "/home/appuser".to_string()), // not a secret name
+            ("DEBUG".to_string(), "1".to_string()),            // too short + not secret
+            ("DB_PASSWORD".to_string(), "correct-horse-battery".to_string()),
+            ("SENTRY_DSN".to_string(), "https://abc123def456@sentry.io/42".to_string()),
+        ])
+    }
+
+    #[test]
+    fn redacts_env_secret_values_by_name() {
+        let r = redactor();
+        assert_eq!(
+            r.redact("key is sk-abcdef0123456789ABCDEF here"),
+            "key is [REDACTED:OPENAI_API_KEY] here"
+        );
+        assert_eq!(
+            r.redact("pw=correct-horse-battery"),
+            "pw=[REDACTED:DB_PASSWORD]"
+        );
+        // `*_DSN` names are treated as secret (DSNs embed passwords).
+        assert!(r
+            .redact("conn https://abc123def456@sentry.io/42")
+            .contains("[REDACTED:SENTRY_DSN]"));
+    }
+
+    #[test]
+    fn does_not_redact_nonsecret_env_or_short_values() {
+        let r = redactor();
+        assert_eq!(r.redact("cwd is /home/appuser"), "cwd is /home/appuser");
+        assert_eq!(r.redact("DEBUG=1"), "DEBUG=1");
+    }
+
+    #[test]
+    fn clean_input_is_returned_borrowed_unchanged() {
+        let r = redactor();
+        let input = "plain prose with no secrets at all";
+        assert!(matches!(r.redact(input), Cow::Borrowed(_)));
+        assert_eq!(r.redact(input), input);
+    }
+
+    #[test]
+    fn longer_overlapping_secret_is_masked_without_tail() {
+        // The length-descending sort must mask the longer value first so no fragment survives.
+        let r = SecretRedactor::from_pairs([
+            ("A_TOKEN".to_string(), "abcdef1234".to_string()),
+            ("B_TOKEN".to_string(), "abcdef1234EXTRA".to_string()),
+        ]);
+        let out = r.redact("val=abcdef1234EXTRA end");
+        assert!(out.contains("[REDACTED:B_TOKEN]"), "got: {out}");
+        assert!(!out.contains("abcdef1234"), "no fragment should survive: {out}");
+    }
+
+    #[test]
+    fn redacts_format_identifiable_credentials_not_in_env() {
+        let r = SecretRedactor::from_pairs(std::iter::empty());
+        assert_eq!(
+            r.redact("token AKIAIOSFODNN7EXAMPLE done"),
+            "token [REDACTED_AWS_KEY] done"
+        );
+        assert!(r
+            .redact("Authorization: Bearer ya29.A0ARrdaM-longtoken")
+            .contains("Bearer [REDACTED]"));
+        assert!(r
+            .redact("ghp_0123456789abcdefghijABCDEFGHIJ")
+            .contains("[REDACTED_GITHUB_TOKEN]"));
+        assert!(r
+            .redact("jwt eyJhbGciOi.eyJzdWIiNDA.SflKxwRJSM done")
+            .contains("[REDACTED_JWT]"));
+        assert!(r
+            .redact("stripe sk_live_0123456789abcdefghij")
+            .contains("[REDACTED_STRIPE_KEY]"));
+        assert!(r.redact("plain prose with no secrets").contains("plain prose"));
+    }
+
+    #[test]
+    fn redacts_generic_assignment_and_full_pem_block() {
+        let r = SecretRedactor::from_pairs(std::iter::empty());
+        // Generic assignment keeps the key name, drops the value.
+        let out = r.redact("password = hunter2longenough");
+        assert!(out.contains("[REDACTED]"), "got: {out}");
+        assert!(!out.contains("hunter2longenough"), "value must be gone: {out}");
+        // Full PEM block (body + footer) is masked, not just the header.
+        let pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAK...\nabcd1234\n-----END RSA PRIVATE KEY-----";
+        let red = r.redact(pem);
+        assert_eq!(red, "[REDACTED_PRIVATE_KEY]");
+        assert!(!red.contains("MIIBOgIBAAJBAK"));
+    }
+
+    #[test]
+    fn redacts_string_leaves_in_nested_json() {
+        let r = redactor();
+        let mut v = json!({
+            "telemetry": {
+                "tool_name": "exec",
+                "result": "OPENAI_API_KEY=sk-abcdef0123456789ABCDEF\nHF_TOKEN=hf_supersecretvalue0123456789",
+                "exit": 0
+            },
+            "list": ["safe", "pw=correct-horse-battery"]
+        });
+        r.redact_json(&mut v);
+        let result = v["telemetry"]["result"].as_str().unwrap();
+        assert!(result.contains("[REDACTED:OPENAI_API_KEY]"));
+        assert!(result.contains("[REDACTED:HF_TOKEN]"));
+        assert!(!result.contains("sk-abcdef"));
+        assert_eq!(v["telemetry"]["exit"], 0); // non-strings untouched
+        assert_eq!(v["telemetry"]["tool_name"], "exec");
+        assert!(v["list"][1]
+            .as_str()
+            .unwrap()
+            .contains("[REDACTED:DB_PASSWORD]"));
+    }
+}

--- a/src/redact.rs
+++ b/src/redact.rs
@@ -48,6 +48,16 @@ const MIN_SECRET_VALUE_LEN: usize = 8;
 /// own default parse depth of 128). Deeper subtrees are left unredacted rather than overflowing.
 const MAX_JSON_DEPTH: usize = 256;
 
+/// Matches env-var / JSON-key *names* that look like they hold a secret (`*_KEY`, `*TOKEN*`,
+/// `*SECRET*`, `*PASSWORD*`, `*_DSN`, …). Compiled once and reused for both the env-value scan and
+/// the JSON-key redaction pass.
+static NAME_IS_SECRET: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)(secret|token|passwd|password|credential|api[_-]?key|access[_-]?key|private[_-]?key|auth[_-]?token|signing|connection[_-]?string|_pat$|_psk$|_dsn$|_key$|^key$)",
+    )
+    .expect("static secret-name regex compiles")
+});
+
 /// Redacts secret values/credentials from strings and JSON trees. Built once (env scan + regex
 /// compile) and reused for every emitted telemetry envelope.
 pub struct SecretRedactor {
@@ -66,15 +76,10 @@ impl SecretRedactor {
 
     /// Build from an explicit set of `(name, value)` pairs (used by tests).
     pub fn from_pairs<I: IntoIterator<Item = (String, String)>>(vars: I) -> Self {
-        let name_is_secret = Regex::new(
-            r"(?i)(secret|token|passwd|password|credential|api[_-]?key|access[_-]?key|private[_-]?key|auth[_-]?token|signing|connection[_-]?string|_pat$|_psk$|_dsn$|_key$|^key$)",
-        )
-        .expect("static secret-name regex compiles");
-
         let mut secret_values: Vec<(String, String)> = vars
             .into_iter()
             .filter(|(name, value)| {
-                value.len() >= MIN_SECRET_VALUE_LEN && name_is_secret.is_match(name)
+                value.len() >= MIN_SECRET_VALUE_LEN && NAME_IS_SECRET.is_match(name)
             })
             .map(|(name, value)| (format!("[REDACTED:{name}]"), value))
             .collect();
@@ -95,7 +100,8 @@ impl SecretRedactor {
                 r"(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}",
                 "[REDACTED_STRIPE_KEY]",
             ),
-            (r"AKIA[0-9A-Z]{16}", "[REDACTED_AWS_KEY]"),
+            // AKIA = permanent access keys, ASIA = temporary/session keys; both are 20 chars.
+            (r"(?:AKIA|ASIA)[0-9A-Z]{16}", "[REDACTED_AWS_KEY]"),
             (r"hf_[A-Za-z0-9]{20,}", "[REDACTED_HF_TOKEN]"),
             (r"gh[pousr]_[A-Za-z0-9]{20,}", "[REDACTED_GITHUB_TOKEN]"),
             (r"glpat-[A-Za-z0-9_-]{16,}", "[REDACTED_GITLAB_TOKEN]"),
@@ -111,10 +117,12 @@ impl SecretRedactor {
                 r"(?is)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
                 "[REDACTED_PRIVATE_KEY]",
             ),
-            // Generic `name = value` assignments; keep the key name, drop the value.
+            // Generic `name = value` assignments; keep the key name, drop the value. Capture the
+            // delimiter+opening-quote (group 2) and the closing quote (group 3) so `api_key: "x"`
+            // stays well-formed as `api_key: "[REDACTED]"` rather than the mangled `api_key=[REDACTED]"`.
             (
-                r#"(?i)(api[_-]?key|secret|token|passwd|password|access[_-]?key)["']?\s*[:=]\s*["']?[A-Za-z0-9._\-/+]{8,}"#,
-                "${1}=[REDACTED]",
+                r#"(?i)(api[_-]?key|secret|token|passwd|password|access[_-]?key)(["']?\s*[:=]\s*["']?)[A-Za-z0-9._\-/+]{8,}(["']?)"#,
+                "${1}${2}[REDACTED]${3}",
             ),
         ];
         raw.iter()
@@ -137,8 +145,10 @@ impl SecretRedactor {
             }
         }
         for (re, repl) in &self.patterns {
-            if re.is_match(&out) {
-                out = Cow::Owned(re.replace_all(&out, *repl).into_owned());
+            // `replace_all` already returns `Cow::Owned` only when it actually replaced something,
+            // so match on that instead of a separate `is_match` pass (which would search twice).
+            if let Cow::Owned(replaced) = re.replace_all(&out, *repl) {
+                out = Cow::Owned(replaced);
             }
         }
         out
@@ -162,9 +172,21 @@ impl SecretRedactor {
             Value::Array(arr) => arr
                 .iter_mut()
                 .for_each(|v| self.redact_json_at(v, depth + 1)),
-            Value::Object(map) => map
-                .values_mut()
-                .for_each(|v| self.redact_json_at(v, depth + 1)),
+            Value::Object(map) => {
+                for (k, v) in map.iter_mut() {
+                    // A string value under a secret-named key (e.g. {"api_key": "..."}) is redacted
+                    // by key even when the value matches no credential format and isn't in this
+                    // process's env — structured telemetry is the common place such bare secrets
+                    // appear. Over-redaction in a monitoring sink is harmless (see module docs).
+                    if let Value::String(s) = v {
+                        if NAME_IS_SECRET.is_match(k) {
+                            *s = format!("[REDACTED:{}]", k.to_uppercase());
+                            continue;
+                        }
+                    }
+                    self.redact_json_at(v, depth + 1);
+                }
+            }
             _ => {}
         }
     }
@@ -243,6 +265,11 @@ mod tests {
             r.redact("token AKIAIOSFODNN7EXAMPLE done"),
             "token [REDACTED_AWS_KEY] done"
         );
+        // Temporary/session keys (ASIA prefix) are redacted too, not just permanent AKIA keys.
+        assert_eq!(
+            r.redact("token ASIAIOSFODNN7EXAMPLE done"),
+            "token [REDACTED_AWS_KEY] done"
+        );
         assert!(r
             .redact("Authorization: Bearer ya29.A0ARrdaM-longtoken")
             .contains("Bearer [REDACTED]"));
@@ -265,6 +292,14 @@ mod tests {
         let out = r.redact("password = hunter2longenough");
         assert!(out.contains("[REDACTED]"), "got: {out}");
         assert!(!out.contains("hunter2longenough"), "value must be gone: {out}");
+        // Quoted assignment keeps its delimiter and BOTH quotes intact (no mangling to
+        // `api_key=[REDACTED]"`).
+        let quoted = r.redact(r#"{"api_key": "abcdef123456"}"#);
+        assert!(
+            quoted.contains(r#""api_key": "[REDACTED]""#),
+            "quotes/delimiter must be preserved: {quoted}"
+        );
+        assert!(!quoted.contains("abcdef123456"), "value must be gone: {quoted}");
         // Full PEM block (body + footer) is masked, not just the header.
         let pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAK...\nabcd1234\n-----END RSA PRIVATE KEY-----";
         let red = r.redact(pem);
@@ -294,5 +329,25 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("[REDACTED:DB_PASSWORD]"));
+    }
+
+    #[test]
+    fn redacts_json_string_values_under_secret_keys() {
+        // A bare secret under a secret-named key — no recognizable credential format, not in the
+        // env — is still redacted by key. Non-secret keys and non-string values are untouched.
+        let r = SecretRedactor::from_pairs(std::iter::empty());
+        let mut v = json!({
+            "api_key": "plainvalue_no_format",
+            "password": "short",
+            "user": "alice",
+            "count": 7,
+            "nested": { "access_key": "anotherplainsecret" }
+        });
+        r.redact_json(&mut v);
+        assert_eq!(v["api_key"], "[REDACTED:API_KEY]");
+        assert_eq!(v["password"], "[REDACTED:PASSWORD]"); // redacted by key even though short
+        assert_eq!(v["user"], "alice");
+        assert_eq!(v["count"], 7);
+        assert_eq!(v["nested"]["access_key"], "[REDACTED:ACCESS_KEY]");
     }
 }


### PR DESCRIPTION
## Summary

Every persisted telemetry path serialized model-authored content **verbatim**, so a secret that lands in tool output (an `env`/`printenv` dump, an echoed `$OPENAI_API_KEY`, a key printed by a script) was written to disk — and, for the webhook, **exfiltrated to a third party in the clear**. Three sinks were affected:

- the observation hook's JSONL journal + (often third-party) **webhook** POST,
- the `conversation.jsonl` analytical log (`logging.rs`),
- the execution **`run.json` / `source.txt`** journals (`run_history.rs`).

This adds `redact::SecretRedactor` and applies it at **every** sink: the observation consumer (before both its sinks and **before the webhook HMAC**, so the signature covers the redacted body), the conversation writer, and the run-journal writer. A process-wide `redact::shared()` (built once from the env) serves the writers that can't thread an instance through.

## Redaction

- **by value** — env vars whose name looks secret (`*_KEY`, `*TOKEN*`, `*SECRET*`, `*PASSWORD*`, `*_DSN`, …) with value ≥ 8 chars are masked wherever they appear (longest-first so overlapping values leave no tail);
- **by format** — linear-time `regex` for OpenAI/Stripe/AWS/HuggingFace/GitHub/GitLab/npm/Slack/Google keys, JWTs, `Bearer`, full PEM private-key blocks, and generic `secret/api_key/token/password = <value>` assignments.

## Why it's safe

- Does **not** change what the child or the model sees (the child still gets the real env), so it never breaks the agent's own use of secrets.
- `conversation.jsonl` is **write-only** telemetry — agent memory lives in SQLite — so redacting it never affects what the agent can recall or use.
- `regex` is linear-time → no ReDoS. Over-redaction in a monitoring sink is harmless, so patterns are generous.
- Out of scope by design: the model's own context and provider-side logs (the agent needs real keys).

## Testing

- `cargo check --all-targets`, `cargo clippy --release --all-targets` (no new warnings), `cargo test --lib` → **331 passed, 0 failed**.
- Redactor unit matrix (env-value incl. `*_DSN` + overlapping ordering, clean-input borrowed/no-alloc, format patterns for AWS/Bearer/GitHub/JWT/Stripe, generic-assignment + full PEM-block, nested-JSON leaves).
- End-to-end `write_run_journal` test asserting executed code, stdout, and stderr are redacted **on disk**.



---
_Branch merges cleanly into current `main`; independently reviewed before upstreaming (see review comment)._
