### PR TITLE
feat: harden agent lifecycle and diagnostic logs

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1519,7 +1519,7 @@ fn spawn_main_chat_reasoning_turn(
             Arc::ptr_eq(stored, &task_token_arc)
         });
 
-        let next_inbound = pending_inbound.get(&task_chat_id).and_then(|r| {
+        let mut next_inbound = pending_inbound.get(&task_chat_id).and_then(|r| {
             let mut g = match r.lock() {
                 Ok(guard) => guard,
                 Err(poisoned) => {
@@ -1536,10 +1536,30 @@ fn spawn_main_chat_reasoning_turn(
             g.pop_front()
         });
 
-        if let Some(mut next_inbound) = next_inbound {
-            match ensure_run_id(&mut next_inbound) {
+        while let Some(mut inbound) = next_inbound {
+            let next_from_queue = || {
+                pending_inbound.get(&task_chat_id).and_then(|r| {
+                    let mut g = match r.lock() {
+                        Ok(guard) => guard,
+                        Err(poisoned) => {
+                            let _ = logger_tx.send(BusMessage::Log(
+                                LogEvent::warn(
+                                    "AgentLogic",
+                                    "pending_inbound mutex poisoned after reasoning turn; recovering queue.",
+                                )
+                                .with_chat_id(&task_chat_id),
+                            ));
+                            poisoned.into_inner()
+                        }
+                    };
+                    g.pop_front()
+                })
+            };
+
+            match ensure_run_id(&mut inbound) {
                 Ok(next_run_id) => {
-                    spawn_main_chat_reasoning_turn(args_for_chain, next_inbound, next_run_id);
+                    spawn_main_chat_reasoning_turn(args_for_chain, inbound, next_run_id);
+                    break;
                 }
                 Err(error) => {
                     let _ = logger_tx.send(BusMessage::Log(
@@ -1549,6 +1569,7 @@ fn spawn_main_chat_reasoning_turn(
                         )
                         .with_chat_id(&task_chat_id),
                     ));
+                    next_inbound = next_from_queue();
                 }
             }
         }
@@ -1980,7 +2001,26 @@ impl ActorLogic<BusMessage> for AgentLogic {
                 return Ok(None);
             }
             BusMessage::Inbound(mut inbound) => {
-                let run_id = ensure_run_id(&mut inbound).map_err(ActorError::from)?;
+                let run_id = match ensure_run_id(&mut inbound) {
+                    Ok(run_id) => run_id,
+                    Err(error) => {
+                        let _ = self.logger_tx.send(BusMessage::Log(
+                            LogEvent::error(
+                                &self.name,
+                                &format!("Rejecting inbound message: {}", error),
+                            )
+                            .with_chat_id(&inbound.chat_id),
+                        ));
+                        let notice = crate::channels::terminal::build_channel_error_notice(
+                            &inbound.channel,
+                            &inbound.chat_id,
+                            inbound.thread_id.as_deref(),
+                            &error,
+                        );
+                        let _ = self.outbound_tx.send(BusMessage::Outbound(notice)).await;
+                        return Ok(None);
+                    }
+                };
                 let chat_id = inbound.chat_id.clone();
                 let session_key = inbound.clarification_session_key();
                 if self
@@ -3973,6 +4013,7 @@ mod tests {
         Router,
     };
     use serde_json::Value;
+    use std::collections::VecDeque;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
@@ -4866,6 +4907,91 @@ mod tests {
                 .get(METADATA_RUN_ID)
                 .and_then(|value| value.as_str()),
             Some(generated.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_tauri_inbound_is_rejected_without_stopping_the_actor() {
+        let provider = RespondingProvider {
+            tag: "done".to_string(),
+        };
+        let (mut agent, mut outbound_rx) = build_agent_with_provider(Box::new(provider));
+        let mut invalid = test_inbound("invalid-run-id", "hello");
+        invalid.channel = "tauri".to_string();
+
+        assert!(matches!(
+            agent.process(BusMessage::Inbound(invalid)).await,
+            Ok(None)
+        ));
+        assert!(matches!(
+            outbound_rx.recv().await,
+            Some(BusMessage::Outbound(_))
+        ));
+
+        let mut valid = test_inbound("valid-after-rejection", "hello");
+        valid.channel = "tauri".to_string();
+        valid.metadata.insert(
+            METADATA_RUN_ID.to_string(),
+            serde_json::json!("valid-run-id"),
+        );
+        agent
+            .process(BusMessage::Inbound(valid))
+            .await
+            .expect("actor remains usable after rejecting malformed inbound");
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(2), outbound_rx.recv()).await,
+            Ok(Some(BusMessage::RunLifecycle(
+                RunLifecycleEvent::Started { .. }
+            )))
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_queued_inbound_does_not_strand_following_valid_message() {
+        let (unblock_tx, unblock_rx) = tokio::sync::oneshot::channel();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let provider = GateFirstChatProvider {
+            calls: calls.clone(),
+            first_unblock: Arc::new(tokio::sync::Mutex::new(Some(unblock_rx))),
+        };
+        let (mut agent, _outbound_rx) = build_agent_with_provider(Box::new(provider));
+        let chat_id = "skip-invalid-queued";
+        agent
+            .process(BusMessage::Inbound(test_inbound(chat_id, "first")))
+            .await
+            .expect("start first turn");
+        for _ in 0..200 {
+            if calls.load(Ordering::SeqCst) == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let mut invalid = test_inbound(chat_id, "invalid queued");
+        invalid.channel = "tauri".to_string();
+        let mut valid = test_inbound(chat_id, "valid queued");
+        valid.channel = "tauri".to_string();
+        valid.metadata.insert(
+            METADATA_RUN_ID.to_string(),
+            serde_json::json!("queued-run-id"),
+        );
+        agent.pending_inbound.insert(
+            chat_id.to_string(),
+            Mutex::new(VecDeque::from([invalid, valid])),
+        );
+
+        unblock_tx.send(()).expect("unblock first turn");
+        for _ in 0..400 {
+            if calls.load(Ordering::SeqCst) == 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "the valid queued message must run after the invalid item is dropped"
         );
     }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -15,7 +15,10 @@ pub use subagent::SubagentHarness;
 use crate::clarification::ClarificationHub;
 use crate::tool_runtime::{with_tool_exec_and_progress_scope, ToolExecCtx, ToolProgressEmitter};
 
-use crate::bus::{BusMessage, InboundMessage, LogEvent, OutboundMessage, TelemetryEvent};
+use crate::bus::{
+    BusMessage, InboundMessage, LogEvent, OutboundMessage, RunBudgetSnapshot, RunFailureKind,
+    RunLifecycleEvent, RunOutcome, RunStuckReason, TelemetryEvent, METADATA_RUN_ID,
+};
 use crate::config::{ResolvedShellPolicy, ShellPolicyMode};
 use crate::hooks::{
     run_post_tool_hooks, run_pre_tool_hooks, run_user_prompt_hooks, HookObservationMeta,
@@ -93,6 +96,29 @@ fn metadata_truthy(meta: &HashMap<String, serde_json::Value>, key: &str) -> bool
                     .unwrap_or(false)
         })
         .unwrap_or(false)
+}
+
+fn ensure_run_id(inbound: &mut InboundMessage) -> Result<String, String> {
+    if let Some(run_id) = inbound
+        .metadata
+        .get(METADATA_RUN_ID)
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|run_id| !run_id.is_empty())
+    {
+        return Ok(run_id.to_string());
+    }
+
+    if inbound.channel.eq_ignore_ascii_case("tauri") {
+        return Err("Tauri inbound messages require a non-empty isanagent_run_id".to_string());
+    }
+
+    let run_id = format!("legacy-{}", uuid::Uuid::new_v4());
+    inbound.metadata.insert(
+        METADATA_RUN_ID.to_string(),
+        serde_json::Value::String(run_id.clone()),
+    );
+    Ok(run_id)
 }
 
 fn text_looks_like_research_request(content: &str) -> bool {
@@ -1175,7 +1201,61 @@ fn send_background_job_notification(
     let _ = outbound_tx.try_send(BusMessage::Outbound(notice));
 }
 
-fn spawn_main_chat_reasoning_turn(args: ReasoningSpawnArgs, inbound: crate::bus::InboundMessage) {
+fn classify_run_outcome(
+    result: &Result<Result<String, String>, Box<dyn std::any::Any + Send>>,
+    cancelled: bool,
+    max_iterations: usize,
+) -> RunOutcome {
+    if cancelled {
+        return RunOutcome::Cancelled;
+    }
+
+    match result {
+        Err(_) => RunOutcome::Failed {
+            failure: RunFailureKind::Internal,
+            retryable: false,
+        },
+        Ok(Err(error)) => {
+            let lower = error.to_ascii_lowercase();
+            let failure = if lower.contains("provider") || lower.contains("llm") {
+                RunFailureKind::Provider
+            } else if lower.contains("tool") {
+                RunFailureKind::Tool
+            } else if lower.contains("persist") || lower.contains("memory") {
+                RunFailureKind::Persistence
+            } else if lower.contains("protocol") || lower.contains("metadata") {
+                RunFailureKind::Protocol
+            } else {
+                RunFailureKind::Internal
+            };
+            let retryable = matches!(failure, RunFailureKind::Provider);
+            RunOutcome::Failed { failure, retryable }
+        }
+        Ok(Ok(message)) if message.starts_with(WAITING_FOR_USER_RESULT_PREFIX) => {
+            RunOutcome::Completed
+        }
+        Ok(Ok(message)) if message.starts_with("Stopped: the agent kept repeating") => {
+            RunOutcome::Stuck {
+                reason: RunStuckReason::DoomLoop,
+            }
+        }
+        Ok(Ok(message)) if message == "Agent reached max reasoning iterations." => {
+            RunOutcome::BudgetExhausted {
+                budget: RunBudgetSnapshot {
+                    iterations_used: max_iterations,
+                    iterations_limit: max_iterations,
+                },
+            }
+        }
+        Ok(Ok(_)) => RunOutcome::Completed,
+    }
+}
+
+fn spawn_main_chat_reasoning_turn(
+    args: ReasoningSpawnArgs,
+    inbound: crate::bus::InboundMessage,
+    run_id: String,
+) {
     let chat_id = inbound.chat_id.clone();
     let cancel_token = Arc::new(tokio_util::sync::CancellationToken::new());
     args.cancellation_tokens
@@ -1245,6 +1325,23 @@ fn spawn_main_chat_reasoning_turn(args: ReasoningSpawnArgs, inbound: crate::bus:
             .with_chat_id(&task_chat_id),
         ));
 
+        if outbound_tx
+            .send(BusMessage::RunLifecycle(RunLifecycleEvent::Started {
+                run_id: run_id.clone(),
+                chat_id: task_chat_id.clone(),
+            }))
+            .await
+            .is_err()
+        {
+            let _ = logger_tx.send(BusMessage::Log(
+                LogEvent::warn(
+                    &agent_name,
+                    "Could not deliver RunLifecycle::Started; continuing reasoning task.",
+                )
+                .with_chat_id(&task_chat_id),
+            ));
+        }
+
         if let Some(ref jid) = background_job_id {
             send_background_job_notification(
                 &outbound_tx,
@@ -1273,6 +1370,7 @@ fn spawn_main_chat_reasoning_turn(args: ReasoningSpawnArgs, inbound: crate::bus:
             outbound_tx: outbound_tx.clone(),
             logger_tx: logger_tx.clone(),
             inbound,
+            run_id: run_id.clone(),
             cancel_token: task_token_arc.as_ref().clone(),
             clarification_hub,
             tool_exec_ctx,
@@ -1360,6 +1458,25 @@ fn spawn_main_chat_reasoning_turn(args: ReasoningSpawnArgs, inbound: crate::bus:
             }
         }
 
+        let outcome = classify_run_outcome(&res, task_token_arc.is_cancelled(), max_iterations);
+        if outbound_tx
+            .send(BusMessage::RunLifecycle(RunLifecycleEvent::Terminated {
+                run_id: run_id.clone(),
+                chat_id: task_chat_id.clone(),
+                outcome,
+            }))
+            .await
+            .is_err()
+        {
+            let _ = logger_tx.send(BusMessage::Log(
+                LogEvent::warn(
+                    &agent_name,
+                    "Could not deliver RunLifecycle::Terminated after reasoning task completion.",
+                )
+                .with_chat_id(&task_chat_id),
+            ));
+        }
+
         if let Some(job_id) = background_job_id {
             let (state, last_error) = match &res {
                 Ok(Ok(s)) if s.starts_with(WAITING_FOR_USER_RESULT_PREFIX) => ("waiting", None),
@@ -1419,8 +1536,21 @@ fn spawn_main_chat_reasoning_turn(args: ReasoningSpawnArgs, inbound: crate::bus:
             g.pop_front()
         });
 
-        if let Some(next_inbound) = next_inbound {
-            spawn_main_chat_reasoning_turn(args_for_chain, next_inbound);
+        if let Some(mut next_inbound) = next_inbound {
+            match ensure_run_id(&mut next_inbound) {
+                Ok(next_run_id) => {
+                    spawn_main_chat_reasoning_turn(args_for_chain, next_inbound, next_run_id);
+                }
+                Err(error) => {
+                    let _ = logger_tx.send(BusMessage::Log(
+                        LogEvent::error(
+                            "AgentLogic",
+                            &format!("Dropping queued inbound without valid run ID: {}", error),
+                        )
+                        .with_chat_id(&task_chat_id),
+                    ));
+                }
+            }
         }
     });
 }
@@ -1441,6 +1571,7 @@ pub(crate) struct ReasoningLoopCtx {
     pub(crate) outbound_tx: mpsc::Sender<BusMessage>,
     pub(crate) logger_tx: LoggerHandle,
     pub(crate) inbound: crate::bus::InboundMessage,
+    pub(crate) run_id: String,
     pub(crate) cancel_token: tokio_util::sync::CancellationToken,
     pub(crate) clarification_hub: Arc<ClarificationHub>,
     pub(crate) tool_exec_ctx: ToolExecCtx,
@@ -1848,7 +1979,8 @@ impl ActorLogic<BusMessage> for AgentLogic {
                 });
                 return Ok(None);
             }
-            BusMessage::Inbound(inbound) => {
+            BusMessage::Inbound(mut inbound) => {
+                let run_id = ensure_run_id(&mut inbound).map_err(ActorError::from)?;
                 let chat_id = inbound.chat_id.clone();
                 let session_key = inbound.clarification_session_key();
                 if self
@@ -1941,7 +2073,7 @@ impl ActorLogic<BusMessage> for AgentLogic {
                     return res;
                 }
 
-                spawn_main_chat_reasoning_turn(self.reasoning_spawn_args().await, inbound);
+                spawn_main_chat_reasoning_turn(self.reasoning_spawn_args().await, inbound, run_id);
 
                 Ok(None)
             }
@@ -1971,6 +2103,7 @@ impl ActorLogic<BusMessage> for AgentLogic {
             }
             BusMessage::Outbound(_)
             | BusMessage::Telemetry(_)
+            | BusMessage::RunLifecycle(_)
             | BusMessage::LoggerControl(_)
             | BusMessage::Log(_)
             | BusMessage::PromoteSyncToBackground(_)
@@ -2313,7 +2446,8 @@ impl AgentLogic {
             serde_json::json!(job_id),
         );
 
-        spawn_main_chat_reasoning_turn(self.reasoning_spawn_args().await, resumed_inbound);
+        let run_id = ensure_run_id(&mut resumed_inbound)?;
+        spawn_main_chat_reasoning_turn(self.reasoning_spawn_args().await, resumed_inbound, run_id);
         Ok(())
     }
 }
@@ -2648,6 +2782,7 @@ impl AgentLogic {
             outbound_tx,
             logger_tx,
             inbound,
+            run_id: _run_id,
             cancel_token,
             clarification_hub,
             tool_exec_ctx,
@@ -3845,7 +3980,10 @@ mod tests {
     use tokio::sync::mpsc;
     use tower::util::ServiceExt;
 
-    use crate::bus::{clarification_session_key, BusMessage, InboundMessage};
+    use crate::bus::{
+        clarification_session_key, BusMessage, InboundMessage, RunLifecycleEvent, RunOutcome,
+        RunStuckReason, METADATA_RUN_ID,
+    };
     use crate::clarification::ClarificationHub;
     use crate::logging::create_logger_channel;
     use crate::memory::SqliteMemoryActor;
@@ -4384,6 +4522,7 @@ mod tests {
             outbound_tx,
             logger_tx,
             inbound,
+            run_id: "test-run-id".to_string(),
             cancel_token: cancel_token.clone(),
             clarification_hub: ClarificationHub::shared(),
             tool_exec_ctx: ToolExecCtx::new("terminal", "loop-test-chat", None)
@@ -4710,6 +4849,99 @@ mod tests {
             attachments: vec![],
             metadata: Default::default(),
         }
+    }
+
+    #[test]
+    fn run_id_is_required_for_tauri_and_backfilled_for_legacy_channels() {
+        let mut tauri = test_inbound("run-id-tauri", "hello");
+        tauri.channel = "tauri".to_string();
+        assert!(super::ensure_run_id(&mut tauri).is_err());
+
+        let mut legacy = test_inbound("run-id-terminal", "hello");
+        let generated = super::ensure_run_id(&mut legacy).expect("legacy run id");
+        assert!(generated.starts_with("legacy-"));
+        assert_eq!(
+            legacy
+                .metadata
+                .get(METADATA_RUN_ID)
+                .and_then(|value| value.as_str()),
+            Some(generated.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn started_lifecycle_event_preserves_caller_run_id() {
+        let provider = RespondingProvider {
+            tag: "done".to_string(),
+        };
+        let (mut agent, mut outbound_rx) = build_agent_with_provider(Box::new(provider));
+        let mut inbound = test_inbound("run-id-chat", "hello");
+        inbound.channel = "tauri".to_string();
+        inbound.metadata.insert(
+            METADATA_RUN_ID.to_string(),
+            serde_json::json!("caller-run-123"),
+        );
+
+        agent
+            .process(BusMessage::Inbound(inbound))
+            .await
+            .expect("process inbound");
+
+        let event = tokio::time::timeout(Duration::from_secs(2), outbound_rx.recv())
+            .await
+            .expect("started lifecycle event before timeout")
+            .expect("outbound event");
+        assert!(matches!(
+            event,
+            BusMessage::RunLifecycle(RunLifecycleEvent::Started { run_id, chat_id })
+                if run_id == "caller-run-123" && chat_id == "run-id-chat"
+        ));
+
+        let terminal = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let Some(BusMessage::RunLifecycle(
+                    event @ RunLifecycleEvent::Terminated { .. },
+                )) = outbound_rx.recv().await
+                {
+                    return event;
+                }
+            }
+        })
+        .await
+        .expect("terminal lifecycle event before timeout");
+        assert!(matches!(
+            terminal,
+            RunLifecycleEvent::Terminated { run_id, chat_id, outcome: RunOutcome::Completed }
+                if run_id == "caller-run-123" && chat_id == "run-id-chat"
+        ));
+    }
+
+    #[test]
+    fn terminal_outcome_classifies_budget_and_doom_loop_without_generic_success() {
+        let budget = super::classify_run_outcome(
+            &Ok(Ok("Agent reached max reasoning iterations.".to_string())),
+            false,
+            7,
+        );
+        assert!(matches!(
+            budget,
+            RunOutcome::BudgetExhausted { budget }
+                if budget.iterations_used == 7 && budget.iterations_limit == 7
+        ));
+
+        let stuck = super::classify_run_outcome(
+            &Ok(Ok(
+                "Stopped: the agent kept repeating the same action with no progress".to_string(),
+            )),
+            false,
+            7,
+        );
+        assert_eq!(
+            stuck,
+            RunOutcome::Stuck {
+                reason: RunStuckReason::DoomLoop,
+            }
+        );
     }
 
     #[tokio::test]

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -573,6 +573,7 @@ impl SubagentHarness {
             outbound_tx: self.inner.deps.outbound_tx.clone(),
             logger_tx: self.inner.deps.logger_tx.clone(),
             inbound,
+            run_id: format!("subagent-{task_id}"),
             cancel_token: task_cancel.clone(),
             clarification_hub: self.inner.deps.clarification_hub.clone(),
             tool_exec_ctx,

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -18,6 +18,8 @@ pub const METADATA_SYNTHETIC_BACKGROUND_RESUME: &str = "isanagent_synthetic_back
 pub const METADATA_BACKGROUND_JOB_ID: &str = "isanagent_background_job_id";
 /// Inbound metadata: the ID of the clarification ticket being replied to.
 pub const METADATA_CLARIFICATION_TICKET_ID: &str = "clarification_ticket_id";
+/// Trusted caller-provided identifier for one foreground reasoning run.
+pub const METADATA_RUN_ID: &str = "isanagent_run_id";
 
 /// An inbound message received from a Channel (e.g. Slack, Email).
 //
@@ -578,6 +580,63 @@ mod tests {
 }
 
 /// A wrapper used to distinguish routing intents inside the Agent network.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunFailureKind {
+    ProviderRetriesExhausted,
+    Provider,
+    Tool,
+    Protocol,
+    Persistence,
+    Internal,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunStuckReason {
+    DoomLoop,
+    RepeatedRootCause,
+    NoProgress,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunBudgetSnapshot {
+    pub iterations_used: usize,
+    pub iterations_limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RunOutcome {
+    Completed,
+    Failed {
+        failure: RunFailureKind,
+        retryable: bool,
+    },
+    Cancelled,
+    Stuck {
+        reason: RunStuckReason,
+    },
+    BudgetExhausted {
+        budget: RunBudgetSnapshot,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RunLifecycleEvent {
+    Started {
+        run_id: String,
+        chat_id: String,
+    },
+    Terminated {
+        run_id: String,
+        chat_id: String,
+        outcome: RunOutcome,
+    },
+}
+
+/// A wrapper used to distinguish routing intents inside the Agent network.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum BusMessage {
@@ -586,6 +645,8 @@ pub enum BusMessage {
     Telemetry(TelemetryEvent),
     /// Verbose structured log event for file-based diagnostics.
     Log(LogEvent),
+    /// Typed foreground reasoning-run lifecycle signal.
+    RunLifecycle(RunLifecycleEvent),
     /// Internal control flow for deterministic logger flush/shutdown.
     LoggerControl(LoggerControlMessage),
     /// Signal to interrupt an active reasoning loop for a specific chat.
@@ -632,4 +693,55 @@ pub enum BusMessage {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         skill_name: Option<String>,
     },
+}
+
+#[cfg(test)]
+mod run_lifecycle_tests {
+    use super::{RunBudgetSnapshot, RunFailureKind, RunLifecycleEvent, RunOutcome, RunStuckReason};
+
+    #[test]
+    fn lifecycle_events_round_trip_for_every_terminal_outcome() {
+        let outcomes = vec![
+            RunOutcome::Completed,
+            RunOutcome::Failed {
+                failure: RunFailureKind::ProviderRetriesExhausted,
+                retryable: true,
+            },
+            RunOutcome::Cancelled,
+            RunOutcome::Stuck {
+                reason: RunStuckReason::RepeatedRootCause,
+            },
+            RunOutcome::BudgetExhausted {
+                budget: RunBudgetSnapshot {
+                    iterations_used: 24,
+                    iterations_limit: 24,
+                },
+            },
+        ];
+
+        for outcome in outcomes {
+            let event = RunLifecycleEvent::Terminated {
+                run_id: "run-123".to_string(),
+                chat_id: "chat-456".to_string(),
+                outcome,
+            };
+            let encoded = serde_json::to_string(&event).expect("serialize lifecycle event");
+            let decoded: RunLifecycleEvent =
+                serde_json::from_str(&encoded).expect("deserialize lifecycle event");
+            assert_eq!(decoded, event);
+        }
+    }
+
+    #[test]
+    fn started_lifecycle_event_round_trips() {
+        let event = RunLifecycleEvent::Started {
+            run_id: "run-123".to_string(),
+            chat_id: "chat-456".to_string(),
+        };
+
+        let encoded = serde_json::to_string(&event).expect("serialize lifecycle event");
+        let decoded: RunLifecycleEvent =
+            serde_json::from_str(&encoded).expect("deserialize lifecycle event");
+        assert_eq!(decoded, event);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -311,6 +311,33 @@ pub struct GitWorktreeConfig {
     pub allow_path_outside_sandbox: Option<bool>,
 }
 
+/// Best-effort workspace diagnostic logging. These limits apply only to the
+/// inspectable `.system_generated/logs/` files; SQLite remains the durable
+/// source of truth for conversations and run state.
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct LoggingConfig {
+    /// Disable file-backed diagnostic logging entirely. Defaults to enabled.
+    pub enabled: Option<bool>,
+    /// Active-file byte limit for `conversation.jsonl`.
+    pub conversation_max_bytes: Option<u64>,
+    /// Active-file byte limit for `runtime.log`.
+    pub runtime_max_bytes: Option<u64>,
+    /// Number of rotated files retained for each diagnostic log.
+    pub retained_generations: Option<usize>,
+    /// Aggregate byte cap for recognized diagnostic log files in one workspace.
+    pub max_total_bytes: Option<u64>,
+}
+
+/// Fully bounded diagnostic-log settings consumed by the logging actor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EffectiveLoggingConfig {
+    pub enabled: bool,
+    pub conversation_max_bytes: u64,
+    pub runtime_max_bytes: u64,
+    pub retained_generations: usize,
+    pub max_total_bytes: u64,
+}
+
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct AppConfig {
     pub restrict_to_workspace: Option<bool>,
@@ -339,6 +366,8 @@ pub struct AppConfig {
     pub multi_tenant_edge: Option<MultiTenantEdgeConfig>,
     /// When `enabled`, `web_search` / `web_fetch` use [Jina Reader](https://r.jina.ai/) and search (`s.jina.ai`).
     pub jina: Option<JinaConfig>,
+    /// Bounded, file-backed diagnostic logs under `.system_generated/logs/`.
+    pub logging: Option<LoggingConfig>,
     pub harness: Option<HarnessConfig>,
     /// Named agent definitions (`[agents.<name>]` in config.toml). Top-level alias for
     /// `harness.agents` when the user keeps agents in the root of config.toml.
@@ -504,6 +533,56 @@ impl AppConfig {
     pub fn resolved_max_tool_output_chars(&self) -> Option<usize> {
         self.max_tool_output_chars
             .or_else(|| self.terminal.as_ref().and_then(|t| t.max_tool_output_chars))
+    }
+
+    /// Resolved bounds for file-backed diagnostic logs. Invalid or missing
+    /// values always resolve to bounded settings; they can never enable
+    /// unbounded workspace log growth.
+    pub fn effective_logging_config(&self) -> EffectiveLoggingConfig {
+        const DEFAULT_CONVERSATION_MAX_BYTES: u64 = 20 * 1024 * 1024;
+        const DEFAULT_RUNTIME_MAX_BYTES: u64 = 10 * 1024 * 1024;
+        const DEFAULT_RETAINED_GENERATIONS: usize = 2;
+        const DEFAULT_TOTAL_MAX_BYTES: u64 = 90 * 1024 * 1024;
+        const MIN_ACTIVE_FILE_BYTES: u64 = 256;
+        const MAX_ACTIVE_FILE_BYTES: u64 = 512 * 1024 * 1024;
+        const MAX_RETAINED_GENERATIONS: usize = 32;
+        const MAX_TOTAL_BYTES: u64 = 1024 * 1024 * 1024;
+
+        let logging = self.logging.as_ref();
+        let bounded_bytes = |configured: Option<u64>, default: u64| {
+            configured
+                .filter(|bytes| *bytes >= MIN_ACTIVE_FILE_BYTES)
+                .map(|bytes| bytes.min(MAX_ACTIVE_FILE_BYTES))
+                .unwrap_or(default)
+        };
+        let conversation_max_bytes = bounded_bytes(
+            logging.and_then(|config| config.conversation_max_bytes),
+            DEFAULT_CONVERSATION_MAX_BYTES,
+        );
+        let runtime_max_bytes = bounded_bytes(
+            logging.and_then(|config| config.runtime_max_bytes),
+            DEFAULT_RUNTIME_MAX_BYTES,
+        );
+        let retained_generations = logging
+            .and_then(|config| config.retained_generations)
+            .unwrap_or(DEFAULT_RETAINED_GENERATIONS)
+            .min(MAX_RETAINED_GENERATIONS);
+        let minimum_total = conversation_max_bytes.saturating_add(runtime_max_bytes);
+        let default_total = DEFAULT_TOTAL_MAX_BYTES.max(minimum_total);
+        let max_total_bytes = logging
+            .and_then(|config| config.max_total_bytes)
+            .filter(|bytes| *bytes >= minimum_total)
+            .map(|bytes| bytes.min(MAX_TOTAL_BYTES))
+            .filter(|bytes| *bytes >= minimum_total)
+            .unwrap_or(default_total);
+
+        EffectiveLoggingConfig {
+            enabled: logging.and_then(|config| config.enabled).unwrap_or(true),
+            conversation_max_bytes,
+            runtime_max_bytes,
+            retained_generations,
+            max_total_bytes,
+        }
     }
 
     /// At least one inbound channel other than terminal (API, Slack, or Email).
@@ -1543,6 +1622,80 @@ pub struct EmailConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn logging_config_uses_bounded_defaults() {
+        let config: AppConfig = toml::from_str("").expect("parse empty config");
+
+        assert_eq!(
+            config.effective_logging_config(),
+            EffectiveLoggingConfig {
+                enabled: true,
+                conversation_max_bytes: 20 * 1024 * 1024,
+                runtime_max_bytes: 10 * 1024 * 1024,
+                retained_generations: 2,
+                max_total_bytes: 90 * 1024 * 1024,
+            }
+        );
+    }
+
+    #[test]
+    fn logging_config_parses_explicit_bounded_values() {
+        let config: AppConfig = toml::from_str(
+            r#"
+[logging]
+enabled = false
+conversation_max_bytes = 1024
+runtime_max_bytes = 2048
+retained_generations = 3
+max_total_bytes = 4096
+"#,
+        )
+        .expect("parse logging config");
+
+        assert_eq!(
+            config.effective_logging_config(),
+            EffectiveLoggingConfig {
+                enabled: false,
+                conversation_max_bytes: 1024,
+                runtime_max_bytes: 2048,
+                retained_generations: 3,
+                max_total_bytes: 4096,
+            }
+        );
+    }
+
+    #[test]
+    fn logging_config_invalid_values_stay_bounded() {
+        let config: AppConfig = toml::from_str(
+            r#"
+[logging]
+conversation_max_bytes = 0
+runtime_max_bytes = 999999999999
+retained_generations = 999
+max_total_bytes = 1
+"#,
+        )
+        .expect("parse logging config");
+        let effective = config.effective_logging_config();
+
+        assert_eq!(effective.conversation_max_bytes, 20 * 1024 * 1024);
+        assert_eq!(effective.runtime_max_bytes, 512 * 1024 * 1024);
+        assert_eq!(effective.retained_generations, 32);
+        assert_eq!(effective.max_total_bytes, 532 * 1024 * 1024);
+    }
+
+    #[test]
+    fn logging_config_rejects_integer_overflow() {
+        let parsed = toml::from_str::<AppConfig>(
+            r#"
+[logging]
+conversation_max_bytes = 18446744073709551616
+"#,
+        );
+
+        assert!(parsed.is_err());
+    }
 
     #[test]
     fn harness_execution_toml_roundtrip() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod clarification;
 pub mod config;
 pub mod execution;
 pub mod hooks;
+pub mod log_rotation;
 pub mod logging;
 pub mod memory;
 pub mod ml_engineer;

--- a/src/log_rotation.rs
+++ b/src/log_rotation.rs
@@ -1,0 +1,260 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+/// Result of attempting to append one complete line record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteLineOutcome {
+    Written,
+    /// The caller must replace the record with a smaller, format-aware summary.
+    /// The writer never splits a record or writes partial UTF-8.
+    RecordTooLarge {
+        record_bytes: u64,
+        max_record_bytes: u64,
+    },
+}
+
+/// A single-writer, size-bounded append-only file with numbered rotations.
+///
+/// Rotation is intentionally synchronous: callers such as LoggingActor already
+/// serialize writes, so this avoids interleaved records and keeps recovery simple.
+pub struct RotatingLineWriter {
+    path: PathBuf,
+    max_bytes: u64,
+    retained_generations: usize,
+    current_bytes: u64,
+    writer: BufWriter<File>,
+}
+
+impl RotatingLineWriter {
+    pub fn new(
+        path: impl Into<PathBuf>,
+        max_bytes: u64,
+        retained_generations: usize,
+    ) -> io::Result<Self> {
+        if max_bytes < 2 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "rotating line writer requires at least two bytes",
+            ));
+        }
+
+        let path = path.into();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let existing_bytes = file_len(&path)?;
+        if existing_bytes > max_bytes {
+            rotate_files(&path, retained_generations)?;
+        }
+
+        let current_bytes = file_len(&path)?;
+        let writer = open_append_writer(&path)?;
+        Ok(Self {
+            path,
+            max_bytes,
+            retained_generations,
+            current_bytes,
+            writer,
+        })
+    }
+
+    pub fn write_line(&mut self, record: &str) -> io::Result<WriteLineOutcome> {
+        let record_bytes = record.len() as u64;
+        let line_bytes = record_bytes.saturating_add(1);
+        if line_bytes > self.max_bytes {
+            return Ok(WriteLineOutcome::RecordTooLarge {
+                record_bytes,
+                max_record_bytes: self.max_bytes.saturating_sub(1),
+            });
+        }
+
+        if self.current_bytes > 0 && self.current_bytes.saturating_add(line_bytes) > self.max_bytes
+        {
+            self.rotate()?;
+        }
+
+        self.writer.write_all(record.as_bytes())?;
+        self.writer.write_all(b"\n")?;
+        self.current_bytes = self.current_bytes.saturating_add(line_bytes);
+        Ok(WriteLineOutcome::Written)
+    }
+
+    pub fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+
+    pub fn current_bytes(&self) -> u64 {
+        self.current_bytes
+    }
+
+    fn rotate(&mut self) -> io::Result<()> {
+        self.writer.flush()?;
+        rotate_files(&self.path, self.retained_generations)?;
+        self.writer = open_append_writer(&self.path)?;
+        self.current_bytes = 0;
+        Ok(())
+    }
+}
+
+fn open_append_writer(path: &Path) -> io::Result<BufWriter<File>> {
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        options.mode(0o600);
+    }
+    options.open(path).map(BufWriter::new)
+}
+
+fn file_len(path: &Path) -> io::Result<u64> {
+    match fs::metadata(path) {
+        Ok(metadata) => Ok(metadata.len()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(0),
+        Err(error) => Err(error),
+    }
+}
+
+fn generation_path(path: &Path, generation: usize) -> PathBuf {
+    PathBuf::from(format!("{}.{}", path.display(), generation))
+}
+
+fn remove_if_exists(path: &Path) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn rename_if_exists(from: &Path, to: &Path) -> io::Result<()> {
+    match fs::rename(from, to) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn rotate_files(path: &Path, retained_generations: usize) -> io::Result<()> {
+    if retained_generations == 0 {
+        remove_if_exists(path)?;
+        return Ok(());
+    }
+
+    let oldest = generation_path(path, retained_generations);
+    remove_if_exists(&oldest)?;
+
+    for generation in (1..retained_generations).rev() {
+        let from = generation_path(path, generation);
+        let to = generation_path(path, generation + 1);
+        rename_if_exists(&from, &to)?;
+    }
+
+    let first_generation = generation_path(path, 1);
+    rename_if_exists(path, &first_generation)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RotatingLineWriter, WriteLineOutcome};
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn read(path: &std::path::Path) -> String {
+        fs::read_to_string(path).expect("read log")
+    }
+
+    #[test]
+    fn writes_until_next_complete_record_requires_rotation() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("runtime.log");
+        let mut writer = RotatingLineWriter::new(&path, 9, 2).expect("writer");
+
+        assert_eq!(
+            writer.write_line("abcd").expect("first write"),
+            WriteLineOutcome::Written
+        );
+        assert_eq!(writer.current_bytes(), 5);
+        assert_eq!(
+            writer.write_line("efgh").expect("second write"),
+            WriteLineOutcome::Written
+        );
+        writer.flush().expect("flush");
+
+        assert_eq!(read(&path), "efgh\n");
+        assert_eq!(read(&path.with_extension("log.1")), "abcd\n");
+    }
+
+    #[test]
+    fn retains_only_requested_number_of_generations() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("conversation.jsonl");
+        let mut writer = RotatingLineWriter::new(&path, 4, 2).expect("writer");
+
+        for record in ["one", "two", "tri", "for"] {
+            assert_eq!(
+                writer.write_line(record).expect("write"),
+                WriteLineOutcome::Written
+            );
+        }
+        writer.flush().expect("flush");
+
+        assert_eq!(read(&path), "for\n");
+        assert_eq!(read(&path.with_extension("jsonl.1")), "tri\n");
+        assert_eq!(read(&path.with_extension("jsonl.2")), "two\n");
+        assert!(!path.with_extension("jsonl.3").exists());
+    }
+
+    #[test]
+    fn startup_rotates_an_oversized_active_file() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("runtime.log");
+        fs::write(&path, "oversized\n").expect("write oversized log");
+
+        let mut writer = RotatingLineWriter::new(&path, 5, 1).expect("writer");
+        assert_eq!(writer.current_bytes(), 0);
+        assert_eq!(
+            writer.write_line("ok").expect("write"),
+            WriteLineOutcome::Written
+        );
+        writer.flush().expect("flush");
+
+        assert_eq!(read(&path.with_extension("log.1")), "oversized\n");
+        assert_eq!(read(&path), "ok\n");
+    }
+
+    #[test]
+    fn zero_retained_generations_discards_old_active_file() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("runtime.log");
+        let mut writer = RotatingLineWriter::new(&path, 4, 0).expect("writer");
+
+        writer.write_line("one").expect("first write");
+        writer.write_line("two").expect("second write");
+        writer.flush().expect("flush");
+
+        assert_eq!(read(&path), "two\n");
+        assert!(!path.with_extension("log.1").exists());
+    }
+
+    #[test]
+    fn rejects_oversized_record_without_partial_write() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("runtime.log");
+        let mut writer = RotatingLineWriter::new(&path, 6, 1).expect("writer");
+
+        assert_eq!(
+            writer.write_line("tool-output").expect("write"),
+            WriteLineOutcome::RecordTooLarge {
+                record_bytes: 11,
+                max_record_bytes: 5,
+            }
+        );
+        writer.flush().expect("flush");
+
+        assert_eq!(read(&path), "");
+    }
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,5 +1,5 @@
-use std::fs::{File, OpenOptions};
-use std::io::{BufWriter, Write};
+use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::{
     mpsc::{sync_channel, Receiver, SyncSender},
@@ -10,9 +10,12 @@ use async_trait::async_trait;
 use log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
 use regex::Regex;
 use serde_json::json;
+use sha2::{Digest, Sha256};
 use tokio::time::Duration;
 
 use crate::bus::{BusMessage, LogEvent, LogLevel, LoggerControlMessage, TelemetryEvent};
+use crate::config::{AppConfig, EffectiveLoggingConfig};
+use crate::log_rotation::{RotatingLineWriter, WriteLineOutcome};
 use crate::{ActorError, ActorLogic};
 
 pub const LOGGER_QUEUE_CAPACITY: usize = 4096;
@@ -148,8 +151,11 @@ fn sanitize_message(message: &str) -> String {
 
 /// The sole component responsible for writing workspace log files.
 pub struct LoggingActor {
-    conversation_writer: BufWriter<File>,
-    runtime_writer: BufWriter<File>,
+    conversation_writer: Option<RotatingLineWriter>,
+    runtime_writer: Option<RotatingLineWriter>,
+    logs_dir: PathBuf,
+    max_total_bytes: u64,
+    failure_reported: bool,
 }
 
 struct LoggingFallbackActor {
@@ -175,54 +181,114 @@ pub fn create_logging_actor_or_fallback(workspace_dir: PathBuf) -> Box<dyn Actor
 
 impl LoggingActor {
     pub fn new(workspace_dir: PathBuf) -> Result<Self, String> {
-        let logs_dir = workspace_dir.join(".system_generated").join("logs");
-        std::fs::create_dir_all(&logs_dir)
-            .map_err(|e| format!("Failed to create logs directory: {}", e))?;
-
-        Ok(Self {
-            conversation_writer: open_writer(&logs_dir.join("conversation.jsonl"))?,
-            runtime_writer: open_writer(&logs_dir.join("runtime.log"))?,
-        })
+        let logging_config = load_logging_config(&workspace_dir);
+        Self::new_with_config(workspace_dir, logging_config)
     }
 
-    fn write_conversation(&mut self, packet: &BusMessage) -> Result<(), ActorError> {
+    pub fn new_with_config(
+        workspace_dir: PathBuf,
+        logging_config: EffectiveLoggingConfig,
+    ) -> Result<Self, String> {
+        let logs_dir = workspace_dir.join(".system_generated").join("logs");
+        fs::create_dir_all(&logs_dir)
+            .map_err(|e| format!("Failed to create logs directory: {}", e))?;
+
+        let mut actor = Self {
+            conversation_writer: None,
+            runtime_writer: None,
+            logs_dir: logs_dir.clone(),
+            max_total_bytes: logging_config.max_total_bytes,
+            failure_reported: false,
+        };
+        if !logging_config.enabled {
+            return Ok(actor);
+        }
+
+        actor.conversation_writer = Some(
+            RotatingLineWriter::new(
+                logs_dir.join("conversation.jsonl"),
+                logging_config.conversation_max_bytes,
+                logging_config.retained_generations,
+            )
+            .map_err(|e| format!("Failed to open conversation log: {}", e))?,
+        );
+        actor.runtime_writer = Some(
+            RotatingLineWriter::new(
+                logs_dir.join("runtime.log"),
+                logging_config.runtime_max_bytes,
+                logging_config.retained_generations,
+            )
+            .map_err(|e| format!("Failed to open runtime log: {}", e))?,
+        );
+        actor
+            .enforce_total_log_cap()
+            .map_err(|e| format!("Failed to enforce diagnostic log cap: {}", e))?;
+        Ok(actor)
+    }
+
+    fn write_conversation(&mut self, packet: &BusMessage) {
         // Serialize to a `Value` first so secrets can be redacted before this analytical journal
         // hits disk — tool results / inbound text routinely carry keys (an `env` dump, an echoed
         // `$OPENAI_API_KEY`). `conversation.jsonl` is write-only telemetry (agent memory lives in
         // SQLite), so redaction here never affects what the agent can recall or use.
-        let mut value = match packet {
+        let serialized = match packet {
             BusMessage::Inbound(inv) => serde_json::to_value(inv),
             BusMessage::Outbound(out) => serde_json::to_value(out),
             BusMessage::Telemetry(tel) => serde_json::to_value(tel),
-            BusMessage::Log(_) => return Ok(()),
-            BusMessage::LoggerControl(_) => return Ok(()),
-            BusMessage::Cancel(_) => return Ok(()),
-            BusMessage::PromoteSyncToBackground(_) => return Ok(()),
-            BusMessage::SetTerminalSessionChat { .. } => return Ok(()),
-            BusMessage::SwitchModel { .. } => return Ok(()),
+            BusMessage::RunLifecycle(event) => serde_json::to_value(event),
+            BusMessage::Log(_) => return,
+            BusMessage::LoggerControl(_) => return,
+            BusMessage::Cancel(_) => return,
+            BusMessage::PromoteSyncToBackground(_) => return,
+            BusMessage::SetTerminalSessionChat { .. } => return,
+            BusMessage::SwitchModel { .. } => return,
             // PR-5: a manual trigger is internal control flow; the resulting
             // `CompactionTriggered` / `CompactionCompleted` telemetry pair already
             // shows up in the conversation log via the `Telemetry(_)` arm above.
-            BusMessage::TriggerCompaction { .. } => return Ok(()),
-            BusMessage::InstallSkill { .. } => return Ok(()),
-        }
-        .map_err(|e| ActorError::from(format!("Failed to serialize conversation event: {}", e)))?;
+            BusMessage::TriggerCompaction { .. } => return,
+            BusMessage::InstallSkill { .. } => return,
+        };
+        let mut value = match serialized {
+            Ok(value) => value,
+            Err(error) => {
+                self.disable_after_failure("serialize conversation event", error.to_string());
+                return;
+            }
+        };
 
         crate::redact::shared().redact_json(&mut value);
-        let json_line = serde_json::to_string(&value).map_err(|e| {
-            ActorError::from(format!("Failed to serialize conversation event: {}", e))
-        })?;
-
-        writeln!(self.conversation_writer, "{}", json_line)
-            .map_err(|e| ActorError::from(format!("Failed to write conversation log: {}", e)))
+        let json_line = match serde_json::to_string(&value) {
+            Ok(line) => line,
+            Err(error) => {
+                self.disable_after_failure("encode conversation event", error.to_string());
+                return;
+            }
+        };
+        let event_kind = conversation_event_kind(packet);
+        let result = match self.conversation_writer.as_mut() {
+            Some(writer) => write_conversation_record(writer, &json_line, event_kind),
+            None => return,
+        };
+        if let Err(error) = result {
+            self.disable_after_failure("write conversation log", error);
+            return;
+        }
+        self.enforce_total_or_disable();
     }
 
-    fn write_runtime_event(&mut self, event: &LogEvent) -> Result<(), ActorError> {
-        writeln!(self.runtime_writer, "{}", event.format_line())
-            .map_err(|e| ActorError::from(format!("Failed to write runtime log: {}", e)))
+    fn write_runtime_event(&mut self, event: &LogEvent) {
+        let result = match self.runtime_writer.as_mut() {
+            Some(writer) => write_runtime_record(writer, &event.format_line()),
+            None => return,
+        };
+        if let Err(error) = result {
+            self.disable_after_failure("write runtime log", error);
+            return;
+        }
+        self.enforce_total_or_disable();
     }
 
-    fn write_shadow_runtime_event(&mut self, packet: &BusMessage) -> Result<(), ActorError> {
+    fn write_shadow_runtime_event(&mut self, packet: &BusMessage) {
         let event = match packet {
             BusMessage::Inbound(msg) => LogEvent::info(
                 "BusMessage",
@@ -254,8 +320,11 @@ impl LoggingActor {
                 "metadata": msg.metadata,
             })),
             BusMessage::Telemetry(telemetry) => telemetry_to_log_event(telemetry),
-            BusMessage::Log(_) => return Ok(()),
-            BusMessage::LoggerControl(_) => return Ok(()),
+            BusMessage::RunLifecycle(event) => {
+                LogEvent::info("BusMessage", &format!("RunLifecycle event={event:?}"))
+            }
+            BusMessage::Log(_) => return,
+            BusMessage::LoggerControl(_) => return,
             BusMessage::Cancel(chat_id) => LogEvent::info(
                 "BusMessage",
                 &format!("Cancel reasoning loop for chat_id={}", chat_id),
@@ -311,33 +380,223 @@ impl LoggingActor {
             ),
         };
 
-        self.write_runtime_event(&event)
+        self.write_runtime_event(&event);
     }
 
-    fn flush_all(&mut self) -> Result<(), ActorError> {
-        self.conversation_writer
-            .flush()
-            .map_err(|e| ActorError::from(format!("Failed to flush conversation log: {}", e)))?;
-        self.runtime_writer
-            .flush()
-            .map_err(|e| ActorError::from(format!("Failed to flush runtime log: {}", e)))?;
+    fn flush_all(&mut self) {
+        let conversation_result = self
+            .conversation_writer
+            .as_mut()
+            .map(RotatingLineWriter::flush)
+            .transpose();
+        if let Err(error) = conversation_result {
+            self.disable_after_failure("flush conversation log", error.to_string());
+            return;
+        }
+        let runtime_result = self
+            .runtime_writer
+            .as_mut()
+            .map(RotatingLineWriter::flush)
+            .transpose();
+        if let Err(error) = runtime_result {
+            self.disable_after_failure("flush runtime log", error.to_string());
+            return;
+        }
+        self.enforce_total_or_disable();
+    }
+
+    fn enforce_total_or_disable(&mut self) {
+        if let Err(error) = self.enforce_total_log_cap() {
+            self.disable_after_failure("enforce diagnostic log cap", error.to_string());
+        }
+    }
+
+    fn enforce_total_log_cap(&self) -> io::Result<()> {
+        let mut total_bytes = 0u64;
+        let mut rotated = Vec::new();
+        for entry in fs::read_dir(&self.logs_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let metadata = entry.metadata()?;
+            if !metadata.is_file() || !recognized_log_file(&path) {
+                continue;
+            }
+            let bytes = self.active_log_bytes(&path).unwrap_or(metadata.len());
+            total_bytes = total_bytes.saturating_add(bytes);
+            if is_rotated_log_file(&path) {
+                rotated.push((
+                    metadata
+                        .modified()
+                        .unwrap_or(std::time::SystemTime::UNIX_EPOCH),
+                    path,
+                    bytes,
+                ));
+            }
+        }
+
+        rotated.sort_by_key(|(modified, path, _)| (*modified, path.clone()));
+        for (_, path, bytes) in rotated {
+            if total_bytes <= self.max_total_bytes {
+                break;
+            }
+            fs::remove_file(&path)?;
+            total_bytes = total_bytes.saturating_sub(bytes);
+        }
         Ok(())
+    }
+
+    fn active_log_bytes(&self, path: &Path) -> Option<u64> {
+        let name = path.file_name()?.to_str()?;
+        match name {
+            "conversation.jsonl" => self
+                .conversation_writer
+                .as_ref()
+                .map(RotatingLineWriter::current_bytes),
+            "runtime.log" => self
+                .runtime_writer
+                .as_ref()
+                .map(RotatingLineWriter::current_bytes),
+            _ => None,
+        }
+    }
+
+    fn disable_after_failure(&mut self, operation: &str, error: String) {
+        self.conversation_writer = None;
+        self.runtime_writer = None;
+        if !self.failure_reported {
+            self.failure_reported = true;
+            eprintln!(
+                "IsanAgent diagnostic logging disabled after {}: {}",
+                operation,
+                sanitize_message(&error)
+            );
+        }
     }
 }
 
 impl Drop for LoggingActor {
     fn drop(&mut self) {
-        let _ = self.flush_all();
+        self.flush_all();
     }
 }
 
-fn open_writer(path: &Path) -> Result<BufWriter<File>, String> {
-    let file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .map_err(|e| format!("Failed to open {}: {}", path.display(), e))?;
-    Ok(BufWriter::new(file))
+fn load_logging_config(workspace_dir: &Path) -> EffectiveLoggingConfig {
+    let config_path = workspace_dir.join("config.toml");
+    fs::read_to_string(config_path)
+        .ok()
+        .and_then(|contents| toml::from_str::<AppConfig>(&contents).ok())
+        .map(|config| config.effective_logging_config())
+        .unwrap_or_else(|| AppConfig::default().effective_logging_config())
+}
+
+fn conversation_event_kind(packet: &BusMessage) -> &'static str {
+    match packet {
+        BusMessage::Inbound(_) => "inbound",
+        BusMessage::Outbound(_) => "outbound",
+        BusMessage::Telemetry(_) => "telemetry",
+        BusMessage::RunLifecycle(_) => "run_lifecycle",
+        _ => "internal",
+    }
+}
+
+fn write_conversation_record(
+    writer: &mut RotatingLineWriter,
+    json_line: &str,
+    event_kind: &str,
+) -> Result<(), String> {
+    match writer
+        .write_line(json_line)
+        .map_err(|error| error.to_string())?
+    {
+        WriteLineOutcome::Written => Ok(()),
+        WriteLineOutcome::RecordTooLarge {
+            record_bytes,
+            max_record_bytes: _,
+        } => {
+            let digest = format!("{:x}", Sha256::digest(json_line.as_bytes()));
+            let replacement = json!({
+                "type": "truncated_log_record",
+                "original_event_type": event_kind,
+                "original_bytes": record_bytes,
+                "sha256": digest,
+            })
+            .to_string();
+            match writer
+                .write_line(&replacement)
+                .map_err(|error| error.to_string())?
+            {
+                WriteLineOutcome::Written => Ok(()),
+                WriteLineOutcome::RecordTooLarge { .. } => Err(
+                    "conversation log record limit is too small for a truncation marker"
+                        .to_string(),
+                ),
+            }
+        }
+    }
+}
+
+fn write_runtime_record(writer: &mut RotatingLineWriter, line: &str) -> Result<(), String> {
+    match writer.write_line(line).map_err(|error| error.to_string())? {
+        WriteLineOutcome::Written => Ok(()),
+        WriteLineOutcome::RecordTooLarge {
+            record_bytes,
+            max_record_bytes,
+        } => {
+            let replacement = truncate_runtime_line(line, record_bytes, max_record_bytes);
+            match writer
+                .write_line(&replacement)
+                .map_err(|error| error.to_string())?
+            {
+                WriteLineOutcome::Written => Ok(()),
+                WriteLineOutcome::RecordTooLarge { .. } => {
+                    Err("runtime log record limit is too small for a truncation marker".to_string())
+                }
+            }
+        }
+    }
+}
+
+fn truncate_runtime_line(line: &str, original_bytes: u64, max_record_bytes: u64) -> String {
+    let max_record_bytes = max_record_bytes as usize;
+    let marker = format!(" [truncated original_bytes={original_bytes}]");
+    if marker.len() >= max_record_bytes {
+        return "~".repeat(max_record_bytes);
+    }
+    let prefix_limit = max_record_bytes - marker.len();
+    format!("{}{}", truncate_utf8(line, prefix_limit), marker)
+}
+
+fn truncate_utf8(input: &str, max_bytes: usize) -> &str {
+    if input.len() <= max_bytes {
+        return input;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !input.is_char_boundary(end) {
+        end -= 1;
+    }
+    &input[..end]
+}
+
+fn log_generation(path: &Path, base: &str) -> Option<usize> {
+    let name = path.file_name()?.to_str()?;
+    name.strip_prefix(&format!("{base}."))?
+        .parse::<usize>()
+        .ok()
+        .filter(|generation| *generation > 0)
+}
+
+fn recognized_log_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    matches!(name, "conversation.jsonl" | "runtime.log")
+        || log_generation(path, "conversation.jsonl").is_some()
+        || log_generation(path, "runtime.log").is_some()
+}
+
+fn is_rotated_log_file(path: &Path) -> bool {
+    log_generation(path, "conversation.jsonl").is_some()
+        || log_generation(path, "runtime.log").is_some()
 }
 
 fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
@@ -739,7 +998,7 @@ impl ActorLogic<BusMessage> for LoggingActor {
     }
 
     async fn on_tick(&mut self) -> Result<Option<(String, BusMessage)>, ActorError> {
-        self.flush_all()?;
+        self.flush_all();
         Ok(None)
     }
 
@@ -749,17 +1008,17 @@ impl ActorLogic<BusMessage> for LoggingActor {
     ) -> Result<Option<(String, BusMessage)>, ActorError> {
         match &packet {
             BusMessage::LoggerControl(LoggerControlMessage::Flush) => {
-                self.flush_all()?;
+                self.flush_all();
                 return Ok(Some((
                     "logger_control".to_string(),
                     BusMessage::LoggerControl(LoggerControlMessage::Flushed),
                 )));
             }
             BusMessage::LoggerControl(LoggerControlMessage::Flushed) => return Ok(None),
-            BusMessage::Log(event) => self.write_runtime_event(event)?,
+            BusMessage::Log(event) => self.write_runtime_event(event),
             _ => {
-                self.write_conversation(&packet)?;
-                self.write_shadow_runtime_event(&packet)?;
+                self.write_conversation(&packet);
+                self.write_shadow_runtime_event(&packet);
             }
         }
 
@@ -797,8 +1056,155 @@ impl ActorLogic<BusMessage> for LoggingFallbackActor {
 
 #[cfg(test)]
 mod tests {
-    use super::{sanitize_message, should_capture};
+    use super::{recognized_log_file, sanitize_message, should_capture, LoggingActor};
+    use crate::bus::{BusMessage, InboundMessage, LogEvent};
+    use crate::config::EffectiveLoggingConfig;
     use log::Level;
+    use std::collections::HashMap;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn logging_config(max_total_bytes: u64) -> EffectiveLoggingConfig {
+        EffectiveLoggingConfig {
+            enabled: true,
+            conversation_max_bytes: 256,
+            runtime_max_bytes: 256,
+            retained_generations: 2,
+            max_total_bytes,
+        }
+    }
+
+    fn inbound(content: String) -> BusMessage {
+        BusMessage::Inbound(InboundMessage {
+            channel: "test".to_string(),
+            sender_id: "sender".to_string(),
+            chat_id: "chat".to_string(),
+            thread_id: None,
+            content,
+            attachments: Vec::new(),
+            metadata: HashMap::new(),
+        })
+    }
+
+    #[test]
+    fn conversation_rotation_keeps_jsonl_valid_and_redacted() {
+        let workspace = tempdir().expect("tempdir");
+        let mut actor = LoggingActor::new_with_config(
+            workspace.path().to_path_buf(),
+            logging_config(90 * 1024 * 1024),
+        )
+        .expect("logger");
+        let secret = "Bearer abc.def-0123456789";
+
+        for _ in 0..4 {
+            actor.write_conversation(&inbound(format!("{secret} {}", "x".repeat(80))));
+        }
+        actor.write_conversation(&inbound("x".repeat(4096)));
+        actor.flush_all();
+
+        let logs_dir = workspace.path().join(".system_generated/logs");
+        for entry in fs::read_dir(logs_dir).expect("read logs") {
+            let path = entry.expect("entry").path();
+            if !recognized_log_file(&path) {
+                continue;
+            }
+            let contents = fs::read_to_string(&path).expect("read log");
+            assert!(!contents.contains(secret));
+            for line in contents.lines() {
+                serde_json::from_str::<serde_json::Value>(line).expect("valid JSONL record");
+            }
+        }
+    }
+
+    #[test]
+    fn total_log_cap_removes_only_rotated_logs() {
+        let workspace = tempdir().expect("tempdir");
+        let mut actor =
+            LoggingActor::new_with_config(workspace.path().to_path_buf(), logging_config(512))
+                .expect("logger");
+
+        for index in 0..8 {
+            actor.write_conversation(&inbound(format!("message-{index}-{}", "x".repeat(80))));
+            actor.write_runtime_event(&LogEvent::info("test", &"y".repeat(180)));
+        }
+        actor.flush_all();
+
+        let logs_dir = workspace.path().join(".system_generated/logs");
+        let files = fs::read_dir(logs_dir)
+            .expect("read logs")
+            .map(|entry| entry.expect("entry"))
+            .filter(|entry| recognized_log_file(&entry.path()))
+            .map(|entry| {
+                (
+                    entry.file_name().to_string_lossy().to_string(),
+                    entry.metadata().expect("metadata").len(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let total: u64 = files.iter().map(|(_, bytes)| *bytes).sum();
+        assert!(
+            total <= 512,
+            "diagnostic logs total {total} bytes: {files:?}"
+        );
+    }
+
+    #[test]
+    fn oversized_runtime_record_is_marked_without_breaking_logging() {
+        let workspace = tempdir().expect("tempdir");
+        let mut actor = LoggingActor::new_with_config(
+            workspace.path().to_path_buf(),
+            logging_config(90 * 1024 * 1024),
+        )
+        .expect("logger");
+
+        actor.write_runtime_event(&LogEvent::info("test", &"x".repeat(4096)));
+        actor.flush_all();
+
+        let runtime_log = workspace.path().join(".system_generated/logs/runtime.log");
+        let contents = fs::read_to_string(runtime_log).expect("read runtime log");
+        assert!(contents.contains("truncated original_bytes="));
+    }
+
+    #[test]
+    fn workspace_logging_config_can_disable_file_logging() {
+        let workspace = tempdir().expect("tempdir");
+        fs::write(
+            workspace.path().join("config.toml"),
+            "[logging]\nenabled = false\n",
+        )
+        .expect("write config");
+        let mut actor = LoggingActor::new(workspace.path().to_path_buf()).expect("logger");
+
+        actor.write_conversation(&inbound("do not write".to_string()));
+        actor.flush_all();
+
+        assert!(!workspace
+            .path()
+            .join(".system_generated/logs/conversation.jsonl")
+            .exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn created_log_files_are_user_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let workspace = tempdir().expect("tempdir");
+        let _actor = LoggingActor::new_with_config(
+            workspace.path().to_path_buf(),
+            logging_config(90 * 1024 * 1024),
+        )
+        .expect("logger");
+        let conversation = workspace
+            .path()
+            .join(".system_generated/logs/conversation.jsonl");
+        let mode = fs::metadata(conversation)
+            .expect("metadata")
+            .permissions()
+            .mode();
+
+        assert_eq!(mode & 0o077, 0);
+    }
 
     #[test]
     fn sanitize_message_masks_secrets_and_emails() {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -415,9 +415,13 @@ impl LoggingActor {
         let mut total_bytes = 0u64;
         let mut rotated = Vec::new();
         for entry in fs::read_dir(&self.logs_dir)? {
-            let entry = entry?;
+            let Ok(entry) = entry else {
+                continue;
+            };
             let path = entry.path();
-            let metadata = entry.metadata()?;
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
             if !metadata.is_file() || !recognized_log_file(&path) {
                 continue;
             }
@@ -439,8 +443,9 @@ impl LoggingActor {
             if total_bytes <= self.max_total_bytes {
                 break;
             }
-            fs::remove_file(&path)?;
-            total_bytes = total_bytes.saturating_sub(bytes);
+            if fs::remove_file(&path).is_ok() {
+                total_bytes = total_bytes.saturating_sub(bytes);
+            }
         }
         Ok(())
     }

--- a/src/tools/isanagent_ignore.rs
+++ b/src/tools/isanagent_ignore.rs
@@ -97,19 +97,11 @@ pub fn is_ignored(target: &Path, is_dir: bool) -> bool {
         .ok();
 
     let mut guard = cache().lock().expect("isanagentignore cache poisoned");
-    let needs_rebuild = guard
-        .get(&dir)
-        .is_none_or(|entry| entry.mtime != mtime);
+    let needs_rebuild = guard.get(&dir).is_none_or(|entry| entry.mtime != mtime);
     if needs_rebuild {
         match build_matcher(&dir) {
             Some(m) => {
-                guard.insert(
-                    dir.clone(),
-                    CachedMatcher {
-                        matcher: m,
-                        mtime,
-                    },
-                );
+                guard.insert(dir.clone(), CachedMatcher { matcher: m, mtime });
             }
             None => {
                 guard.remove(&dir);
@@ -128,9 +120,7 @@ pub fn is_ignored(target: &Path, is_dir: bool) -> bool {
     // `matched_path_or_any_parents` walks ancestor components so a file inside
     // an ignored directory is caught — matches `.gitignore` semantics.
     matches!(
-        entry
-            .matcher
-            .matched_path_or_any_parents(rel, is_dir),
+        entry.matcher.matched_path_or_any_parents(rel, is_dir),
         Match::Ignore(_)
     )
 }


### PR DESCRIPTION
## Summary
- add bounded, redacted rotating diagnostic logs with safe failure handling
- add typed run lifecycle events and trusted run IDs
- classify cancellation, provider/internal failures, doom loops, and iteration exhaustion as terminal outcomes

## Validation
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features (401 passed, 6 documented ignored)
- git diff --check