### PR TITLE
ci: notify altai-app on main-latest publish

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -94,3 +94,25 @@ jobs:
           replacesArtifacts: true
           makeLatest: true
           artifacts: "artifacts/*"
+
+  notify-altai-app:
+    name: Notify altai-app to sync
+    needs: release
+    runs-on: ubuntu-24.04
+    # Cross-repo repository_dispatch needs a PAT (or fine-grained token)
+    # with `contents:write` on altaidevorg/altai-app. Skip quietly when unset.
+    if: ${{ vars.ALTAI_APP_DISPATCH_ENABLED != 'false' }}
+    steps:
+      - name: Dispatch isanagent-released to altai-app
+        env:
+          GH_TOKEN: ${{ secrets.ALTAI_APP_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "ALTAI_APP_DISPATCH_TOKEN not set; skipping altai-app notify (daily sync + cargo update still apply)."
+            exit 0
+          fi
+          gh api repos/altaidevorg/altai-app/dispatches \
+            -f event_type=isanagent-released \
+            -f "client_payload[isanagent_sha]=${{ github.sha }}" \
+            -f "client_payload[source_run]=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -100,8 +100,9 @@ jobs:
     needs: release
     runs-on: ubuntu-24.04
     # Cross-repo repository_dispatch needs a PAT (or fine-grained token)
-    # with `contents:write` on altaidevorg/altai-app. Skip quietly when unset.
-    if: ${{ vars.ALTAI_APP_DISPATCH_ENABLED != 'false' }}
+    # with `contents:write` on altaidevorg/altai-app. Opt in via repo variable
+    # ALTAI_APP_DISPATCH_ENABLED=true; skip when unset/false.
+    if: ${{ vars.ALTAI_APP_DISPATCH_ENABLED == 'true' }}
     steps:
       - name: Dispatch isanagent-released to altai-app
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,5 +139,8 @@ After implementing a feature, follow this exact workflow to deliver high-quality
 3. Run `cargo fmt` so that it's always well-formatted, avoiding unnecessary diffs that simply come from formatting.
 4. This is a living document --keep this document up-to-date as you introduce new features and/or architectures.
 
+## Releases & ALTAI sync
+Pushing to `main` runs `.github/workflows/release-artifacts.yml`, which publishes rolling tag **`main-latest`** binaries. After that release job, an optional **`notify-altai-app`** step dispatches `isanagent-released` to `altaidevorg/altai-app` when secret `ALTAI_APP_DISPATCH_TOKEN` is set (cross-repo PAT). ALTAI also refreshes the crate from `branch = "main"` on every local/CI/release build via `cargo update -p isanagent`.
+
 ## Note for Windows
 On windows, building the project in debug mode causes a PDB-related linker error. Build the project in release mode on Windows instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ After implementing a feature, follow this exact workflow to deliver high-quality
 4. This is a living document --keep this document up-to-date as you introduce new features and/or architectures.
 
 ## Releases & ALTAI sync
-Pushing to `main` runs `.github/workflows/release-artifacts.yml`, which publishes rolling tag **`main-latest`** binaries. After that release job, an optional **`notify-altai-app`** step dispatches `isanagent-released` to `altaidevorg/altai-app` when secret `ALTAI_APP_DISPATCH_TOKEN` is set (cross-repo PAT). ALTAI also refreshes the crate from `branch = "main"` on every local/CI/release build via `cargo update -p isanagent`.
+Pushing to `main` runs `.github/workflows/release-artifacts.yml`, which publishes rolling tag **`main-latest`** binaries. After that release job, an optional **`notify-altai-app`** step runs only when repo variable `ALTAI_APP_DISPATCH_ENABLED=true`, and dispatches `isanagent-released` to `altaidevorg/altai-app` when secret `ALTAI_APP_DISPATCH_TOKEN` is set (cross-repo PAT). ALTAI also refreshes the crate from `branch = "main"` on every local/CI/release build via `cargo update -p isanagent`.
 
 ## Note for Windows
 On windows, building the project in debug mode causes a PDB-related linker error. Build the project in release mode on Windows instead.


### PR DESCRIPTION
## Summary
- After the \`main-latest\` release job, dispatch \`isanagent-released\` to \`altaidevorg/altai-app\` when secret \`ALTAI_APP_DISPATCH_TOKEN\` is set
- Document the ALTAI sync contract in \`AGENTS.md\`

Skips quietly without the token (daily sync + \`cargo update\` on ALTAI still apply).

## Test plan
- [ ] Workflow YAML validates
- [ ] With token unset: notify job exits 0 and prints skip message
- [ ] With token set: altai-app \`Sync İsanAgent\` workflow starts via \`repository_dispatch\`

Made with [Cursor](https://cursor.com)