### PR TITLE
feat: correlate streamed tool lifecycle events

### DIFF
--- a/docs/public-api-surface.md
+++ b/docs/public-api-surface.md
@@ -129,8 +129,8 @@ pub struct OutboundMessage {
 | `ToolResult` | `chat_id`, `channel`, `tool_name`, `result`, `tool_call_id`, `background_job_id` |
 | `AgentThought` | `chat_id`, `thought`, `background_job_id` |
 | `AgentUsage` | `chat_id`, `model`, `prompt_tokens`, `completion_tokens`, `total_tokens`, `background_job_id` |
-| `ToolCallStarted` | `chat_id`, `tool_name`, `args`, `background_job_id` |
-| `ToolCallFinished` | `chat_id`, `tool_name`, `result`, `is_error`, `background_job_id` |
+| `ToolCallStarted` | `chat_id`, `tool_name`, `args`, `tool_call_id`, `background_job_id` |
+| `ToolCallFinished` | `chat_id`, `tool_name`, `result`, `is_error`, `tool_call_id`, `background_job_id` |
 | `ToolProgress` | `chat_id`, `channel`, `tool_name`, `tool_call_id`, `message`, `background_job_id` |
 | `CronTrigger` | `job_id`, `message` |
 | `ExecutionRunFinished` | `chat_id`, `channel`, `provider_id`, `session_id`, `exit_code`, `duration_ms`, `stdout_len`, `stderr_len`, `artifact_count`, `git_head`, `description` |

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -901,6 +901,7 @@ async fn log_tool_invocation_start(
             chat_id: inbound.chat_id.clone(),
             tool_name: tool_name.to_string(),
             args: args_str.clone(),
+            tool_call_id: Some(tc.id.clone()),
             background_job_id: crate::bus::get_background_job_id(&inbound.metadata),
         }))
         .await;
@@ -925,6 +926,7 @@ async fn log_tool_invocation_start(
             chat_id: inbound.chat_id.clone(),
             tool_name: tool_name.to_string(),
             args: args_str.clone(),
+            tool_call_id: Some(tc.id.clone()),
             background_job_id: crate::bus::get_background_job_id(&inbound.metadata),
         },
     );
@@ -3989,6 +3991,7 @@ impl AgentLogic {
                             tool_name: tool_name.clone(),
                             result: tool_result_text.clone(),
                             is_error,
+                            tool_call_id: Some(tc.id.clone()),
                             background_job_id: crate::bus::get_background_job_id(&inbound.metadata),
                         };
                         let _ = outbound_tx.send(BusMessage::Telemetry(tfin.clone())).await;
