### PR TITLE
fix(agent): make in-band is_error tool-scoped and exit-code-aware

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -2817,13 +2817,15 @@ impl AgentLogic {
                                 persist_and_cancel!();
                             }
                         };
-                        let was_err = tool_result.is_err();
+                        // Compute is_error from the RAW result (a dispatch Err, or an in-band Ok
+                        // failure — a non-zero runner `Exit code:` or a scoped `Error:` payload)
+                        // BEFORE finalize_tool_output truncates the tail-anchored exit marker away.
+                        // tool_output_looks_like_failure (text-only, all tools) missed non-zero
+                        // exits whose output did not start with "Error:" and false-flagged content
+                        // tools like read_file; tool_call_is_error is tool-scoped and exit-aware.
+                        let is_error =
+                            crate::utils::tool_call_is_error(&tc.function.name, &tool_result);
                         let tool_result_text = finalize_tool_output(tool_result);
-                        // Treat both a dispatch Err AND an in-band Ok("Error: ...") (recoverable
-                        // tool-reported failure) as an error, so the model's is_error signal
-                        // matches what the result text already conveys.
-                        let is_error = was_err
-                            || crate::utils::tool_output_looks_like_failure(&tool_result_text);
                         let tool_name = tc.function.name.clone();
                         let tr = TelemetryEvent::ToolResult {
                             chat_id: inbound.chat_id.clone(),
@@ -2926,13 +2928,15 @@ impl AgentLogic {
                             }
                         };
 
-                        let was_err = tool_result.is_err();
+                        // Compute is_error from the RAW result (a dispatch Err, or an in-band Ok
+                        // failure — a non-zero runner `Exit code:` or a scoped `Error:` payload)
+                        // BEFORE finalize_tool_output truncates the tail-anchored exit marker away.
+                        // tool_output_looks_like_failure (text-only, all tools) missed non-zero
+                        // exits whose output did not start with "Error:" and false-flagged content
+                        // tools like read_file; tool_call_is_error is tool-scoped and exit-aware.
+                        let is_error =
+                            crate::utils::tool_call_is_error(&tc.function.name, &tool_result);
                         let tool_result_text = finalize_tool_output(tool_result);
