### PR TITLE
feat: preserve typed tool status in API streams

### DIFF
--- a/docs/public-api-surface.md
+++ b/docs/public-api-surface.md
@@ -130,7 +130,7 @@ pub struct OutboundMessage {
 | `AgentThought` | `chat_id`, `thought`, `background_job_id` |
 | `AgentUsage` | `chat_id`, `model`, `prompt_tokens`, `completion_tokens`, `total_tokens`, `background_job_id` |
 | `ToolCallStarted` | `chat_id`, `tool_name`, `args`, `background_job_id` |
-| `ToolCallFinished` | `chat_id`, `tool_name`, `result`, `background_job_id` |
+| `ToolCallFinished` | `chat_id`, `tool_name`, `result`, `is_error`, `background_job_id` |
 | `ToolProgress` | `chat_id`, `channel`, `tool_name`, `tool_call_id`, `message`, `background_job_id` |
 | `CronTrigger` | `job_id`, `message` |
 | `ExecutionRunFinished` | `chat_id`, `channel`, `provider_id`, `session_id`, `exit_code`, `duration_ms`, `stdout_len`, `stderr_len`, `artifact_count`, `git_head`, `description` |

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -3988,6 +3988,7 @@ impl AgentLogic {
                             chat_id: inbound.chat_id.clone(),
                             tool_name: tool_name.clone(),
                             result: tool_result_text.clone(),
+                            is_error,
                             background_job_id: crate::bus::get_background_job_id(&inbound.metadata),
                         };
                         let _ = outbound_tx.send(BusMessage::Telemetry(tfin.clone())).await;
@@ -4098,6 +4099,7 @@ impl AgentLogic {
                             chat_id: inbound.chat_id.clone(),
                             tool_name: tn,
                             result: tool_result_text.clone(),
+                            is_error,
                             background_job_id: crate::bus::get_background_job_id(&inbound.metadata),
                         };
                         let _ = outbound_tx.send(BusMessage::Telemetry(tfin.clone())).await;

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -181,6 +181,10 @@ pub enum TelemetryEvent {
         chat_id: String,
         tool_name: String,
         result: String,
+        /// Authoritative executor status. Defaults to success so telemetry
+        /// persisted before this field was added still deserializes.
+        #[serde(default)]
+        is_error: bool,
         background_job_id: Option<String>,
     },
     /// Mid–tool-call status (e.g. uv-managed Python env setup); not a tool result.
@@ -535,7 +539,7 @@ fn redact_chat_id(chat_id: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{clarification_session_key, InboundMessage, LogEvent, LogLevel};
+    use super::{clarification_session_key, InboundMessage, LogEvent, LogLevel, TelemetryEvent};
     use crate::tool_runtime::ToolExecCtx;
 
     #[test]
@@ -557,6 +561,28 @@ mod tests {
             metadata: Default::default(),
         };
         assert_eq!(inbound.clarification_session_key(), "api:x:");
+    }
+
+    #[test]
+    fn legacy_tool_completion_defaults_to_success_status() {
+        let encoded = serde_json::json!({
+            "ToolCallFinished": {
+                "chat_id": "chat-1",
+                "tool_name": "read_file",
+                "result": "Error: literal file content",
+                "background_job_id": null
+            }
+        });
+        let event: TelemetryEvent =
+            serde_json::from_value(encoded).expect("deserialize legacy telemetry");
+
+        assert!(matches!(
+            event,
+            TelemetryEvent::ToolCallFinished {
+                is_error: false,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/src/channels/api.rs
+++ b/src/channels/api.rs
@@ -92,6 +92,7 @@ enum StreamEvent {
     ToolCallFinished {
         tool_name: String,
         result: String,
+        is_error: bool,
     },
     AgentThought {
         thought: String,
@@ -652,14 +653,16 @@ impl ApiChannel {
                 chat_id,
                 tool_name,
                 result,
+                is_error,
                 ..
             } => {
                 if let Some(pending) = self.pending_requests.get(&chat_id) {
                     if let PendingRequest::Stream(pending) = pending.value() {
-                        if let Err(e) = pending
-                            .stream_tx
-                            .try_send(StreamEvent::ToolCallFinished { tool_name, result })
-                        {
+                        if let Err(e) = pending.stream_tx.try_send(StreamEvent::ToolCallFinished {
+                            tool_name,
+                            result,
+                            is_error,
+                        }) {
                             error!("Failed to send tool_call_finished to stream: {}", e);
                         }
                     }
@@ -2567,7 +2570,7 @@ fn log_api(logger_tx: &LoggerHandle, event: LogEvent) {
 mod tests {
     use super::{
         bearer_token_matches, build_router, is_loopback_bind, validate_bind_security, ApiState,
-        PendingRequest, EMBEDDED_UI_ASSETS,
+        PendingRequest, StreamEvent, EMBEDDED_UI_ASSETS,
     };
     use crate::bus::{BusMessage, OutboundMessage};
     use crate::channels::api_store::ResponseStore;
@@ -2588,6 +2591,24 @@ mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use tokio::sync::{mpsc, oneshot};
     use tower::ServiceExt;
+
+    #[test]
+    fn streamed_tool_completion_preserves_typed_error_status() {
+        for (result, is_error) in [
+            ("Error: this is file content, not a failure", false),
+            ("native failure without a text prefix", true),
+        ] {
+            let event = StreamEvent::ToolCallFinished {
+                tool_name: "read_file".to_string(),
+                result: result.to_string(),
+                is_error,
+            };
+            let encoded = serde_json::to_value(event).expect("serialize stream event");
+
+            assert_eq!(encoded["type"], "tool_call_finished");
+            assert_eq!(encoded["is_error"], is_error);
+        }
+    }
 
     struct LocalTempDir {
         path: std::path::PathBuf,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -712,13 +712,15 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
             chat_id,
             tool_name,
             result,
+            is_error,
             ..
         } => LogEvent::debug(
             "Telemetry",
             &format!(
-                "ToolCallFinished tool={} result_len={}",
+                "ToolCallFinished tool={} result_len={} is_error={}",
                 tool_name,
-                result.len()
+                result.len(),
+                is_error
             ),
         )
         .with_chat_id(chat_id),


### PR DESCRIPTION
## Summary
- carry the authoritative tool result status through ToolCallFinished telemetry
- expose is_error on streamed API tool completion events
- preserve backwards compatibility for older telemetry without the field
- include typed status in diagnostic logs and public API documentation

## Validation
- cargo check
- cargo test --lib (422 passed, 6 ignored)
- cargo clippy --all-targets -- -D warnings