### PR TITLE
feat(skills): rescan-on-miss so runtime-added skills load without restart

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -3177,10 +3177,8 @@ impl Tool for LoadSkillTool {
             .and_then(|v| v.as_str())
             .unwrap_or("load");
 
-        let registry = self.registry.read().await;
-
         if action == "list" {
-            return Ok(registry.format_skill_directory());
+            return Ok(self.registry.read().await.format_skill_directory());
         }
 
         let skill_name = args
@@ -3193,11 +3191,33 @@ impl Tool for LoadSkillTool {
             .and_then(|v| v.as_str())
             .unwrap_or("full");
 
-        if detail == "metadata" {
-            return registry.get_skill_metadata(skill_name);
+        // First attempt against the registry as it was last scanned. The read guard is scoped to
+        // this block and dropped before the rescan path below takes the write lock, so we never
+        // hold a read guard across a write acquisition on the same RwLock (which would deadlock).
+        let first = {
+            let registry = self.registry.read().await;
+            if detail == "metadata" {
+                registry.get_skill_metadata(skill_name)
+            } else {
+                registry.get_skill_instructions(skill_name)
+            }
+        };
+        if first.is_ok() {
+            return first;
         }
 
-        registry.get_skill_instructions(skill_name)
+        // Miss: a SKILL.md may have been dropped into the skills directory since the registry was
+        // last scanned (it is scanned once at startup). Rescan once and retry before reporting the
+        // skill missing, so a freshly added skill is loadable without restarting the agent. The
+        // rescan is paid only on an actual miss, so the common path (skill already present) is
+        // unchanged.
+        self.registry.write().await.scan_for_skills();
+        let registry = self.registry.read().await;
+        if detail == "metadata" {
+            registry.get_skill_metadata(skill_name)
+        } else {
+            registry.get_skill_instructions(skill_name)
+        }
     }
 }
 
@@ -4195,5 +4215,68 @@ mod tests {
             .await
             .unwrap();
         assert!(full.contains("do things"));
+    }
+
+    #[tokio::test]
+    async fn load_skill_rescans_on_miss_to_pick_up_a_new_skill() {
+        let root = LocalTempDir::new();
+        let skills_root = root.path().join("skills");
+
+        // One skill present when the registry is first scanned (at startup).
+        let first = skills_root.join("first_skill");
+        std::fs::create_dir_all(&first).unwrap();
+        std::fs::write(
+            first.join("SKILL.md"),
+            "---\nname: first_skill\ndescription: present at startup\n---\n\nalpha body\n",
+        )
+        .unwrap();
+
+        let reg = Arc::new(tokio::sync::RwLock::new(SkillRegistry::new(
+            skills_root.clone(),
+        )));
+        let tool = super::LoadSkillTool {
+            registry: reg.clone(),
+        };
+
+        // A skill dropped into the directory AFTER the startup scan: the in-memory registry has
+        // never seen it.
+        let late = skills_root.join("late_skill");
+        std::fs::create_dir_all(&late).unwrap();
+        std::fs::write(
+            late.join("SKILL.md"),
+            "---\nname: late_skill\ndescription: added after scan\n---\n\nomega instructions\n",
+        )
+        .unwrap();
+
+        // Without rescan-on-miss this would error "skill not found"; the on-miss rescan must pick
+        // the new skill up and return its instructions without an agent restart.
+        let loaded = tool
+            .execute(serde_json::json!({ "skill_name": "late_skill", "detail": "full" }))
+            .await
+            .expect("late skill should be loadable after the on-miss rescan");
+        assert!(loaded.contains("omega instructions"), "{loaded}");
+
+        // metadata path also benefits from the rescan (covers the detail == "metadata" branch).
+        let late_meta = tool
+            .execute(serde_json::json!({ "skill_name": "late_skill", "detail": "metadata" }))
+            .await
+            .expect("late skill metadata after rescan");
+        assert!(late_meta.contains("Available: true"), "{late_meta}");
+
+        // The originally-present skill still loads.
+        let alpha = tool
+            .execute(serde_json::json!({ "skill_name": "first_skill", "detail": "full" }))
+            .await
+            .expect("first skill still loads");
+        assert!(alpha.contains("alpha body"), "{alpha}");
+
+        // A genuinely non-existent skill still errors after a rescan turns up nothing new.
+        let missing = tool
+            .execute(serde_json::json!({ "skill_name": "no_such_skill" }))
+            .await;
+        assert!(
+            missing.is_err(),
+            "unknown skill should still error after rescan: {missing:?}"
+        );
     }
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -3207,12 +3207,14 @@ impl Tool for LoadSkillTool {
         }
 
         // Miss: a SKILL.md may have been dropped into the skills directory since the registry was
-        // last scanned (it is scanned once at startup). Rescan once and retry before reporting the
-        // skill missing, so a freshly added skill is loadable without restarting the agent. The
+        // last scanned (it is scanned once at startup). Rescan once and re-resolve before reporting
+        // the skill missing, so a freshly added skill is loadable without restarting the agent. The
         // rescan is paid only on an actual miss, so the common path (skill already present) is
-        // unchanged.
-        self.registry.write().await.scan_for_skills();
-        let registry = self.registry.read().await;
+        // unchanged. Hold a single write guard for both the rescan and the follow-up lookup (the
+        // guard derefs to the registry for the immutable getters), avoiding a redundant drop-then-
+        // reacquire and closing the gap between scan and read.
+        let mut registry = self.registry.write().await;
+        registry.scan_for_skills();
         if detail == "metadata" {
             registry.get_skill_metadata(skill_name)
         } else {


### PR DESCRIPTION
## Summary

Wires an automatic **rescan-on-miss** into the skill load path so a `SKILL.md` dropped into the skills directory at runtime becomes loadable **without restarting the agent**.

## Why this overlaps with `main`, and how it's resolved

The skills system became reloadable in #45, which wrapped the registry as `SharedSkillRegistry = Arc<tokio::sync::RwLock<SkillRegistry>>` and made `scan_for_skills(&mut self)` re-runnable behind the write lock.

This refinement was originally developed against a **different** reload design (an inner `std::sync::RwLock<HashMap>` *inside* `SkillRegistry` with an immutable `scan_for_skills(&self)` atomic rebuild-and-swap). That structural choice — lock *inside* the registry vs. #45's lock *around* the whole registry — is what conflicts: the two are mutually exclusive ownership/locking models, and re-imposing the inner-lock version would fight #45's `Arc<RwLock<SkillRegistry>>` + `&mut self` scan throughout the call graph.

**Resolution:** instead of re-litigating the locking model, this PR keeps #45's structure entirely and rebuilds only the missing *behavior* on top of it. #45 gave the registry the *ability* to reload (the write lock and `&mut` scan exist), but nothing in the load path *triggers* a reload — the directory is scanned once at startup, so a skill added afterwards stays invisible until some unrelated path happens to rescan. `LoadSkillTool::execute` now closes that gap directly.

## What changed

In `LoadSkillTool::execute` (`src/agent/mod.rs`):

- On a `load` / `metadata` lookup **miss**, take the write lock, call `scan_for_skills()`, and retry the lookup **once** before reporting the skill missing.
- The first-attempt read guard is scoped to its own block and dropped **before** the write lock is acquired, so a read guard is never held across a write acquisition on the same `tokio::sync::RwLock` (which is non-reentrant and writer-preferring — holding both would deadlock). The `list` branch likewise takes its own short-lived read guard.
- The rescan is paid **only on an actual miss**, so the common path (skill already present) is unchanged — no extra disk I/O on the hot path.
- `scan_for_skills` inserts by name, so a rescan additively picks up new skills and is safe to call repeatedly (idempotent in effect).

## Verification

- `cargo test --lib load_skill` → 2 passed:
  - `load_skill_tool_supports_list_and_metadata` (existing — no regression).
  - `load_skill_rescans_on_miss_to_pick_up_a_new_skill` (new): writes a `SKILL.md` **after** the startup scan, then asserts both the full and metadata load paths resolve it, the pre-existing skill still loads, and an unknown skill still errors after a fruitless rescan.
- `cargo clippy --release --lib` → no new warnings on the changed code.

An independent review confirmed the deadlock-avoidance (read guard provably dropped before the write acquisition) and verified the new test genuinely fails without the production change.

## Known tradeoff (non-blocking)

`scan_for_skills` does blocking `std::fs` work while holding the write guard. This fires only on a miss (rare) and matches the existing `install_skills_from_repo` pattern; a future hardening could move the scan to `spawn_blocking`. Left out here to keep the change minimal and focused.