-                        // Treat both a dispatch Err AND an in-band Ok("Error: ...") (recoverable
-                        // tool-reported failure) as an error, so the model's is_error signal
-                        // matches what the result text already conveys.
-                        let is_error = was_err
-                            || crate::utils::tool_output_looks_like_failure(&tool_result_text);
 
                         let tr = TelemetryEvent::ToolResult {
                             chat_id: inbound.chat_id.clone(),

--- a/src/tools/builtin.rs
+++ b/src/tools/builtin.rs
@@ -1000,29 +1000,33 @@ impl Tool for ShellExecTool {
                     result.push_str(&stderr);
                 }
 
-                if !output.status.success() {
-                    result.push_str(&format!(
-                        "\nExit code: {}",
-                        output.status.code().unwrap_or(-1)
-                    ));
-                }
+                // Compute the non-zero exit marker but append it LAST — after the grep advisory
+                // and after the size-truncation — so it always survives as the final line. The
+                // agent derives `is_error` by tail-anchoring on this marker
+                // (`utils::tool_output_signals_failure`); if the advisory or the truncation notice
+                // trailed it, a genuine non-zero exit on grep-like or large (>10 KB) output would
+                // be silently recorded as a success and the model would build on broken state.
+                let exit_marker = (!output.status.success())
+                    .then(|| format!("\nExit code: {}", output.status.code().unwrap_or(-1)));
 
-                if result.is_empty() {
+                if result.is_empty() && exit_marker.is_none() {
                     Ok("(no output)".to_string())
                 } else {
                     if grep_like {
                         result.push_str("\n\n[advisory] Prefer `search_text` for code/log discovery and `read_file` for file reads; shell grep/cat pipelines are less portable across hosts.");
                     }
-                    // Truncate if massive
+                    // Truncate if massive (the exit marker is appended afterwards, so it is never cut).
                     if result.len() > 10000 {
-                        Ok(format!(
+                        result = format!(
                             "{}\n... (truncated, {} more chars)",
                             &result[..10000],
                             result.len() - 10000
-                        ))
-                    } else {
-                        Ok(result)
+                        );
                     }
+                    if let Some(marker) = exit_marker {
+                        result.push_str(&marker);
+                    }
+                    Ok(result)
                 }
             }
             Ok(Err(e)) => Err(format!("Failed to execute command: {}", e)),
@@ -2318,6 +2322,11 @@ impl Tool for PythonRunTool {
             result.push_str(&stderr);
         }
 
+        // Keep this the LAST append to `result`: the agent tail-anchors on the final `Exit code:`
+        // line to derive is_error (utils::tool_output_signals_failure). python_run currently has no
+        // grep advisory and no size truncation, so the marker is already the final line; if either
+        // is ever added here, append it BEFORE this marker (see the exec path in ShellExecTool,
+        // which appends the marker last for exactly this invariant).
         if !output.status.success() {
             result.push_str(&format!(
                 "\nExit code: {}",
@@ -2566,5 +2575,65 @@ mod python_run_tests {
         }
         assert!(out.contains("hello from python"));
         let _ = fs::remove_dir_all(&root);
+    }
+}
+
+#[cfg(all(test, unix))]
+mod exec_failure_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn exec_tool() -> ShellExecTool {
+        let root = std::env::temp_dir().join(format!("isanagent_exec_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        ShellExecTool {
+            workspace_dir: root,
+            restrict_to_workspace: false,
+        }
+    }
+
+    fn last_nonempty_line(s: &str) -> &str {
+        s.lines().rev().find(|l| !l.trim().is_empty()).unwrap_or("")
+    }
+
+    /// Large (>10 KB) failing output: the internal truncation must NOT cut the `Exit code:` marker,
+    /// and the agent's `is_error` heuristic must flag it. Regression guard for the truncation gap.
+    #[tokio::test]
+    async fn large_failing_output_keeps_exit_marker_last() {
+        let out = exec_tool()
+            .execute(json!({
+                "command": "i=0; while [ $i -lt 1500 ]; do echo xxxxxxxxxx; i=$((i+1)); done; exit 7"
+            }))
+            .await
+            .expect("exec returns Ok with the captured output");
+        assert!(out.len() > 10_000, "expected truncation to engage: {}", out.len());
+        assert!(out.contains("(truncated,"), "expected truncation notice");
+        assert_eq!(last_nonempty_line(&out), "Exit code: 7");
+        assert!(crate::utils::tool_output_signals_failure("exec", &out));
+    }
+
+    /// grep-like failing command: the advisory must not trail (and thus hide) the exit marker.
+    #[tokio::test]
+    async fn grep_like_failure_keeps_exit_marker_last() {
+        let out = exec_tool()
+            .execute(json!({
+                "command": "grep zzz /isanagent/definitely/missing/path/xyz; exit 2"
+            }))
+            .await
+            .expect("exec returns Ok");
+        assert!(out.contains("[advisory]"), "grep-like advisory expected: {out}");
+        assert_eq!(last_nonempty_line(&out), "Exit code: 2");
+        assert!(crate::utils::tool_output_signals_failure("exec", &out));
+    }
+
+    /// A successful command is never flagged and carries no exit marker.
+    #[tokio::test]
+    async fn successful_command_has_no_exit_marker() {
+        let out = exec_tool()
+            .execute(json!({ "command": "echo ok" }))
+            .await
+            .expect("exec returns Ok");
+        assert!(!out.contains("Exit code:"), "no marker on success: {out}");
+        assert!(!crate::utils::tool_output_signals_failure("exec", &out));
     }
 }

--- a/src/tools/builtin.rs
+++ b/src/tools/builtin.rs
@@ -1017,10 +1017,18 @@ impl Tool for ShellExecTool {
                     }
                     // Truncate if massive (the exit marker is appended afterwards, so it is never cut).
                     if result.len() > 10000 {
+                        // Step back to a char boundary at/below the 10 KB cap so we never slice
+                        // through a multi-byte UTF-8 sequence (e.g. Turkish text or emoji straddling
+                        // the limit), which would panic. Matches the is_char_boundary idiom used by
+                        // the other truncation sites in this file.
+                        let mut cut = 10000;
+                        while cut > 0 && !result.is_char_boundary(cut) {
+                            cut -= 1;
+                        }
                         result = format!(
                             "{}\n... (truncated, {} more chars)",
-                            &result[..10000],
-                            result.len() - 10000
+                            &result[..cut],
+                            result.len() - cut
                         );
                     }
                     if let Some(marker) = exit_marker {
@@ -2635,5 +2643,18 @@ mod exec_failure_tests {
             .expect("exec returns Ok");
         assert!(!out.contains("Exit code:"), "no marker on success: {out}");
         assert!(!crate::utils::tool_output_signals_failure("exec", &out));
+    }
+
+    /// Output whose 10 KB truncation point lands inside a multi-byte UTF-8 sequence must not panic.
+    /// `yes ₺ | head -n 5000 | tr -d '\n'` emits 5000 × '₺' (3 bytes each) = 15000 bytes, so byte
+    /// 10000 falls mid-character. Before the char-boundary step-back this panicked on `&result[..10000]`.
+    #[tokio::test]
+    async fn large_multibyte_output_truncates_on_a_char_boundary() {
+        let out = exec_tool()
+            .execute(json!({ "command": "yes ₺ | head -n 5000 | tr -d '\\n'" }))
+            .await
+            .expect("exec returns Ok without panicking on a mid-char truncation");
+        // Reaching here at all proves no char-boundary panic (the String is valid UTF-8 by type).
+        assert!(out.contains("(truncated,"), "expected truncation notice");
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -763,6 +763,68 @@ pub fn truncate_utf8_safe(s: &mut String, max_bytes: usize, suffix: &str) {
     s.push_str(suffix);
 }
 
+/// Whether a tool's *in-band* `Ok(...)` payload should be treated as a failure (`is_error`),
+/// scoped to the specific tools that report recoverable failures inside `Ok(...)` rather than
+/// via `Err`.
+///
+/// This is the precise counterpart to [`tool_output_looks_like_failure`] (which the UI layer in
+/// `channels/terminal.rs` still uses for result tinting). That helper does a text-only prefix
+/// check on *every* tool's *finalized* output, which has two failure modes this function closes:
+///
+/// 1. **Non-zero exit codes are missed.** `exec`/`python_run` report failure by appending a
+///    trailing `Exit code: <N>` line — not by starting with `"Error:"`. A failed `cargo build`
+///    (exit 1 with output that does not begin `"Error:"`) would be recorded as a *success*. Here
+///    we tail-anchor on the runner's `Exit code:` marker instead.
+/// 2. **File content is false-flagged.** A text-only check applied to *all* tools misclassifies
+///    `read_file` returning a log/file that legitimately begins with `"Error:"`. Here the
+///    `"Error:"` prefix rule is restricted to exactly the tools whose entire `Ok` payload is a
+///    control message: `edit_file` / `list_dir` / `glob_files` / `search_text` (plus `list_dir`'s
+///    `"Error reading dir:"` variant). That is the complete set of tools using the `"Error:"`
+///    *prefix* convention in `tools/builtin.rs`; `read_file` and every other content-returning tool
+///    are excluded. (A few tools report failures in other phrasings — e.g. `cron` returns
+///    `"Job <id> was not found"` — which neither this nor the prior text-only check flags; those
+///    are low-risk, non-state-corrupting, and the message text still informs the model.)
+///
+/// `raw_output` must be the **pre-truncation** `Ok` payload: the `Exit code:` marker sits at the
+/// tail and the agent's `finalize_tool_output` would truncate it away. `exec` additionally appends
+/// the marker *after* its grep advisory and its internal 10 KB cap, so it is always the final line
+/// of its own payload and tail-anchoring is sound.
+///
+/// Known, accepted residual: a successful command whose own output's final line is literally
+/// `Exit code: <non-zero>` is a false positive. Low-frequency; the only consequence is a spurious
+/// `is_error` (a possible wasted retry, never a masked real failure), so it is tolerated rather
+/// than papered over with brittle text gymnastics.
+pub fn tool_output_signals_failure(tool_name: &str, raw_output: &str) -> bool {
+    if matches!(tool_name, "exec" | "python_run") {
+        if let Some(last) = raw_output.lines().rev().find(|l| !l.trim().is_empty()) {
+            if let Some(code) = last.trim().strip_prefix("Exit code:") {
+                if code.trim().parse::<i64>().is_ok_and(|c| c != 0) {
+                    return true;
+                }
+            }
+        }
+    }
+    if matches!(tool_name, "edit_file" | "list_dir" | "glob_files" | "search_text") {
+        let head = raw_output.trim_start();
+        if head.starts_with("Error:") || head.starts_with("Error reading dir:") {
+            return true;
+        }
+    }
+    false
+}
+
+/// Whether a completed tool call should be recorded as a failure (`is_error`): the dispatch
+/// `Result` was `Err`, or an `Ok` payload signals an in-band failure (see
+/// [`tool_output_signals_failure`]). Single source of truth for both tool-result sites in the
+/// reasoning loop. Pass the **raw** `Result` (before `finalize_tool_output`) so the runner exit
+/// marker is still present at the tail.
+pub fn tool_call_is_error(tool_name: &str, result: &Result<String, String>) -> bool {
+    match result {
+        Err(_) => true,
+        Ok(raw) => tool_output_signals_failure(tool_name, raw),
+    }
+}
+
 /// Robustly extracts a JSON object from a raw LLM text response.
 /// Intended to handle markdown formatting (` ```json ... ``` `)
 /// or conversational wrappers around the core `{ ... }` payload.
@@ -912,5 +974,125 @@ mod tests {
             "grep found 'Error:' in 2 logs"
         ));
         assert!(!tool_output_looks_like_failure(""));
+    }
+
+    #[test]
+    fn inband_failure_detects_nonzero_exit_for_runners() {
+        // exec / python_run append a trailing "Exit code: <N>" only on non-zero exit.
+        assert!(tool_output_signals_failure(
+            "exec",
+            "some stdout\nSTDERR:\nboom\nExit code: 1"
+        ));
+        assert!(tool_output_signals_failure(
+            "python_run",
+            "Traceback ...\nExit code: 2"
+        ));
+        // Negative exit (signal / unknown) still counts as failure.
+        assert!(tool_output_signals_failure("exec", "killed\nExit code: -1"));
+    }
+
+    #[test]
+    fn inband_failure_ignores_successful_runner_output() {
+        // No trailing exit marker -> success.
+        assert!(!tool_output_signals_failure("exec", "build succeeded\nall good"));
+        assert!(!tool_output_signals_failure("python_run", "42\n"));
+        // "(no output)" sentinel must not be treated as failure.
+        assert!(!tool_output_signals_failure("exec", "(no output)"));
+    }
+
+    #[test]
+    fn inband_failure_is_anchored_to_the_last_line() {
+        // An "Exit code: 1" line in the MIDDLE of output (e.g. a cat'd log) where the command
+        // itself succeeded must NOT be flagged — only the trailing runner marker counts.
+        let log = "old run log:\nExit code: 1\n--- new run ---\ndone";
+        assert!(!tool_output_signals_failure("exec", log));
+    }
+
+    #[test]
+    fn inband_failure_detects_error_prefix_for_scoped_tools() {
+        assert!(tool_output_signals_failure(
+            "edit_file",
+            "Error: old_text not found in file."
+        ));
+        assert!(tool_output_signals_failure(
+            "list_dir",
+            "Error reading dir: permission denied"
+        ));
+        assert!(tool_output_signals_failure(
+            "glob_files",
+            "Error: path not found: /nope"
+        ));
+        // Normal listings/results are not failures.
+        assert!(!tool_output_signals_failure(
+            "search_text",
+            "src/main.rs:10: fn main() {"
+        ));
+        assert!(!tool_output_signals_failure("list_dir", "foo/\nbar.rs\nbaz.rs"));
+    }
+
+    #[test]
+    fn inband_failure_does_not_misclassify_file_content() {
+        // read_file returns raw file content and is intentionally NOT scoped for the "Error:"
+        // prefix rule: a file that legitimately begins with "Error:" must not look like a failure.
+        // This is the key false positive the broader text-only check (tool_output_looks_like_failure)
+        // would hit; the tool-scoped check fixes it.
+        assert!(!tool_output_signals_failure(
+            "read_file",
+            "Error: this is line one of a saved log file"
+        ));
+        // Likewise the exit rule is scoped to the runners only.
+        assert!(!tool_output_signals_failure("read_file", "build.log\nExit code: 7"));
+        // An unrelated tool with an "Error:"-looking payload is left alone.
+        assert!(!tool_output_signals_failure(
+            "web_search",
+            "Error: how to fix a 500 — top results ..."
+        ));
+    }
+
+    #[test]
+    fn inband_failure_exit_code_edge_cases() {
+        // Explicit zero (the runners never emit this, but the parser must treat it as success).
+        assert!(!tool_output_signals_failure("exec", "done\nExit code: 0"));
+        // Non-numeric / garbage after the prefix -> not a failure signal.
+        assert!(!tool_output_signals_failure("exec", "huh\nExit code: abc"));
+        // Empty / whitespace-only output -> no signal.
+        assert!(!tool_output_signals_failure("exec", "   \n  "));
+        assert!(!tool_output_signals_failure("python_run", ""));
+    }
+
+    #[test]
+    fn inband_failure_known_residual_spoofed_exit_marker() {
+        // Documented, accepted false positive: a *successful* command whose own final line forges
+        // the marker. Locked in as intentional so a future change is a conscious decision, not a
+        // silent regression. Consequence is at most a spurious retry, never a masked real failure.
+        assert!(tool_output_signals_failure("exec", "echo test\nExit code: 1"));
+    }
+
+    #[test]
+    fn tool_call_is_error_combines_dispatch_and_in_band() {
+        // Dispatch-level failure.
+        assert!(tool_call_is_error(
+            "exec",
+            &Err("Failed to execute command".to_string())
+        ));
+        assert!(tool_call_is_error("read_file", &Err("not found".to_string())));
+        // In-band failures surfaced through `Ok`.
+        assert!(tool_call_is_error(
+            "edit_file",
+            &Ok("Error: old_text not found in file.".to_string())
+        ));
+        assert!(tool_call_is_error(
+            "python_run",
+            &Ok("Traceback ...\nExit code: 1".to_string())
+        ));
+        // Genuine successes.
+        assert!(!tool_call_is_error(
+            "exec",
+            &Ok("build succeeded".to_string())
+        ));
+        assert!(!tool_call_is_error(
+            "read_file",
+            &Ok("Error: line one of a log file".to_string())
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Refines the in-band `is_error` detection introduced in #46 so that:

1. **Non-zero exit codes from `exec`/`python_run` are detected** (they were previously missed unless the output happened to begin with `Error:`).
2. **Content tools like `read_file` are no longer false-flagged** when their payload legitimately begins with `Error:`.
3. **The `exec` `Exit code:` marker survives truncation and the grep advisory**, so the signal is reliable even on large or grep-like output.

## Why this overlaps with `main`, and how it's resolved

This change was developed in parallel with #46 (`8d7dafde`), which independently added in-band `is_error` via `utils::tool_output_looks_like_failure(text)` — a **text-only** check (`starts_with "Error:" / "error:"`) applied to **every** tool's **finalized** output at the two reasoning-loop tool-result sites in `src/agent/mod.rs`.

Because both touch the same call sites and the same helper area in `src/utils.rs`, they overlap. Rather than duplicate the mechanism, this PR **builds on #46** and closes two real gaps in the text-only heuristic:

| Gap in the text-only check | Consequence | Fix here |
|---|---|---|
| **Misses non-zero exit codes.** `exec`/`python_run` signal failure by appending a trailing `Exit code: <N>` line, not by starting with `Error:`. | A failed `cargo build` (exit 1 whose output doesn't start with `Error:`) was recorded as a **success** — the model builds on broken state, and the signature-based doom-loop detector reasons over a wrong outcome. | `exec`/`python_run` are flagged when the **last non-empty line** is `Exit code: <non-zero>` (tail-anchored). |
| **False-positives on file content.** The text-only check ran on every tool's output, so `read_file` returning a log/file that begins with `Error:` was misclassified as a failed call. | Spurious `is_error` on legitimate reads. | The `Error:` prefix rule is **tool-scoped** to exactly the four tools whose entire `Ok` payload is a control message: `edit_file` / `list_dir` / `glob_files` / `search_text`. |
| **Checks the finalized (truncated) text.** | A non-zero exit on >10 KB or grep-like output could have its `Exit code:` line truncated/pushed off the tail before the check ran. | `is_error` is computed on the **raw** `Ok` payload *before* `finalize_tool_output`, and `exec` now appends the marker **last** (after the grep advisory and the internal 10 KB cap) so it is always the final line. |

`utils::tool_output_looks_like_failure` from #46 is **kept** — it still backs `channels/terminal.rs` UI result tinting (tool-agnostic, already-finalized text). The new `tool_output_signals_failure` / `tool_call_is_error` are the precise, tool-aware path used for the agent's structured `is_error`. The two concerns (UI tinting vs. agent semantics) stay cleanly separated.

### Why tool-scoping is precise, not arbitrary

The `{edit_file, list_dir, glob_files, search_text}` set is the complete list of tools that emit the `Ok("Error: …")` / `Ok("Error reading dir: …")` **prefix** convention in `tools/builtin.rs` (verified by enumerating every in-band `Ok(...)` failure return). `read_file` and the other content-returning tools are intentionally excluded because their payload is data, not a control message.

## Changes

- **`src/utils.rs`** — add `tool_output_signals_failure(tool_name, raw_output)` (tool-scoped, exit-code-aware) and `tool_call_is_error(tool_name, &Result<String,String>)`. 9 unit tests covering exit-code detection, tail-anchoring, scoped-prefix matching, the `read_file` non-misclassification, exit-code edge cases (zero / garbage / empty), and the documented spoofed-marker residual.
- **`src/agent/mod.rs`** — both tool-result sites compute `is_error` via `tool_call_is_error` on the **raw** result, before `finalize_tool_output` consumes it.
- **`src/tools/builtin.rs`** — `exec` appends the non-zero `Exit code:` marker last (survives the advisory + 10 KB truncation); a guard comment on `python_run` documents the same marker-last invariant. 3 unix integration tests (large failing output, grep-like failing output, success).

## Verification

- `cargo test --lib utils::` → 15 passed (9 new).
- `cargo test --lib exec_failure_tests::` → 3 passed.
- `cargo clippy --release --all-targets` → no new warnings on the changed code.

## Notes / accepted residuals

- **Accepted false positive (documented + tested):** a *successful* command whose own final output line is literally `Exit code: <non-zero>`. The harness appends the authoritative marker *after* all command-controlled bytes, so this can only ever produce a spurious `is_error` (at worst a wasted retry) — it can **never mask a real failure** (the dangerous direction is closed by construction).
- **Pre-existing, out of scope:** `src/tools/builtin.rs` truncates `exec` output with `&result[..10000]`, a raw byte slice that can panic on a multi-byte UTF-8 boundary. This predates the change (identical to `main`; only relocated here) and is left for a separate follow-up that can switch it to the existing `truncate_utf8_safe` helper without altering this PR's truncation-notice semantics.
