### PR TITLE
Add approval gate for file mutations

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -424,6 +424,17 @@ fn edit_policy_mode_for_session(
     }
 }
 
+/// Reason shown when the edit policy blocks a mutation. Unattended sessions
+/// default to Deny independently of plan mode, so the message distinguishes the
+/// two cases rather than hardcoding "plan mode active" everywhere (PR #62 review #2).
+fn edit_policy_block_reason(unattended_session: bool) -> &'static str {
+    if unattended_session {
+        "File edit blocked by policy: unattended edit mode is active."
+    } else {
+        "File edit blocked by policy: plan mode active — finalize or apply the plan first."
+    }
+}
+
 fn command_preview(command: &str) -> String {
     const MAX_PREVIEW: usize = 160;
     if command.len() <= MAX_PREVIEW {
@@ -492,6 +503,26 @@ mod code_exec_gate_tests {
         assert!(is_code_exec_tool("execution_run_background"));
         assert!(!is_code_exec_tool("read_file"));
         assert!(!is_code_exec_tool("web_search"));
+    }
+
+    #[test]
+    fn file_mutate_category_covers_write_and_edit_only() {
+        assert!(is_file_mutate_tool("write_file"));
+        assert!(is_file_mutate_tool("edit_file"));
+        assert!(!is_file_mutate_tool("read_file"));
+        assert!(!is_file_mutate_tool("exec"));
+        assert!(!is_file_mutate_tool("list_dir"));
+        assert!(!is_file_mutate_tool("search_text"));
+    }
+
+    #[test]
+    fn edit_block_reason_distinguishes_unattended_and_plan_mode() {
+        // PR #62 review #2: the Deny message must match why the edit was blocked.
+        let unattended = edit_policy_block_reason(true);
+        assert!(unattended.contains("unattended"), "{unattended}");
+        assert!(!unattended.contains("plan mode"), "{unattended}");
+        let plan = edit_policy_block_reason(false);
+        assert!(plan.contains("plan mode"), "{plan}");
     }
 
     #[test]
@@ -826,11 +857,14 @@ async fn execute_tool_call_with_activity(
                                 "timeout_secs": 1800,
                                 "allow_empty": false
                             });
+                            // System-initiated approval prompt: bypass the sub-agent tool
+                            // allowlist so a restricted sub-agent (e.g. allowlist={exec})
+                            // can still surface the approval dialog.
                             let ask_result = tools
                                 .execute_tool_scoped(
                                     "ask_user",
                                     ask_payload,
-                                    allow.as_deref(),
+                                    None,
                                     is_subagent,
                                 )
                                 .await;
@@ -916,8 +950,7 @@ async fn execute_tool_call_with_activity(
                 ShellPolicyMode::Allow => {}
                 ShellPolicyMode::Deny => {
                     return ToolExecutionFinished::Completed(Err(
-                        "File edit blocked by policy: plan mode active — finalize or apply the plan first."
-                            .to_string(),
+                        edit_policy_block_reason(runtime.unattended_session).to_string(),
                     ));
                 }
                 ShellPolicyMode::Ask => {
@@ -951,11 +984,14 @@ async fn execute_tool_call_with_activity(
                                 }
                             }
                         });
+                        // System-initiated approval prompt: bypass the sub-agent tool
+                        // allowlist so a restricted sub-agent (e.g. allowlist={write_file})
+                        // can still surface the edit approval dialog.
                         let reply = match tools
                             .execute_tool_scoped(
                                 "ask_user",
                                 ask_payload,
-                                allow.as_deref(),
+                                None,
                                 is_subagent,
                             )
                             .await

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -413,6 +413,17 @@ fn shell_policy_mode_for_session(
     }
 }
 
