### PR TITLE
feat(agent): cross-provider failover when the primary's retries are exhausted

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1908,6 +1908,125 @@ impl AgentLogic {
     }
 }
 
+/// A configured alternate LLM provider to fail over to when the primary's retries are exhausted.
+/// Holds everything [`crate::provider::create_provider`] needs; resolved once at startup from the
+/// `[providers.*]` config.
+#[derive(Clone)]
+pub struct FallbackProviderSpec {
+    pub provider_name: String,
+    pub base_url: String,
+    pub api_key: String,
+    pub model_name: String,
+}
+
+// Manual `Debug` so a stray `{:?}` can never dump the API key into a log.
+impl std::fmt::Debug for FallbackProviderSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FallbackProviderSpec")
+            .field("provider_name", &self.provider_name)
+            .field("base_url", &self.base_url)
+            .field("api_key", &"[redacted]")
+            .field("model_name", &self.model_name)
+            .finish()
+    }
+}
+
+/// Filter `candidates` to genuine fallbacks: drop any whose (provider, base_url, model) matches the
+/// active primary, so the primary is never retried as its own fallback. Matching the full identity
+/// (not just provider+model) correctly excludes the primary even when it came from the `[provider]`
+/// default block rather than the `[providers.*]` map a candidate was built from.
+pub fn build_fallback_specs(
+    primary_provider: &str,
+    primary_base_url: &str,
+    primary_model: &str,
+    candidates: Vec<FallbackProviderSpec>,
+) -> Vec<FallbackProviderSpec> {
+    candidates
+        .into_iter()
+        .filter(|c| {
+            !(c.provider_name == primary_provider
+                && c.base_url == primary_base_url
+                && c.model_name == primary_model)
+        })
+        .collect()
+}
+
+/// Process-wide fallback providers, set once at startup (like the primary, these are config).
+/// Empty until set, so failover is simply inert when unconfigured or in tests.
+static FALLBACK_PROVIDERS: std::sync::OnceLock<Vec<FallbackProviderSpec>> = std::sync::OnceLock::new();
+
+/// Install the fallback provider list. Call once at startup, after the primary is built; a second
+/// call is ignored (OnceLock). **Do not call from tests** — the `OnceLock` can't be reset, so it
+/// would pollute every other test in the binary. Tests drive [`try_fallbacks`] directly instead.
+pub fn set_fallback_providers(specs: Vec<FallbackProviderSpec>) {
+    let _ = FALLBACK_PROVIDERS.set(specs);
+}
+
+fn fallback_providers() -> &'static [FallbackProviderSpec] {
+    FALLBACK_PROVIDERS.get().map(Vec::as_slice).unwrap_or(&[])
+}
+
+/// Result of attempting the configured fallback providers.
+enum FallbackOutcome {
+    Ok(crate::utils::LLMResponse),
+    Cancelled,
+    Exhausted,
+}
+
+/// Borrowed logging identity for the failover loop (bundled to keep the arg count in check).
+struct FailoverLogCtx<'a> {
+    logger_tx: &'a LoggerHandle,
+    name: &'a str,
+    chat_id: &'a str,
+}
+
+/// Try each fallback provider **once**, returning the first successful response. `build` constructs
+/// a provider from a spec — real code passes [`crate::provider::create_provider`]; tests inject a
+/// mock builder, keeping this loop fully testable without network. Cancellation preempts a
+/// fallback chat.
+async fn try_fallbacks<F>(
+    fallbacks: &[FallbackProviderSpec],
+    build: F,
+    context: &[crate::utils::ChatMessage],
+    tools_payload: &Option<serde_json::Value>,
+    cancel_token: &tokio_util::sync::CancellationToken,
+    log: FailoverLogCtx<'_>,
+) -> FallbackOutcome
+where
+    F: Fn(&FallbackProviderSpec) -> Box<dyn crate::traits::Provider>,
+{
+    for spec in fallbacks {
+        let _ = log.logger_tx.send(BusMessage::Log(
+            LogEvent::warn(
+                log.name,
+                &format!(
+                    "Primary LLM exhausted; failing over to provider={} model={}",
+                    spec.provider_name, spec.model_name
+                ),
+            )
+            .with_chat_id(log.chat_id),
+        ));
+        let provider = build(spec);
+        let res = tokio::select! {
+            r = provider.chat(context, tools_payload.clone()) => r,
+            _ = cancel_token.cancelled() => return FallbackOutcome::Cancelled,
+        };
+        match res {
+            Ok(resp) => return FallbackOutcome::Ok(resp),
+            Err(e) => {
+                let _ = log.logger_tx.send(BusMessage::Log(
+                    LogEvent::warn(
+                        log.name,
+                        &format!("Fallback provider={} failed: {}", spec.provider_name, e),
+                    )
+                    .with_chat_id(log.chat_id),
+                ));
+            }
+        }
+    }
+    FallbackOutcome::Exhausted
+}
+
 /// Outcome of a `provider.chat` invocation that may be retried for transient errors.
 enum ChatRetryOutcome {
     Ok(crate::utils::LLMResponse),
@@ -1996,6 +2115,30 @@ async fn chat_with_retry(
             }
         }
     }