@@ -4100,6 +4103,7 @@ impl AgentLogic {
                             tool_name: tn,
                             result: tool_result_text.clone(),
                             is_error,
+                            tool_call_id: Some(tc.id.clone()),
                             background_job_id: crate::bus::get_background_job_id(&inbound.metadata),
                         };
                         let _ = outbound_tx.send(BusMessage::Telemetry(tfin.clone())).await;

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -175,6 +175,8 @@ pub enum TelemetryEvent {
         chat_id: String,
         tool_name: String,
         args: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_call_id: Option<String>,
         background_job_id: Option<String>,
     },
     ToolCallFinished {
@@ -185,6 +187,8 @@ pub enum TelemetryEvent {
         /// persisted before this field was added still deserializes.
         #[serde(default)]
         is_error: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_call_id: Option<String>,
         background_job_id: Option<String>,
     },
     /// Mid–tool-call status (e.g. uv-managed Python env setup); not a tool result.

--- a/src/channels/api.rs
+++ b/src/channels/api.rs
@@ -84,15 +84,21 @@ enum StreamEvent {
     ToolCallStarted {
         tool_name: String,
         args: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tool_call_id: Option<String>,
     },
     ToolProgress {
         tool_name: String,
         message: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tool_call_id: Option<String>,
     },
     ToolCallFinished {
         tool_name: String,
         result: String,
         is_error: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tool_call_id: Option<String>,
     },
     AgentThought {
         thought: String,
@@ -619,14 +625,16 @@ impl ApiChannel {
                 chat_id,
                 tool_name,
                 args,
+                tool_call_id,
                 ..
             } => {
                 if let Some(pending) = self.pending_requests.get(&chat_id) {
                     if let PendingRequest::Stream(pending) = pending.value() {
-                        if let Err(e) = pending
-                            .stream_tx
-                            .try_send(StreamEvent::ToolCallStarted { tool_name, args })
-                        {
+                        if let Err(e) = pending.stream_tx.try_send(StreamEvent::ToolCallStarted {
+                            tool_name,
+                            args,
+                            tool_call_id,
+                        }) {
                             error!("Failed to send tool_call_started to stream: {}", e);
                         }
                     }
@@ -636,14 +644,16 @@ impl ApiChannel {
                 chat_id,
                 tool_name,
                 message,
+                tool_call_id,
                 ..
             } => {
                 if let Some(pending) = self.pending_requests.get(&chat_id) {
                     if let PendingRequest::Stream(pending) = pending.value() {
-                        if let Err(e) = pending
-                            .stream_tx
-                            .try_send(StreamEvent::ToolProgress { tool_name, message })
-                        {
+                        if let Err(e) = pending.stream_tx.try_send(StreamEvent::ToolProgress {
+                            tool_name,
+                            message,
+                            tool_call_id,
+                        }) {
                             error!("Failed to send tool_progress to stream: {}", e);
                         }
                     }
@@ -654,6 +664,7 @@ impl ApiChannel {
                 tool_name,
                 result,
                 is_error,
+                tool_call_id,
                 ..
             } => {
                 if let Some(pending) = self.pending_requests.get(&chat_id) {
@@ -662,6 +673,7 @@ impl ApiChannel {
                             tool_name,
                             result,
                             is_error,
+                            tool_call_id,
                         }) {
                             error!("Failed to send tool_call_finished to stream: {}", e);
                         }
@@ -2602,11 +2614,40 @@ mod tests {
                 tool_name: "read_file".to_string(),
                 result: result.to_string(),
                 is_error,
+                tool_call_id: Some("call-42".to_string()),
             };
             let encoded = serde_json::to_value(event).expect("serialize stream event");
 
             assert_eq!(encoded["type"], "tool_call_finished");
             assert_eq!(encoded["is_error"], is_error);
+            assert_eq!(encoded["tool_call_id"], "call-42");
+        }
+    }
+
+    #[test]
+    fn streamed_tool_lifecycle_uses_one_correlation_id() {
+        let events = [
+            StreamEvent::ToolCallStarted {
+                tool_name: "exec".to_string(),
+                args: r#"{"cmd":"cargo test"}"#.to_string(),
+                tool_call_id: Some("call-7".to_string()),
+            },
+            StreamEvent::ToolProgress {
+                tool_name: "exec".to_string(),
+                message: "still running".to_string(),
+                tool_call_id: Some("call-7".to_string()),
+            },
+            StreamEvent::ToolCallFinished {
+                tool_name: "exec".to_string(),
+                result: "done".to_string(),
+                is_error: false,
+                tool_call_id: Some("call-7".to_string()),
+            },
+        ];
+
+        for event in events {
+            let encoded = serde_json::to_value(event).expect("serialize stream event");
+            assert_eq!(encoded["tool_call_id"], "call-7");
         }
     }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -702,10 +702,16 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
             chat_id,
             tool_name,
             args,
+            tool_call_id,
             ..
         } => LogEvent::debug(
             "Telemetry",
-            &format!("ToolCallStarted tool={} args_len={}", tool_name, args.len()),
+            &format!(
+                "ToolCallStarted tool={} args_len={} id={}",
+                tool_name,
+                args.len(),
+                tool_call_id.as_deref().unwrap_or("-")
+            ),
         )
         .with_chat_id(chat_id),
         TelemetryEvent::ToolCallFinished {
@@ -713,14 +719,16 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
             tool_name,
             result,
             is_error,
+            tool_call_id,
             ..
         } => LogEvent::debug(
             "Telemetry",
             &format!(
-                "ToolCallFinished tool={} result_len={} is_error={}",
+                "ToolCallFinished tool={} result_len={} is_error={} id={}",
                 tool_name,
                 result.len(),
-                is_error
+                is_error,
+                tool_call_id.as_deref().unwrap_or("-")
             ),
         )
         .with_chat_id(chat_id),


### PR DESCRIPTION
## Summary
- propagate the provider tool call ID through started and finished telemetry
- expose one correlation ID across API stream start, progress, and finish events
- include correlation IDs in structured diagnostics while preserving backward-compatible deserialization

## Validation
- cargo check
- cargo test --lib
- cargo clippy --all-targets -- -D warnings
- git diff --check