+fn edit_policy_mode_for_session(
+    policy: &ResolvedShellPolicy,
+    unattended_session: bool,
+) -> ShellPolicyMode {
+    if unattended_session {
+        policy.unattended_edit_mode
+    } else {
+        policy.interactive_edit_mode
+    }
+}
+
 fn command_preview(command: &str) -> String {
     const MAX_PREVIEW: usize = 160;
     if command.len() <= MAX_PREVIEW {
@@ -431,6 +442,11 @@ fn is_code_exec_tool(tool_name: &str) -> bool {
         tool_name,
         "exec" | "python_run" | "execution_run" | "execution_run_background"
     )
+}
+
+/// Tools that mutate a workspace file and therefore need the edit policy gate.
+fn is_file_mutate_tool(tool_name: &str) -> bool {
+    matches!(tool_name, "write_file" | "edit_file")
 }
 
 /// Code-exec tools that run *arbitrary* code (Python source / session cells) where the
@@ -754,6 +770,7 @@ async fn execute_tool_call_with_activity(
 
     with_tool_exec_and_progress_scope(tool_exec_ctx, progress_emitter, async move {
         let mut args = args;
+        let mut approved_mutation_preview = None;
         let activity_handle = tool_execution_activity
             .as_ref()
             .map(|a| a.start(chat_id.as_str(), tool_name.as_str()));
@@ -892,18 +909,94 @@ async fn execute_tool_call_with_activity(
             }
         }
 
+        // Run this after steering hooks: a hook may rewrite the arguments, and the
+        // user must see the exact mutation that will be executed.
+        if is_file_mutate_tool(&tool_name) {
+            match edit_policy_mode_for_session(&runtime.shell_policy, runtime.unattended_session) {
+                ShellPolicyMode::Allow => {}
+                ShellPolicyMode::Deny => {
+                    return ToolExecutionFinished::Completed(Err(
+                        "File edit blocked by policy: plan mode active — finalize or apply the plan first."
+                            .to_string(),
+                    ));
+                }
+                ShellPolicyMode::Ask => {
+                    let preview = match tools
+                        .preview_mutation_scoped(&tool_name, &args, allow.as_deref(), is_subagent)
+                        .await
+                    {
+                        Ok(preview) => preview,
+                        // Invalid/no-op edits retain their ordinary tool result; there is no
+                        // mutation to approve in that case.
+                        Err(error) => {
+                            return ToolExecutionFinished::Completed(Err(format!(
+                                "Could not prepare edit approval: {error}"
+                            )));
+                        }
+                    };
+                    if let Some(preview) = preview {
+                        let ask_payload = serde_json::json!({
+                            "prompt": format!(
+                                "Approve edit to `{}`? Review the attached diff, then reply with approve or deny.",
+                                preview.path
+                            ),
+                            "choices": ["approve", "deny"],
+                            "timeout_secs": 1800,
+                            "allow_empty": false,
+                            "metadata": {
+                                "edit_diff": {
+                                    "file": preview.path,
+                                    "diff": preview.diff,
+                                    "truncated": preview.diff_truncated,
+                                }
+                            }
+                        });
+                        let reply = match tools
+                            .execute_tool_scoped(
+                                "ask_user",
+                                ask_payload,
+                                allow.as_deref(),
+                                is_subagent,
+                            )
+                            .await
+                        {
+                            Ok(reply) => reply,
+                            Err(error) => {
+                                return ToolExecutionFinished::Completed(Err(format!(
+                                    "Edit policy approval failed: {error}"
+                                )));
+                            }
+                        };
+                        if !shell_approval_reply_is_grant(&reply) {
+                            return ToolExecutionFinished::Completed(Err(
+                                "Edit not approved by user; mutation skipped.".to_string(),
+                            ));
+                        }
+                        approved_mutation_preview = Some(preview);
+                    }
+                }
+            }
+        }
+
         let args_for_post = args.clone();
         let completed = match cancel_owned.as_ref() {
             None => Some(
                 tools
-                    .execute_tool_scoped(&tool_name, args, allow.as_deref(), is_subagent)
+                    .execute_tool_scoped_with_approved_mutation(
+                        &tool_name,
+                        args,
+                        approved_mutation_preview.as_ref(),
+                        allow.as_deref(),
+                        is_subagent,
+                    )
                     .await,
             ),
             Some(token) => {
                 tokio::select! {
-                    res = tools.execute_tool_scoped(
+                    res = tools.execute_tool_scoped_with_approved_mutation(
                         &tool_name,
                         args,
+                        approved_mutation_preview.as_ref(),
                         allow.as_deref(),
                         is_subagent,
                     ) => Some(res),
@@ -4257,6 +4350,8 @@ mod tests {
             shell_policy: Arc::new(crate::config::ResolvedShellPolicy {
                 interactive_mode: crate::config::ShellPolicyMode::Ask,
                 unattended_mode: crate::config::ShellPolicyMode::Deny,
+                interactive_edit_mode: crate::config::ShellPolicyMode::Ask,
+                unattended_edit_mode: crate::config::ShellPolicyMode::Deny,
                 approval_patterns: Vec::new(),
             }),
             hook_tool_ctx: None,
@@ -4344,6 +4439,8 @@ mod tests {
             shell_policy: crate::config::ResolvedShellPolicy {
                 interactive_mode: crate::config::ShellPolicyMode::Ask,
                 unattended_mode: crate::config::ShellPolicyMode::Deny,
+                interactive_edit_mode: crate::config::ShellPolicyMode::Ask,
+                unattended_edit_mode: crate::config::ShellPolicyMode::Deny,
                 approval_patterns: Vec::new(),
             },
             hook_tool_ctx: None,
@@ -4402,6 +4499,8 @@ mod tests {
             shell_policy: crate::config::ResolvedShellPolicy {
                 interactive_mode: crate::config::ShellPolicyMode::Ask,
                 unattended_mode: crate::config::ShellPolicyMode::Deny,
+                interactive_edit_mode: crate::config::ShellPolicyMode::Ask,
+                unattended_edit_mode: crate::config::ShellPolicyMode::Deny,
                 approval_patterns: Vec::new(),
             },
             hook_tool_ctx: None,

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -1325,6 +1325,8 @@ mod tests {
             shell_policy: Arc::new(ResolvedShellPolicy {
                 interactive_mode: crate::config::ShellPolicyMode::Ask,
                 unattended_mode: crate::config::ShellPolicyMode::Deny,
+                interactive_edit_mode: crate::config::ShellPolicyMode::Ask,
+                unattended_edit_mode: crate::config::ShellPolicyMode::Deny,
                 approval_patterns: Vec::new(),
             }),
             hook_tool_ctx: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,6 +183,10 @@ pub struct ShellPolicyConfig {
     pub unattended_default: Option<String>,
     /// Extra lowercase substrings that should require approval in `ask` mode.
     pub interactive_requires_approval_for: Option<Vec<String>>,
+    /// File edit mode: `ask`, `deny`, or `allow` (default `ask`).
+    pub edit_mode: Option<String>,
+    /// File edit mode for unattended/autonomous sessions (default `deny`).
+    pub edit_unattended_default: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -196,6 +200,9 @@ pub enum ShellPolicyMode {
 pub struct ResolvedShellPolicy {
     pub interactive_mode: ShellPolicyMode,
     pub unattended_mode: ShellPolicyMode,
+    /// File mutation policy, intentionally independent from shell execution.
+    pub interactive_edit_mode: ShellPolicyMode,
+    pub unattended_edit_mode: ShellPolicyMode,
     pub approval_patterns: Vec<String>,
 }
 
@@ -753,6 +760,14 @@ impl AppConfig {
             shell_cfg.and_then(|s| s.unattended_default.as_deref()),
             ShellPolicyMode::Deny,
         );
+        let interactive_edit_mode = parse_shell_policy_mode(
+            shell_cfg.and_then(|s| s.edit_mode.as_deref()),
+            ShellPolicyMode::Ask,
+        );
+        let unattended_edit_mode = parse_shell_policy_mode(
+            shell_cfg.and_then(|s| s.edit_unattended_default.as_deref()),
+            ShellPolicyMode::Deny,
+        );
         let mut approval_patterns = vec![
             "rm -rf".to_string(),
             "rm -fr".to_string(),
@@ -778,6 +793,8 @@ impl AppConfig {
         ResolvedShellPolicy {
             interactive_mode,
             unattended_mode,
+            interactive_edit_mode,
+            unattended_edit_mode,
             approval_patterns,
         }
     }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -368,6 +368,31 @@ mod scoped_tools_tests {
         assert!(err.contains("not available"));
     }
 
+    #[tokio::test]
+    async fn system_initiated_ask_user_bypasses_subagent_allowlist() {
+        // Regression for PR #62 review feedback: system-initiated approval prompts
+        // (shell + edit policy gates) call ask_user with allowlist=None so a
+        // restricted sub-agent allowlist (e.g. {write_file} / {exec}) can still
+        // surface the approval dialog.
+        let mut r = ToolRegistry::new();
+        r.register(Box::new(NamedTool { n: "ask_user" }));
+        r.register(Box::new(NamedTool { n: "write_file" }));
+
+        // A sub-agent allowlisted to {write_file} (no ask_user) blocks a direct
+        // ask_user call — this is the failure the None-allowlist bypass avoids.
+        let allow: HashSet<String> = ["write_file".to_string()].into_iter().collect();
+        let err = r
+            .execute_tool_scoped("ask_user", Value::Null, Some(&allow), true)
+            .await
+            .unwrap_err();
+        assert!(err.contains("not allowed"), "{err}");
+
+        // With allowlist=None the system-initiated ask_user succeeds.
+        r.execute_tool_scoped("ask_user", Value::Null, None, true)
+            .await
+            .expect("system-initiated ask_user must bypass the allowlist");
+    }
+
     #[test]
     fn list_scoped_filters_allowlist_and_nested_tools() {
         let mut r = ToolRegistry::new();

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,4 +1,4 @@
-use crate::traits::Tool;
+use crate::traits::{MutationPreview, Tool};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
@@ -116,6 +116,63 @@ impl ToolRegistry {
         }
     }
 
+    /// Ask a tool for its file-mutation preview without executing it.
+    pub async fn preview_mutation_scoped(
+        &self,
+        name: &str,
+        args: &Value,
+        allowlist: Option<&HashSet<String>>,
+        is_subagent: bool,
+    ) -> Result<Option<MutationPreview>, String> {
+        self.authorize_scoped(name, allowlist, is_subagent)?;
+        match self.get_tool(name) {
+            Some(tool) => tool.preview_mutation(args).await,
+            None => Err(format!("Tool '{}' not found", name)),
+        }
+    }
+
+    /// Execute with a preview previously approved by the user.
+    pub async fn execute_tool_scoped_with_approved_mutation(
+        &self,
+        name: &str,
+        args: Value,
+        approved_preview: Option<&MutationPreview>,
+        allowlist: Option<&HashSet<String>>,
+        is_subagent: bool,
+    ) -> Result<String, String> {
+        self.authorize_scoped(name, allowlist, is_subagent)?;
+        match self.get_tool(name) {
+            Some(tool) => {
+                tool.execute_with_approved_mutation(args, approved_preview)
+                    .await
+            }
+            None => Err(format!("Tool '{}' not found", name)),
+        }
+    }
+
+    fn authorize_scoped(
+        &self,
+        name: &str,
+        allowlist: Option<&HashSet<String>>,
+        is_subagent: bool,
+    ) -> Result<(), String> {
+        if is_subagent && Self::is_subagent_restricted_tool(name) {
+            return Err(format!(
+                "Tool '{}' is not available inside a sub-agent run",
+                name
+            ));
+        }
+        if let Some(set) = allowlist {
+            if !set.is_empty() && !set.contains(name) {
+                return Err(format!(
+                    "Tool '{}' is not allowed for this sub-agent (allowlist)",
+                    name
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Tools that must not run inside a sub-agent loop (prevents unbounded recursion).
     pub fn is_subagent_restricted_tool(name: &str) -> bool {
         matches!(name, "subagent_spawn" | "subagent_plan_execute")
@@ -182,20 +239,7 @@ impl ToolRegistry {
         allowlist: Option<&HashSet<String>>,
         is_subagent: bool,
     ) -> Result<String, String> {
-        if is_subagent && Self::is_subagent_restricted_tool(name) {
-            return Err(format!(
-                "Tool '{}' is not available inside a sub-agent run",
-                name
-            ));
-        }
-        if let Some(set) = allowlist {
-            if !set.is_empty() && !set.contains(name) {
-                return Err(format!(
-                    "Tool '{}' is not allowed for this sub-agent (allowlist)",
-                    name
-                ));
-            }
-        }
+        self.authorize_scoped(name, allowlist, is_subagent)?;
         self.execute_tool(name, args).await
     }
 }

--- a/src/tools/builtin.rs
+++ b/src/tools/builtin.rs
@@ -361,7 +361,14 @@ impl Tool for WriteFileTool {
             .ok_or("Missing 'content' argument")?;
         let actual_path = resolve_path(path_str, &self.workspace_dir, self.restrict_to_workspace)?;
         let before = match fs::read_to_string(&actual_path) {
-            Ok(content) => Some(content),
+            Ok(current_content) => {
+                // No-op write: the file already holds the exact content. Skip the
+                // approval prompt — there is no mutation to review.
+                if current_content == content {
+                    return Ok(None);
+                }
+                Some(current_content)
+            }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
             Err(error) => return Err(format!("Could not preview write target: {error}")),
         };
@@ -515,6 +522,12 @@ impl Tool for EditFileTool {
             .get("replace_all")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        // No-op edit: identical old/new text produces an empty diff. Skip the
+        // approval prompt — there is no mutation to review. (execute() separately
+        // returns an "identical" error so the model learns the edit was a no-op.)
+        if old_text == new_text {
+            return Ok(None);
+        }
         let actual_path = resolve_path(path_str, &self.workspace_dir, self.restrict_to_workspace)?;
         let before = fs::read_to_string(&actual_path)
             .map_err(|error| format!("Could not preview edit target: {error}"))?;
@@ -2715,6 +2728,47 @@ mod mutation_preview_tests {
         let preview = tool.preview_mutation(&args).await.unwrap().unwrap();
         assert!(preview.diff.contains("-beta"), "{}", preview.diff);
         assert!(preview.diff.contains("+gamma"), "{}", preview.diff);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn write_preview_skips_noop_when_content_unchanged() {
+        // PR #62 review #4: writing identical content is a no-op; skip the prompt.
+        let root = workspace();
+        fs::write(root.join("same.txt"), "identical\n").unwrap();
+        let tool = WriteFileTool {
+            workspace_dir: root.clone(),
+            restrict_to_workspace: true,
+        };
+        let args = json!({ "path": "same.txt", "content": "identical\n" });
+        assert!(
+            tool.preview_mutation(&args).await.unwrap().is_none(),
+            "identical-content write must be a no-op preview"
+        );
+        // A genuinely different write still produces a preview.
+        let changed = json!({ "path": "same.txt", "content": "new\n" });
+        assert!(tool.preview_mutation(&changed).await.unwrap().is_some());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn edit_preview_skips_noop_when_old_equals_new() {
+        // PR #62 review #3: identical old/new text is a no-op; skip the prompt.
+        let root = workspace();
+        fs::write(root.join("notes.txt"), "alpha\nbeta\n").unwrap();
+        let tool = EditFileTool {
+            workspace_dir: root.clone(),
+            restrict_to_workspace: true,
+        };
+        let args = json!({
+            "path": "notes.txt",
+            "old_text": "beta",
+            "new_text": "beta"
+        });
+        assert!(
+            tool.preview_mutation(&args).await.unwrap().is_none(),
+            "identical old/new text must be a no-op preview"
+        );
         let _ = fs::remove_dir_all(root);
     }
 }

--- a/src/tools/builtin.rs
+++ b/src/tools/builtin.rs
@@ -2,13 +2,14 @@ use async_trait::async_trait;
 use chrono::Utc;
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
 use tokio::time::{timeout, Duration};
 use walkdir::WalkDir;
 
 use crate::config::JinaWebBackend;
-use crate::traits::Tool;
+use crate::traits::{MutationPreview, Tool};
 use crate::utils::{join_lexically_under_root, normalize_sandbox_relative_input};
 use crate::NodeHandle;
 
@@ -18,6 +19,8 @@ const MAX_GLOB_RESULTS: usize = 500;
 const MAX_SEARCH_TEXT_CHARS: usize = 20_000;
 /// Maximum unified-diff lines included in `edit_file` output.
 const MAX_DIFF_OUTPUT_LINES: usize = 80;
+/// Bound approval metadata so a large write cannot flood the UI event channel.
+const MAX_EDIT_APPROVAL_DIFF_CHARS: usize = 16_000;
 
 /// Resolves a path against the workspace and enforces boundary restrictions.
 pub fn resolve_path(path: &str, workspace_dir: &Path, restrict: bool) -> Result<PathBuf, String> {
@@ -120,6 +123,85 @@ fn truncate_diff_output(diff: String) -> String {
 fn unified_diff_snippet(old: &str, new: &str) -> String {
     let patch = diffy::create_patch(old, new);
     truncate_diff_output(patch.to_string())
+}
+
+fn truncate_approval_diff(mut diff: String) -> (String, bool) {
+    if diff.len() <= MAX_EDIT_APPROVAL_DIFF_CHARS {
+        return (diff, false);
+    }
+    let mut end = MAX_EDIT_APPROVAL_DIFF_CHARS;
+    while !diff.is_char_boundary(end) {
+        end -= 1;
+    }
+    diff.truncate(end);
+    diff.push_str("\n... (approval diff truncated)");
+    (diff, true)
+}
+
+fn content_fingerprint(content: Option<&str>) -> String {
+    match content {
+        Some(content) => format!("sha256:{:x}", Sha256::digest(content.as_bytes())),
+        None => "absent".to_string(),
+    }
+}
+
+fn display_mutation_path(actual_path: &Path, workspace_dir: &Path) -> String {
+    // `resolve_path` returns a canonical target. Canonicalize the workspace too
+    // so `/var` versus `/private/var` aliases on macOS still produce a relative
+    // user-facing path and a stable approval identity.
+    let canonical_workspace =
+        fs::canonicalize(workspace_dir).unwrap_or_else(|_| workspace_dir.to_path_buf());
+    actual_path
+        .strip_prefix(&canonical_workspace)
+        .unwrap_or(actual_path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn mutation_preview(
+    workspace_dir: &Path,
+    restrict_to_workspace: bool,
+    path_str: &str,
+    before: Option<&str>,
+    after: &str,
+) -> Result<MutationPreview, String> {
+    let actual_path = resolve_path(path_str, workspace_dir, restrict_to_workspace)?;
+    let display_path = display_mutation_path(&actual_path, workspace_dir);
+    let (diff, diff_truncated) =
+        truncate_approval_diff(unified_diff_snippet(before.unwrap_or(""), after));
+    Ok(MutationPreview {
+        path: display_path,
+        diff,
+        diff_truncated,
+        base_fingerprint: content_fingerprint(before),
+    })
+}
+
+fn validate_approved_preview(
+    workspace_dir: &Path,
+    restrict_to_workspace: bool,
+    path_str: &str,
+    approved_preview: &MutationPreview,
+) -> Result<(), String> {
+    let actual_path = resolve_path(path_str, workspace_dir, restrict_to_workspace)?;
+    let display_path = display_mutation_path(&actual_path, workspace_dir);
+    if display_path != approved_preview.path {
+        return Err(
+            "Edit approval no longer matches the requested path; request a new approval.".into(),
+        );
+    }
+    let current = match fs::read_to_string(&actual_path) {
+        Ok(content) => Some(content),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(format!("Could not re-read approved edit target: {error}")),
+    };
+    if content_fingerprint(current.as_deref()) != approved_preview.base_fingerprint {
+        return Err(
+            "Edit target changed after approval; request a new approval with an updated diff."
+                .into(),
+        );
+    }
+    Ok(())
 }
 
 fn ripgrep_available() -> bool {
@@ -267,6 +349,51 @@ impl Tool for WriteFileTool {
             .map(|_| format!("Successfully wrote to {}", actual_path.display()))
             .map_err(|e| e.to_string())
     }
+
+    async fn preview_mutation(&self, args: &Value) -> Result<Option<MutationPreview>, String> {
+        let path_str = args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'path' argument")?;
+        let content = args
+            .get("content")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'content' argument")?;
+        let actual_path = resolve_path(path_str, &self.workspace_dir, self.restrict_to_workspace)?;
+        let before = match fs::read_to_string(&actual_path) {
+            Ok(content) => Some(content),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(format!("Could not preview write target: {error}")),
+        };
+        mutation_preview(
+            &self.workspace_dir,
+            self.restrict_to_workspace,
+            path_str,
+            before.as_deref(),
+            content,
+        )
+        .map(Some)
+    }
+
+    async fn execute_with_approved_mutation(
+        &self,
+        args: Value,
+        approved_preview: Option<&MutationPreview>,
+    ) -> Result<String, String> {
+        if let Some(preview) = approved_preview {
+            let path_str = args
+                .get("path")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing 'path' argument")?;
+            validate_approved_preview(
+                &self.workspace_dir,
+                self.restrict_to_workspace,
+                path_str,
+                preview,
+            )?;
+        }
+        self.execute(args).await
+    }
 }
 
 pub struct EditFileTool {
@@ -369,6 +496,68 @@ impl Tool for EditFileTool {
             actual_path.display(),
             diff
         ))
+    }
+
+    async fn preview_mutation(&self, args: &Value) -> Result<Option<MutationPreview>, String> {
+        let path_str = args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'path' argument")?;
+        let old_text = args
+            .get("old_text")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'old_text' argument")?;
+        let new_text = args
+            .get("new_text")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'new_text' argument")?;
+        let replace_all = args
+            .get("replace_all")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let actual_path = resolve_path(path_str, &self.workspace_dir, self.restrict_to_workspace)?;
+        let before = fs::read_to_string(&actual_path)
+            .map_err(|error| format!("Could not preview edit target: {error}"))?;
+        if !before.contains(old_text) {
+            return Ok(None);
+        }
+        let count = before.matches(old_text).count();
+        if count > 1 && !replace_all {
+            return Ok(None);
+        }
+        let after = if replace_all {
+            before.replace(old_text, new_text)
+        } else {
+            before.replacen(old_text, new_text, 1)
+        };
+        mutation_preview(
+            &self.workspace_dir,
+            self.restrict_to_workspace,
+            path_str,
+            Some(&before),
+            &after,
+        )
+        .map(Some)
+    }
+
+    async fn execute_with_approved_mutation(
+        &self,
+        args: Value,
+        approved_preview: Option<&MutationPreview>,
+    ) -> Result<String, String> {
+        if let Some(preview) = approved_preview {
+            let path_str = args
+                .get("path")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing 'path' argument")?;
+            validate_approved_preview(
+                &self.workspace_dir,
+                self.restrict_to_workspace,
+                path_str,
+                preview,
+            )?;
+        }
+        self.execute(args).await
     }
 }
 
@@ -2450,6 +2639,83 @@ mod glob_files_tests {
         );
 
         let _ = fs::remove_dir_all(&root);
+    }
+}
+
+#[cfg(test)]
+mod mutation_preview_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn workspace() -> PathBuf {
+        let root =
+            std::env::temp_dir().join(format!("isanagent_mutation_{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    #[tokio::test]
+    async fn write_preview_records_absent_file_and_approved_write_succeeds() {
+        let root = workspace();
+        let tool = WriteFileTool {
+            workspace_dir: root.clone(),
+            restrict_to_workspace: true,
+        };
+        let args = json!({ "path": "new.txt", "content": "new content\n" });
+        let preview = tool.preview_mutation(&args).await.unwrap().unwrap();
+        assert_eq!(preview.path, "new.txt");
+        assert_eq!(preview.base_fingerprint, "absent");
+        assert!(preview.diff.contains("+new content"));
+
+        tool.execute_with_approved_mutation(args, Some(&preview))
+            .await
+            .unwrap();
+        assert_eq!(
+            fs::read_to_string(root.join("new.txt")).unwrap(),
+            "new content\n"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn approved_write_rejects_intervening_change() {
+        let root = workspace();
+        let target = root.join("notes.txt");
+        fs::write(&target, "before\n").unwrap();
+        let tool = WriteFileTool {
+            workspace_dir: root.clone(),
+            restrict_to_workspace: true,
+        };
+        let args = json!({ "path": "notes.txt", "content": "approved\n" });
+        let preview = tool.preview_mutation(&args).await.unwrap().unwrap();
+        fs::write(&target, "changed elsewhere\n").unwrap();
+
+        let error = tool
+            .execute_with_approved_mutation(args, Some(&preview))
+            .await
+            .expect_err("intervening change must invalidate approval");
+        assert!(error.contains("changed after approval"), "{error}");
+        assert_eq!(fs::read_to_string(&target).unwrap(), "changed elsewhere\n");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn edit_preview_describes_exact_replacement() {
+        let root = workspace();
+        fs::write(root.join("notes.txt"), "alpha\nbeta\n").unwrap();
+        let tool = EditFileTool {
+            workspace_dir: root.clone(),
+            restrict_to_workspace: true,
+        };
+        let args = json!({
+            "path": "notes.txt",
+            "old_text": "beta",
+            "new_text": "gamma"
+        });
+        let preview = tool.preview_mutation(&args).await.unwrap().unwrap();
+        assert!(preview.diff.contains("-beta"), "{}", preview.diff);
+        assert!(preview.diff.contains("+gamma"), "{}", preview.diff);
+        let _ = fs::remove_dir_all(root);
     }
 }
 

--- a/src/tools/workflow.rs
+++ b/src/tools/workflow.rs
@@ -321,6 +321,10 @@ impl Tool for AskUserTool {
                 "allow_empty": {
                     "type": "boolean",
                     "description": "If false (default), treat whitespace-only replies as invalid and keep waiting until timeout."
+                },
+                "metadata": {
+                    "type": "object",
+                    "description": "Optional UI-only structured metadata attached to the clarification event. Do not put secrets here."
                 }
             },
             "required": ["prompt"]
@@ -525,6 +529,15 @@ impl Tool for AskUserTool {
         body.push_str(prompt);
 
         let mut metadata = HashMap::new();
+        if let Some(extra) = args.get("metadata").and_then(|v| v.as_object()) {
+            // Metadata is deliberately restricted to a JSON object and is carried only on
+            // the outbound clarification event. Callers must keep it bounded and secret-free.
+            metadata.extend(
+                extra
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone())),
+            );
+        }
         metadata.insert(
             METADATA_CLARIFICATION.to_string(),
             serde_json::Value::Bool(true),

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,19 @@
 use async_trait::async_trait;
 use serde_json::Value;
 
+/// A bounded, user-facing description of a pending file mutation.
+///
+/// The agent dispatcher creates this before asking for approval. `base_fingerprint`
+/// identifies the exact file state the user reviewed; mutation tools re-check it
+/// immediately before writing so an intervening edit is detected.
+#[derive(Debug, Clone)]
+pub struct MutationPreview {
+    pub path: String,
+    pub diff: String,
+    pub diff_truncated: bool,
+    pub base_fingerprint: String,
+}
+
 // --- Trait Definitions ---
 
 /// A Provider abstracts the generation capabilities of an LLM.
@@ -63,4 +76,24 @@ pub trait Tool: Send + Sync {
 
     /// Execute the tool with the given JSON arguments.
     async fn execute(&self, args: Value) -> Result<String, String>;
+
+    /// Return a preview for a file mutation, if this tool performs one.
+    ///
+    /// The default keeps existing tools source-compatible and lets the central
+    /// dispatcher apply a single policy to the small set of mutation tools.
+    async fn preview_mutation(&self, _args: &Value) -> Result<Option<MutationPreview>, String> {
+        Ok(None)
+    }
+
+    /// Execute a mutation after the dispatcher has obtained user approval.
+    ///
+    /// Mutation tools override this to validate `approved_preview` before
+    /// writing. Non-mutation tools retain the normal execution path.
+    async fn execute_with_approved_mutation(
+        &self,
+        args: Value,
+        _approved_preview: Option<&MutationPreview>,
+    ) -> Result<String, String> {
+        self.execute(args).await
+    }
 }


### PR DESCRIPTION
## Summary\n- add a central policy gate for write_file and edit_file\n- show a bounded diff through ask_user metadata before an edit runs\n- revalidate the approved file fingerprint immediately before writing\n- add independent interactive and unattended edit policy modes\n\n## Verification\n- cargo test --lib --no-fail-fast\n\nThe ALTAI-side event renderer and permission-mode mapping will follow once this crate API is merged and pinned.