+    // Primary exhausted. Before surfacing a failure, try each configured fallback provider once, so
+    // a transient outage / key rotation / model deprecation on the primary doesn't drop a long
+    // unattended turn. The primary stays the active provider — failover is per-call.
+    match try_fallbacks(
+        fallback_providers(),
+        |s| {
+            crate::provider::create_provider(&s.provider_name, &s.base_url, &s.api_key, &s.model_name)
+        },
+        context,
+        &tools_payload,
+        cancel_token,
+        FailoverLogCtx {
+            logger_tx,
+            name,
+            chat_id,
+        },
+    )
+    .await
+    {
+        FallbackOutcome::Ok(resp) => return ChatRetryOutcome::Ok(resp),
+        FallbackOutcome::Cancelled => return ChatRetryOutcome::Cancelled,
+        FallbackOutcome::Exhausted => {}
+    }
+
     ChatRetryOutcome::Failed(
         last_err
             .map(|e| e.to_string())
@@ -3408,6 +3551,162 @@ mod tests {
         ) -> Result<LLMResponse, LLMError> {
             Err(LLMError::ApiError("Status 400 bad request".into()))
         }
+    }
+
+    /// Returns `Ok` with `content` set to `tag` — a stand-in for a working fallback provider.
+    #[derive(Clone)]
+    struct RespondingProvider {
+        tag: String,
+    }
+
+    #[async_trait]
+    impl Provider for RespondingProvider {
+        async fn chat(
+            &self,
+            _messages: &[ChatMessage],
+            _tools: Option<serde_json::Value>,
+        ) -> Result<LLMResponse, LLMError> {
+            Ok(LLMResponse {
+                content: self.tag.clone(),
+                tool_calls: None,
+                reasoning_content: None,
+                usage: None,
+            })
+        }
+    }
+
+    fn fb_spec(name: &str) -> super::FallbackProviderSpec {
+        super::FallbackProviderSpec {
+            provider_name: name.to_string(),
+            base_url: String::new(),
+            api_key: String::new(),
+            model_name: format!("{name}-model"),
+        }
+    }
+
+    fn fb_full(provider: &str, base: &str, model: &str) -> super::FallbackProviderSpec {
+        super::FallbackProviderSpec {
+            provider_name: provider.to_string(),
+            base_url: base.to_string(),
+            api_key: "k".to_string(),
+            model_name: model.to_string(),
+        }
+    }
+
+    #[test]
+    fn build_fallback_specs_excludes_primary_by_full_identity() {
+        let candidates = vec![
+            fb_full("anthropic", "https://api.anthropic.com", "claude"), // == primary
+            fb_full("openai", "https://api.openai.com", "gpt-4o"),
+        ];
+        let out = super::build_fallback_specs(
+            "anthropic",
+            "https://api.anthropic.com",
+            "claude",
+            candidates,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].provider_name, "openai");
+    }
+
+    #[test]
+    fn build_fallback_specs_keeps_same_provider_different_model_or_url() {
+        // Same provider but a different model — a legitimate fallback, must be kept.
+        let candidates = vec![
+            fb_full("openai", "u", "gpt-4o-mini"),
+            fb_full("openai", "u2", "gpt-4o"), // same provider+model, different base_url -> kept
+        ];
+        let out = super::build_fallback_specs("openai", "u", "gpt-4o", candidates);
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn fallback_spec_debug_redacts_api_key() {
+        let dbg = format!("{:?}", fb_full("openai", "u", "m"));
+        assert!(dbg.contains("[redacted]"), "{dbg}");
+        assert!(!dbg.contains("\"k\""), "api key must not appear: {dbg}");
+    }
+
+    #[tokio::test]
+    async fn try_fallbacks_returns_first_success() {
+        let (logger, _rx) = crate::logging::create_logger_channel(64);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let specs = vec![fb_spec("a"), fb_spec("b")];
+        // 'a' fails, 'b' succeeds -> first success wins, 'b' chosen.
+        let out = super::try_fallbacks(
+            &specs,
+            |s| -> Box<dyn Provider> {
+                if s.provider_name == "b" {
+                    Box::new(RespondingProvider { tag: "b-ok".into() })
+                } else {
+                    Box::new(NonTransientErrorProvider)
+                }
+            },
+            &[],
+            &None,
+            &cancel,
+            super::FailoverLogCtx { logger_tx: &logger, name: "agent", chat_id: "c1" },
+        )
+        .await;
+        match out {
+            super::FallbackOutcome::Ok(r) => assert_eq!(r.content, "b-ok"),
+            _ => panic!("expected Ok from fallback b"),
+        }
+    }
+
+    #[tokio::test]
+    async fn try_fallbacks_all_fail_is_exhausted() {
+        let (logger, _rx) = crate::logging::create_logger_channel(64);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let specs = vec![fb_spec("a"), fb_spec("b")];
+        let out = super::try_fallbacks(
+            &specs,
+            |_| -> Box<dyn Provider> { Box::new(NonTransientErrorProvider) },
+            &[],
+            &None,
+            &cancel,
+            super::FailoverLogCtx { logger_tx: &logger, name: "agent", chat_id: "c1" },
+        )
+        .await;
+        assert!(matches!(out, super::FallbackOutcome::Exhausted));
+    }
+
+    #[tokio::test]
+    async fn try_fallbacks_empty_is_exhausted() {
+        let (logger, _rx) = crate::logging::create_logger_channel(64);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let out = super::try_fallbacks(
+            &[],
+            |_| -> Box<dyn Provider> { Box::new(RespondingProvider { tag: "x".into() }) },
+            &[],
+            &None,
+            &cancel,
+            super::FailoverLogCtx { logger_tx: &logger, name: "agent", chat_id: "c1" },
+        )
+        .await;
+        assert!(matches!(out, super::FallbackOutcome::Exhausted));
+    }
+
+    #[tokio::test]
+    async fn try_fallbacks_cancellation_short_circuits() {
+        let (logger, _rx) = crate::logging::create_logger_channel(64);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        cancel.cancel(); // pre-cancelled; the slow provider's chat never wins the select
+        let specs = vec![fb_spec("a")];
+        let out = super::try_fallbacks(
+            &specs,
+            |_| -> Box<dyn Provider> {
+                Box::new(LongSleepProvider {
+                    calls: Arc::new(AtomicUsize::new(0)),
+                })
+            },
+            &[],
+            &None,
+            &cancel,
+            super::FailoverLogCtx { logger_tx: &logger, name: "agent", chat_id: "c1" },
+        )
+        .await;
+        assert!(matches!(out, super::FallbackOutcome::Cancelled));
     }
 
     #[derive(Clone)]

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1944,9 +1944,15 @@ pub fn build_fallback_specs(
     candidates
         .into_iter()
         .filter(|c| {
-            !(c.provider_name == primary_provider
-                && c.base_url == primary_base_url
-                && c.model_name == primary_model)
+            // Normalize before comparing so the primary isn't accidentally retried as its own
+            // fallback: trailing slashes on base URLs are insignificant, and provider/model names
+            // are matched case-insensitively (e.g. `https://api.openai.com/v1/` vs `.../v1`, or
+            // `OpenAI` vs `openai`).
+            let norm_c_url = c.base_url.trim_end_matches('/');
+            let norm_p_url = primary_base_url.trim_end_matches('/');
+            !(c.provider_name.eq_ignore_ascii_case(primary_provider)
+                && norm_c_url == norm_p_url
+                && c.model_name.eq_ignore_ascii_case(primary_model))
         })
         .collect()
 }
@@ -2012,7 +2018,19 @@ where
             _ = cancel_token.cancelled() => return FallbackOutcome::Cancelled,
         };
         match res {
-            Ok(resp) => return FallbackOutcome::Ok(resp),
+            Ok(resp) => {
+                let _ = log.logger_tx.send(BusMessage::Log(
+                    LogEvent::info(
+                        log.name,
+                        &format!(
+                            "Fallback succeeded: provider={} model={}",
+                            spec.provider_name, spec.model_name
+                        ),
+                    )
+                    .with_chat_id(log.chat_id),
+                ));
+                return FallbackOutcome::Ok(resp);
+            }
             Err(e) => {
                 let _ = log.logger_tx.send(BusMessage::Log(
                     LogEvent::warn(
@@ -3596,7 +3614,9 @@ mod tests {
     #[test]
     fn build_fallback_specs_excludes_primary_by_full_identity() {
         let candidates = vec![
-            fb_full("anthropic", "https://api.anthropic.com", "claude"), // == primary
+            // Same identity as the primary but with different casing and a trailing slash on the
+            // base URL — must still be excluded after normalization.
+            fb_full("Anthropic", "https://api.anthropic.com/", "Claude"),
             fb_full("openai", "https://api.openai.com", "gpt-4o"),
         ];
         let out = super::build_fallback_specs(

--- a/src/main.rs
+++ b/src/main.rs
@@ -593,6 +593,38 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             isanagent::provider::create_provider(&cfg.provider_name, &base_url, key, &model_name);
         let p2 =
             isanagent::provider::create_provider(&cfg.provider_name, &base_url, key, &model_name);
+
+        // Cross-provider failover: register every *other* configured provider with a resolvable
+        // key as a fallback, so an exhausted-retry failure on the primary (a 5xx/529 outage, a
+        // rotated key, a deprecated model) fails over instead of dropping the turn. The primary is
+        // excluded by full (provider, base_url, model) identity via `build_fallback_specs`.
+        let candidates: Vec<isanagent::agent::FallbackProviderSpec> = expanded_providers
+            .values()
+            .filter_map(|fb_cfg| {
+                let fb_key = fb_cfg.resolve_api_key().ok()?;
+                let fb_base = fb_cfg.resolved_base_url().ok()?;
+                Some(isanagent::agent::FallbackProviderSpec {
+                    provider_name: fb_cfg.provider_name.clone(),
+                    base_url: fb_base,
+                    api_key: fb_key,
+                    model_name: fb_cfg.model_name.clone(),
+                })
+            })
+            .collect();
+        let fallbacks = isanagent::agent::build_fallback_specs(
+            &cfg.provider_name,
+            &base_url,
+            &model_name,
+            candidates,
+        );
+        if !fallbacks.is_empty() {
+            log::info!(
+                "Cross-provider failover enabled with {} fallback provider(s).",
+                fallbacks.len()
+            );
+        }
+        isanagent::agent::set_fallback_providers(fallbacks);
+
         (p1, p2)
     } else {
         // No API key found — list the env vars the user could set.


### PR DESCRIPTION
## Summary

A transient 5xx/529 outage, a rotated key, or a deprecated model on the active provider bounced a long unattended turn straight to an "LLM failed / press `/retry`" banner — even when other providers were configured. The pieces existed (provider map, `create_provider`, `is_transient`) but nothing wired them together.

After `chat_with_retry` exhausts its retries on the primary, it now **tries each configured fallback provider once** and uses the first success. The primary stays the active provider (failover is **per-call**), so a transient blip recovers without a permanent switch.

## Design

- `FallbackProviderSpec` (manual `Debug` that **redacts `api_key`**) + a process-wide `set_fallback_providers` / `fallback_providers()` (`OnceLock`, set once at startup like the primary — config, not per-turn state; inert when unconfigured or in tests).
- `try_fallbacks` is generic over a **provider-builder closure**: production passes `create_provider`, tests inject mocks, so the loop is fully testable without network. Cancellation preempts a fallback chat (`tokio::select!`).
- `build_fallback_specs` excludes the primary by **full (provider, base_url, model) identity**, so a primary configured in the `[provider]` default block and also duplicated under `[providers.*]` isn't retried as its own fallback. `main` resolves keys for each `[providers.*]` entry and registers the rest.
- No new clippy allows: the shared logging identity is bundled into `FailoverLogCtx` to keep arg counts within the lint threshold.

## Notes (accepted scope)

- Primary `ContextOverflow` short-circuits *before* failover (drives emergency-compaction as before). A *fallback* that itself overflows is treated as a generic error → try next (failover's job is availability, not window-fitting).
- Per-call (not sticky) failover avoids silently pinning a session to a pricier/weaker fallback after one blip.

## Testing

- `cargo check --all-targets`, `cargo clippy --release --all-targets` (no new warnings), `cargo test --lib` → **330 passed, 0 failed**.
- `try_fallbacks`: first-success-wins, all-fail/empty → exhausted, pre-cancelled → cancelled (deterministic via a slow mock). `build_fallback_specs`: excludes exact primary, keeps same-provider-different-model/url. Plus a Debug-redaction test for `api_key`.



---
_Branch merges cleanly into current `main`; independently reviewed before upstreaming (see review comment)._
