### PR TITLE
feat: expose reusable host entry point

### DIFF
--- a/src/channels/terminal.rs
+++ b/src/channels/terminal.rs
@@ -533,6 +533,8 @@ pub struct TerminalChannelConfig {
     pub status_model: String,
     pub memory_node: NodeHandle<MemoryMessage>,
     pub providers: std::collections::HashMap<String, crate::config::ProviderConfig>,
+    /// Whether the TUI should render ANSI foreground colors.
+    pub color_enabled: bool,
 }
 
 /// Stdin/stdout terminal: always Ratatui (alternate screen). Requires an interactive TTY.
@@ -553,6 +555,7 @@ pub struct TerminalChannel {
     outbound_ui_tx: Arc<Mutex<Option<std::sync::mpsc::Sender<OutboundMessage>>>>,
     /// Named alternative providers for `/model` switching.
     providers: std::collections::HashMap<String, crate::config::ProviderConfig>,
+    color_enabled: bool,
 }
 
 impl TerminalChannel {
@@ -567,6 +570,7 @@ impl TerminalChannel {
             memory_node: config.memory_node,
             outbound_ui_tx: Arc::new(Mutex::new(None)),
             providers: config.providers,
+            color_enabled: config.color_enabled,
         }
     }
 }
@@ -616,6 +620,7 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
         let sandbox_clone = sandbox_dir.clone();
         let log_clone = logger_tx.clone();
         let memory_node_clone = self.memory_node.clone();
+        let color_enabled = self.color_enabled;
 
         let opening_banner = format!(
             "ALTAI isanagent v{} — thread {}\n\
@@ -640,6 +645,7 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
                         status_model,
                         memory_node: memory_node_clone,
                         providers: providers_clone,
+                        color_enabled,
                     },
                 );
                 if let Ok(mut g) = bridge.lock() {

--- a/src/channels/terminal.rs
+++ b/src/channels/terminal.rs
@@ -535,6 +535,8 @@ pub struct TerminalChannelConfig {
     pub providers: std::collections::HashMap<String, crate::config::ProviderConfig>,
     /// Whether the TUI should render ANSI foreground colors.
     pub color_enabled: bool,
+    /// Load the configured chat's persisted transcript before accepting input.
+    pub resume_session: bool,
 }
 
 /// Stdin/stdout terminal: always Ratatui (alternate screen). Requires an interactive TTY.
@@ -556,6 +558,7 @@ pub struct TerminalChannel {
     /// Named alternative providers for `/model` switching.
     providers: std::collections::HashMap<String, crate::config::ProviderConfig>,
     color_enabled: bool,
+    resume_session: bool,
 }
 
 impl TerminalChannel {
@@ -571,6 +574,7 @@ impl TerminalChannel {
             outbound_ui_tx: Arc::new(Mutex::new(None)),
             providers: config.providers,
             color_enabled: config.color_enabled,
+            resume_session: config.resume_session,
         }
     }
 }
@@ -621,6 +625,7 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
         let log_clone = logger_tx.clone();
         let memory_node_clone = self.memory_node.clone();
         let color_enabled = self.color_enabled;
+        let resume_session = self.resume_session;
 
         let opening_banner = format!(
             "ALTAI isanagent v{} — thread {}\n\
@@ -646,6 +651,7 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
                         memory_node: memory_node_clone,
                         providers: providers_clone,
                         color_enabled,
+                        resume_session,
                     },
                 );
                 if let Ok(mut g) = bridge.lock() {

--- a/src/channels/terminal.rs
+++ b/src/channels/terminal.rs
@@ -1,4 +1,4 @@
-use crate::bus::{BusMessage, LogEvent, OutboundMessage};
+use crate::bus::{BusMessage, InboundMessage, LogEvent, OutboundMessage};
 use crate::channels::Channel;
 use crate::config::AppConfig;
 use crate::logging::LoggerHandle;
@@ -539,6 +539,13 @@ pub struct TerminalChannelConfig {
     pub resume_session: bool,
     /// File references composed into the first user message.
     pub initial_files: Vec<PathBuf>,
+    pub mode: TerminalMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalMode {
+    Tui,
+    Line,
 }
 
 /// Stdin/stdout terminal: always Ratatui (alternate screen). Requires an interactive TTY.
@@ -562,6 +569,7 @@ pub struct TerminalChannel {
     color_enabled: bool,
     resume_session: bool,
     initial_files: Vec<PathBuf>,
+    mode: TerminalMode,
 }
 
 impl TerminalChannel {
@@ -579,6 +587,7 @@ impl TerminalChannel {
             color_enabled: config.color_enabled,
             resume_session: config.resume_session,
             initial_files: config.initial_files,
+            mode: config.mode,
         }
     }
 }
@@ -601,6 +610,49 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
         }
 
         let channel_name = self.name().to_string();
+        if self.mode == TerminalMode::Line {
+            let (tx, rx) = std::sync::mpsc::channel::<OutboundMessage>();
+            *self
+                .outbound_ui_tx
+                .lock()
+                .map_err(|_| "terminal outbound bridge poisoned".to_string())? = Some(tx);
+            let chat_id = self.chat_id.clone();
+            let shutdown = self.shutdown_tx.clone();
+            std::thread::spawn(move || {
+                for message in rx {
+                    println!("{}", message.content);
+                }
+            });
+            std::thread::spawn(move || {
+                use std::io::BufRead;
+                println!("ALTAI line mode. Type /exit to quit.");
+                for line in std::io::stdin().lock().lines() {
+                    let Ok(content) = line else { break };
+                    if matches!(content.trim(), "/exit" | "/quit") {
+                        let _ = shutdown.send(());
+                        break;
+                    }
+                    if content.trim().is_empty() {
+                        continue;
+                    }
+                    if bus_tx
+                        .blocking_send(BusMessage::Inbound(InboundMessage {
+                            channel: "terminal".into(),
+                            sender_id: "local_user".into(),
+                            chat_id: chat_id.clone(),
+                            thread_id: None,
+                            content,
+                            attachments: Vec::new(),
+                            metadata: Default::default(),
+                        }))
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            });
+            return Ok(());
+        }
         let chat_id_clone = self.chat_id.clone();
         let status_model = self.status_model.clone();
         let logger_tx = self.logger_tx.clone();

--- a/src/channels/terminal.rs
+++ b/src/channels/terminal.rs
@@ -537,6 +537,8 @@ pub struct TerminalChannelConfig {
     pub color_enabled: bool,
     /// Load the configured chat's persisted transcript before accepting input.
     pub resume_session: bool,
+    /// File references composed into the first user message.
+    pub initial_files: Vec<PathBuf>,
 }
 
 /// Stdin/stdout terminal: always Ratatui (alternate screen). Requires an interactive TTY.
@@ -559,6 +561,7 @@ pub struct TerminalChannel {
     providers: std::collections::HashMap<String, crate::config::ProviderConfig>,
     color_enabled: bool,
     resume_session: bool,
+    initial_files: Vec<PathBuf>,
 }
 
 impl TerminalChannel {
@@ -575,6 +578,7 @@ impl TerminalChannel {
             providers: config.providers,
             color_enabled: config.color_enabled,
             resume_session: config.resume_session,
+            initial_files: config.initial_files,
         }
     }
 }
@@ -626,6 +630,7 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
         let memory_node_clone = self.memory_node.clone();
         let color_enabled = self.color_enabled;
         let resume_session = self.resume_session;
+        let initial_files = self.initial_files.clone();
 
         let opening_banner = format!(
             "ALTAI isanagent v{} — thread {}\n\
@@ -652,6 +657,7 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
                         providers: providers_clone,
                         color_enabled,
                         resume_session,
+                        initial_files,
                     },
                 );
                 if let Ok(mut g) = bridge.lock() {

--- a/src/channels/terminal_ui/mod.rs
+++ b/src/channels/terminal_ui/mod.rs
@@ -20,7 +20,7 @@ pub use app::{
     TerminalUiFocus, TerminalUiMode, ToastKind, ToolNoticePhase, ToolRailEntry,
     TranscriptSelection,
 };
-pub use theme::{init_from_env, uses_ansi_color, Theme};
+pub use theme::{init, init_from_env, uses_ansi_color, Theme};
 
 pub(crate) use attachments::parse_terminal_attachments;
 pub(crate) use run::{run_ratatui_main, RatatuiMainConfig};

--- a/src/channels/terminal_ui/run.rs
+++ b/src/channels/terminal_ui/run.rs
@@ -1297,6 +1297,8 @@ pub(crate) struct RatatuiMainConfig {
     pub providers: std::collections::HashMap<String, crate::config::ProviderConfig>,
     /// Whether the host permits ANSI foreground colors for this session.
     pub color_enabled: bool,
+    /// Whether `chat_id` names a persisted chat that should be loaded.
+    pub resume_session: bool,
 }
 
 /// Run until user quits. Restores terminal on exit.
@@ -1314,6 +1316,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
         memory_node,
         providers,
         color_enabled,
+        resume_session,
     } = config;
 
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -1349,6 +1352,23 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
     app.cells.push(Cell::System {
         message: opening_banner,
     });
+    if resume_session {
+        match load_thread_transcript_cells(&rt, &memory_node, &chat_id) {
+            Ok(mut cells) => {
+                let sid = &chat_id[..8.min(chat_id.len())];
+                cells.insert(
+                    0,
+                    Cell::System {
+                        message: format!("Resumed session {sid}… — loaded from workspace memory."),
+                    },
+                );
+                app.cells = cells;
+            }
+            Err(error) => app.cells.push(Cell::System {
+                message: format!("Could not load session history: {error}"),
+            }),
+        }
+    }
 
     sync_terminal_session_chat(&bus_tx, &chat_id);
     refresh_conversations_list(&rt, &memory_node, &mut app);

--- a/src/channels/terminal_ui/run.rs
+++ b/src/channels/terminal_ui/run.rs
@@ -42,7 +42,7 @@ use crate::channels::terminal_ui::protocol::{
 };
 use crate::channels::terminal_ui::text_format::truncate_chars_display;
 use crate::channels::terminal_ui::{
-    execution_browser, init_from_env, uses_ansi_color, AgentTaskStatus, App, Cell, JobStripStatus,
+    execution_browser, init, uses_ansi_color, AgentTaskStatus, App, Cell, JobStripStatus,
     ModelSelector, TerminalUiFocus, Theme, ToastKind, ToolNoticePhase, ToolRailEntry,
     TranscriptSelection,
 };
@@ -1295,6 +1295,8 @@ pub(crate) struct RatatuiMainConfig {
     pub memory_node: NodeHandle<MemoryMessage>,
     /// Named alternative providers for `/model` switching.
     pub providers: std::collections::HashMap<String, crate::config::ProviderConfig>,
+    /// Whether the host permits ANSI foreground colors for this session.
+    pub color_enabled: bool,
 }
 
 /// Run until user quits. Restores terminal on exit.
@@ -1311,6 +1313,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
         status_model,
         memory_node,
         providers,
+        color_enabled,
     } = config;
 
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -1318,7 +1321,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
         .build()
         .map_err(io::Error::other)?;
 
-    init_from_env();
+    init(color_enabled);
 
     let mut stdout = stdout();
     enable_raw_mode()?;

--- a/src/channels/terminal_ui/run.rs
+++ b/src/channels/terminal_ui/run.rs
@@ -1299,6 +1299,8 @@ pub(crate) struct RatatuiMainConfig {
     pub color_enabled: bool,
     /// Whether `chat_id` names a persisted chat that should be loaded.
     pub resume_session: bool,
+    /// File references composed into the first user message.
+    pub initial_files: Vec<PathBuf>,
 }
 
 /// Run until user quits. Restores terminal on exit.
@@ -1317,6 +1319,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
         providers,
         color_enabled,
         resume_session,
+        initial_files,
     } = config;
 
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -1352,6 +1355,19 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
     app.cells.push(Cell::System {
         message: opening_banner,
     });
+    if !initial_files.is_empty() {
+        let refs = initial_files
+            .iter()
+            .map(|path| format!("@{}", path.display()))
+            .collect::<Vec<_>>()
+            .join(" ");
+        app.input = format!("{refs} ");
+        app.cursor = app.input.len();
+        app.cells.push(Cell::System {
+            message: "Attached file references were added to the composer for the next message."
+                .into(),
+        });
+    }
     if resume_session {
         match load_thread_transcript_cells(&rt, &memory_node, &chat_id) {
             Ok(mut cells) => {

--- a/src/channels/terminal_ui/theme.rs
+++ b/src/channels/terminal_ui/theme.rs
@@ -12,6 +12,11 @@ pub fn init_from_env() {
         std::env::var_os("NO_COLOR"),
         Some(s) if !s.is_empty()
     );
+    init(allow);
+}
+
+/// Set the color capability chosen by an embedding host for this TUI session.
+pub fn init(allow: bool) {
     USE_ANSI_COLOR.store(allow, Ordering::Relaxed);
 }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -89,6 +89,8 @@ pub struct HostConfig {
     pub no_color: bool,
     /// Existing terminal chat identifier to load on startup.
     pub resume: Option<String>,
+    /// Files preloaded into the terminal's next composed message.
+    pub files: Vec<PathBuf>,
 }
 
 /// Interactive permission modes exposed to embedding hosts.
@@ -867,6 +869,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             },
             color_enabled: !config.no_color,
             resume_session: config.resume.is_some(),
+            initial_files: config.files.clone(),
         }));
         terminal.start(bus_tx.clone()).await?;
         out_channels.insert(terminal.name().to_string(), terminal);
@@ -1655,6 +1658,7 @@ mod tests {
         assert!(config.permission.is_none());
         assert!(!config.no_color);
         assert!(config.resume.is_none());
+        assert!(config.files.is_empty());
     }
 
     #[test]
@@ -1740,6 +1744,7 @@ mod tests {
             permission: None,
             no_color: false,
             resume: None,
+            files: Vec::new(),
         });
         assert_eq!(host.next_event().await, Some(HostEvent::Starting));
         assert!(host.shutdown());

--- a/src/host.rs
+++ b/src/host.rs
@@ -16,7 +16,7 @@ use crate::bus::{BusMessage, InboundMessage, LoggerControlMessage, TelemetryEven
 use crate::channels::terminal::{
     build_agent_thought_terminal_notice, build_tool_call_terminal_notice,
     build_tool_progress_terminal_notice, build_tool_result_terminal_notice,
-    terminal_startup_suppresses_plain_banner, TerminalChannelConfig,
+    terminal_startup_suppresses_plain_banner, TerminalChannelConfig, TerminalMode,
 };
 use crate::channels::{
     api::ApiChannel, email::EmailChannel, slack::SlackChannel, terminal::TerminalChannel, Channel,
@@ -91,6 +91,7 @@ pub struct HostConfig {
     pub resume: Option<String>,
     /// Files preloaded into the terminal's next composed message.
     pub files: Vec<PathBuf>,
+    pub line_mode: bool,
 }
 
 /// Interactive permission modes exposed to embedding hosts.
@@ -870,6 +871,11 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             color_enabled: !config.no_color,
             resume_session: config.resume.is_some(),
             initial_files: config.files.clone(),
+            mode: if config.line_mode {
+                TerminalMode::Line
+            } else {
+                TerminalMode::Tui
+            },
         }));
         terminal.start(bus_tx.clone()).await?;
         out_channels.insert(terminal.name().to_string(), terminal);
@@ -1659,6 +1665,7 @@ mod tests {
         assert!(!config.no_color);
         assert!(config.resume.is_none());
         assert!(config.files.is_empty());
+        assert!(!config.line_mode);
     }
 
     #[test]
@@ -1745,6 +1752,7 @@ mod tests {
             no_color: false,
             resume: None,
             files: Vec::new(),
+            line_mode: false,
         });
         assert_eq!(host.next_event().await, Some(HostEvent::Starting));
         assert!(host.shutdown());

--- a/src/host.rs
+++ b/src/host.rs
@@ -83,6 +83,8 @@ pub struct HostConfig {
     /// Optional interactive shell and file-edit policy override selected by
     /// the host application.
     pub permission: Option<HostPermissionMode>,
+    /// Disable ANSI foreground colors while retaining terminal structure.
+    pub no_color: bool,
 }
 
 /// Interactive permission modes exposed to embedding hosts.
@@ -854,6 +856,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                 }
                 all_providers
             },
+            color_enabled: !config.no_color,
         }));
         terminal.start(bus_tx.clone()).await?;
         out_channels.insert(terminal.name().to_string(), terminal);
@@ -1617,6 +1620,7 @@ mod tests {
         assert!(config.sandbox.is_none());
         assert!(config.model.is_none());
         assert!(config.permission.is_none());
+        assert!(!config.no_color);
     }
 
     #[test]
@@ -1680,6 +1684,7 @@ mod tests {
             sandbox: None,
             model: None,
             permission: None,
+            no_color: false,
         });
         assert_eq!(host.next_event().await, Some(HostEvent::Starting));
         assert!(host.shutdown());

--- a/src/host.rs
+++ b/src/host.rs
@@ -85,6 +85,8 @@ pub struct HostConfig {
     pub permission: Option<HostPermissionMode>,
     /// Disable ANSI foreground colors while retaining terminal structure.
     pub no_color: bool,
+    /// Existing terminal chat identifier to load on startup.
+    pub resume: Option<String>,
 }
 
 /// Interactive permission modes exposed to embedding hosts.
@@ -837,7 +839,12 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     let active_terminal_session_chat: Arc<RwLock<String>> = Arc::new(RwLock::new(String::new()));
 
     let terminal_chat_id = if workspace.config.terminal_enabled() {
-        let id = uuid::Uuid::new_v4().to_string();
+        let id = config
+            .resume
+            .as_deref()
+            .filter(|id| !id.trim().is_empty())
+            .map(str::to_owned)
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         *active_terminal_session_chat.write().await = id.clone();
         let terminal = Arc::new(TerminalChannel::new(TerminalChannelConfig {
             chat_id: id.clone(),
@@ -857,6 +864,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                 all_providers
             },
             color_enabled: !config.no_color,
+            resume_session: config.resume.is_some(),
         }));
         terminal.start(bus_tx.clone()).await?;
         out_channels.insert(terminal.name().to_string(), terminal);
@@ -1621,6 +1629,7 @@ mod tests {
         assert!(config.model.is_none());
         assert!(config.permission.is_none());
         assert!(!config.no_color);
+        assert!(config.resume.is_none());
     }
 
     #[test]
@@ -1685,6 +1694,7 @@ mod tests {
             model: None,
             permission: None,
             no_color: false,
+            resume: None,
         });
         assert_eq!(host.next_event().await, Some(HostEvent::Starting));
         assert!(host.shutdown());

--- a/src/host.rs
+++ b/src/host.rs
@@ -80,6 +80,8 @@ pub struct HostConfig {
     pub sandbox: Option<PathBuf>,
     /// Optional `provider/model` or model-only override selected by the host.
     pub model: Option<String>,
+    /// Optional provider/model used after the primary provider is exhausted.
+    pub fallback_model: Option<String>,
     /// Optional interactive shell and file-edit policy override selected by
     /// the host application.
     pub permission: Option<HostPermissionMode>,
@@ -1289,6 +1291,28 @@ fn apply_host_overrides(config: &mut AppConfig, host: &HostConfig) -> Result<(),
         }
     }
 
+    if let Some(model) = host.fallback_model.as_deref() {
+        let model = model.trim();
+        if model.is_empty() {
+            return Err("fallback model override cannot be empty".to_string());
+        }
+        let mut fallback = config.provider.clone().unwrap_or_default();
+        if let Some((provider_name, model_name)) = model.split_once('/') {
+            if provider_name.is_empty() || model_name.is_empty() {
+                return Err(format!("invalid fallback provider/model override: {model}"));
+            }
+            fallback.provider_name = provider_name.to_string();
+            fallback.model_name = model_name.to_string();
+            fallback.api_key_env.clear();
+        } else {
+            fallback.model_name = model.to_string();
+        }
+        config
+            .providers
+            .get_or_insert_with(Default::default)
+            .insert("__altai_cli_fallback".to_string(), fallback);
+    }
+
     if let Some(permission) = host.permission {
         let shell_policy = config
             .harness
@@ -1627,6 +1651,7 @@ mod tests {
         assert!(config.config.is_none());
         assert!(config.sandbox.is_none());
         assert!(config.model.is_none());
+        assert!(config.fallback_model.is_none());
         assert!(config.permission.is_none());
         assert!(!config.no_color);
         assert!(config.resume.is_none());
@@ -1677,6 +1702,25 @@ mod tests {
         }
     }
 
+    #[test]
+    fn host_fallback_override_registers_a_failover_provider() {
+        let mut config = AppConfig::default();
+        apply_host_overrides(
+            &mut config,
+            &HostConfig {
+                fallback_model: Some("openai/gpt-test".to_string()),
+                ..HostConfig::default()
+            },
+        )
+        .expect("valid fallback override");
+        let fallback = config
+            .providers
+            .and_then(|providers| providers.get("__altai_cli_fallback").cloned())
+            .expect("fallback provider");
+        assert_eq!(fallback.provider_name, "openai");
+        assert_eq!(fallback.model_name, "gpt-test");
+    }
+
     #[tokio::test]
     async fn spawned_host_accepts_an_external_graceful_shutdown() {
         let temp = tempfile::tempdir().expect("temporary workspace");
@@ -1692,6 +1736,7 @@ mod tests {
             config: Some(config_path),
             sandbox: None,
             model: None,
+            fallback_model: None,
             permission: None,
             no_color: false,
             resume: None,

--- a/src/host.rs
+++ b/src/host.rs
@@ -70,8 +70,13 @@ const EXECUTION_HARNESS_SYSTEM_GUIDANCE: &str = r#"
 
 #[derive(Debug, Clone, Default)]
 pub struct HostConfig {
+    /// Durable IsanAgent state directory.
     pub workspace: Option<PathBuf>,
+    /// Path to the IsanAgent TOML configuration file.
     pub config: Option<PathBuf>,
+    /// Project directory exposed to tools. Defaults to IsanAgent's own
+    /// workspace sandbox for backward compatibility.
+    pub sandbox: Option<PathBuf>,
 }
 
 pub type HostError = Box<dyn std::error::Error + Send + Sync>;
@@ -166,6 +171,7 @@ async fn run_host(
         .config
         .as_ref()
         .map(|path| path.to_string_lossy().to_string());
+    let sandbox = config.sandbox.as_deref();
     let workspace_dir = resolve_workspace_root(workspace_arg.as_deref());
 
     let (logger_bus_tx, logger_bus_rx) = create_logger_channel(LOGGER_QUEUE_CAPACITY);
@@ -205,7 +211,11 @@ async fn run_host(
     println!("Starting Advanced isanagent System...");
     log::info!("Starting Advanced isanagent System.");
 
-    let workspace = IsanagentWorkspace::new(workspace_arg.as_deref(), config_arg.as_deref())?;
+    let workspace = IsanagentWorkspace::new_with_sandbox(
+        workspace_arg.as_deref(),
+        config_arg.as_deref(),
+        sandbox,
+    )?;
     println!("Loading isanagent workspace at: {:?}", workspace.dir);
     log::info!("Loading isanagent workspace at {:?}", workspace.dir);
 
@@ -1547,6 +1557,7 @@ mod tests {
         let config = HostConfig::default();
         assert!(config.workspace.is_none());
         assert!(config.config.is_none());
+        assert!(config.sandbox.is_none());
     }
 
     #[tokio::test]
@@ -1562,6 +1573,7 @@ mod tests {
         let mut host = spawn_host(HostConfig {
             workspace: Some(temp.path().to_path_buf()),
             config: Some(config_path),
+            sandbox: None,
         });
         assert_eq!(host.next_event().await, Some(HostEvent::Starting));
         assert!(host.shutdown());

--- a/src/host.rs
+++ b/src/host.rs
@@ -74,10 +74,90 @@ pub struct HostConfig {
     pub config: Option<PathBuf>,
 }
 
-pub type HostResult<T> = Result<T, Box<dyn std::error::Error>>;
+pub type HostError = Box<dyn std::error::Error + Send + Sync>;
+pub type HostResult<T> = Result<T, HostError>;
+
+/// Lifecycle events emitted by a host started through [`spawn_host`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostEvent {
+    /// The host task has been scheduled and is beginning runtime setup.
+    Starting,
+    /// The host task exited normally or with an error.
+    Stopped { outcome: HostExit },
+}
+
+/// The terminal state of a spawned host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostExit {
+    Completed,
+    Failed(String),
+}
+
+/// A running IsanAgent host with explicit lifecycle observation and shutdown.
+pub struct HostHandle {
+    shutdown_tx: mpsc::UnboundedSender<()>,
+    events: mpsc::UnboundedReceiver<HostEvent>,
+    task: tokio::task::JoinHandle<HostResult<()>>,
+}
+
+impl HostHandle {
+    /// Request graceful host shutdown. Returns false only when the host task
+    /// has already stopped accepting control messages.
+    pub fn shutdown(&self) -> bool {
+        self.shutdown_tx.send(()).is_ok()
+    }
+
+    /// Receive the next lifecycle event, or `None` once the host task closes
+    /// its event stream.
+    pub async fn next_event(&mut self) -> Option<HostEvent> {
+        self.events.recv().await
+    }
+
+    /// Wait for the complete host shutdown sequence and surface any startup or
+    /// runtime error from the embedded host.
+    pub async fn wait(self) -> HostResult<()> {
+        self.task
+            .await
+            .map_err(|error| Box::new(error) as HostError)?
+    }
+}
+
+/// Spawn the complete IsanAgent runtime and return explicit lifecycle control.
+///
+/// This is the embedding entry point for applications such as ALTAI. The
+/// existing [`start_host`] function remains available for callers that simply
+/// want to await the host until it exits.
+pub fn spawn_host(config: HostConfig) -> HostHandle {
+    let (shutdown_tx, shutdown_rx) = mpsc::unbounded_channel();
+    let (events_tx, events) = mpsc::unbounded_channel();
+    let task = tokio::spawn(async move {
+        let _ = events_tx.send(HostEvent::Starting);
+        let result = run_host(config, Some(shutdown_rx)).await;
+        let outcome = match &result {
+            Ok(()) => HostExit::Completed,
+            Err(error) => HostExit::Failed(error.to_string()),
+        };
+        let _ = events_tx.send(HostEvent::Stopped { outcome });
+        result
+    });
+
+    HostHandle {
+        shutdown_tx,
+        events,
+        task,
+    }
+}
+
 /// Start the complete IsanAgent runtime, including its terminal channel when
 /// enabled by the selected configuration.
 pub async fn start_host(config: HostConfig) -> HostResult<()> {
+    run_host(config, None).await
+}
+
+async fn run_host(
+    config: HostConfig,
+    mut external_shutdown_rx: Option<mpsc::UnboundedReceiver<()>>,
+) -> HostResult<()> {
     let workspace_arg = config
         .workspace
         .as_ref()
@@ -1103,6 +1183,9 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         _ = shutdown_rx.recv() => {
             log::info!("Shutdown requested (terminal /exit or internal signal).");
         }
+        _ = wait_for_external_shutdown(&mut external_shutdown_rx) => {
+            log::info!("Shutdown requested by embedded host controller.");
+        }
         _ = tokio::signal::ctrl_c() => {
             log::info!("Shutdown requested via Ctrl+C.");
         }
@@ -1145,6 +1228,15 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     }
 
     Ok(())
+}
+
+async fn wait_for_external_shutdown(receiver: &mut Option<mpsc::UnboundedReceiver<()>>) {
+    match receiver {
+        Some(receiver) => {
+            let _ = receiver.recv().await;
+        }
+        None => std::future::pending::<()>().await,
+    }
 }
 
 async fn maybe_prompt_uv_install_on_launch(workspace: &IsanagentWorkspace) {
@@ -1448,11 +1540,44 @@ venv is touched."
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[test]
     fn host_config_defaults_to_the_existing_workspace_resolution() {
         let config = HostConfig::default();
         assert!(config.workspace.is_none());
         assert!(config.config.is_none());
+    }
+
+    #[tokio::test]
+    async fn spawned_host_accepts_an_external_graceful_shutdown() {
+        let temp = tempfile::tempdir().expect("temporary workspace");
+        let config_path = temp.path().join("config.toml");
+        fs::write(
+            &config_path,
+            "[terminal]\nenabled = false\n\n[api]\nenabled = true\nport = 0\n",
+        )
+        .expect("headless config");
+
+        let mut host = spawn_host(HostConfig {
+            workspace: Some(temp.path().to_path_buf()),
+            config: Some(config_path),
+        });
+        assert_eq!(host.next_event().await, Some(HostEvent::Starting));
+        assert!(host.shutdown());
+
+        let stopped = tokio::time::timeout(Duration::from_secs(10), host.next_event())
+            .await
+            .expect("host should stop promptly");
+        assert_eq!(
+            stopped,
+            Some(HostEvent::Stopped {
+                outcome: HostExit::Completed
+            })
+        );
+        tokio::time::timeout(Duration::from_secs(10), host.wait())
+            .await
+            .expect("host task should join")
+            .expect("host should complete cleanly");
     }
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -22,6 +22,7 @@ use crate::channels::{
     api::ApiChannel, email::EmailChannel, slack::SlackChannel, terminal::TerminalChannel, Channel,
 };
 use crate::clarification::ClarificationHub;
+use crate::config::{AppConfig, HarnessConfig, ProviderConfig, ShellPolicyConfig};
 use crate::execution::{ExecutionJobManager, InflightSyncRegistry};
 use crate::logging::{
     create_logger_channel, create_logging_actor_or_fallback, init_runtime_logger,
@@ -77,6 +78,20 @@ pub struct HostConfig {
     /// Project directory exposed to tools. Defaults to IsanAgent's own
     /// workspace sandbox for backward compatibility.
     pub sandbox: Option<PathBuf>,
+    /// Optional `provider/model` or model-only override selected by the host.
+    pub model: Option<String>,
+    /// Optional interactive shell and file-edit policy override selected by
+    /// the host application.
+    pub permission: Option<HostPermissionMode>,
+}
+
+/// Interactive permission modes exposed to embedding hosts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostPermissionMode {
+    Ask,
+    AutoEdit,
+    Plan,
+    Bypass,
 }
 
 pub type HostError = Box<dyn std::error::Error + Send + Sync>;
@@ -211,11 +226,12 @@ async fn run_host(
     println!("Starting Advanced isanagent System...");
     log::info!("Starting Advanced isanagent System.");
 
-    let workspace = IsanagentWorkspace::new_with_sandbox(
+    let mut workspace = IsanagentWorkspace::new_with_sandbox(
         workspace_arg.as_deref(),
         config_arg.as_deref(),
         sandbox,
     )?;
+    apply_host_overrides(&mut workspace.config, &config).map_err(std::io::Error::other)?;
     println!("Loading isanagent workspace at: {:?}", workspace.dir);
     log::info!("Loading isanagent workspace at {:?}", workspace.dir);
 
@@ -1240,6 +1256,47 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     Ok(())
 }
 
+fn apply_host_overrides(config: &mut AppConfig, host: &HostConfig) -> Result<(), String> {
+    if let Some(model) = host.model.as_deref() {
+        let model = model.trim();
+        if model.is_empty() {
+            return Err("model override cannot be empty".to_string());
+        }
+
+        let provider = config.provider.get_or_insert_with(ProviderConfig::default);
+        if let Some((provider_name, model_name)) = model.split_once('/') {
+            if provider_name.is_empty() || model_name.is_empty() || model_name.contains('/') {
+                return Err(format!("invalid provider/model override: {model}"));
+            }
+            provider.provider_name = provider_name.to_string();
+            provider.model_name = model_name.to_string();
+            // Let the provider's conventional key variable be inferred after
+            // changing provider family (for example ANTHROPIC_API_KEY).
+            provider.api_key_env.clear();
+        } else {
+            provider.model_name = model.to_string();
+        }
+    }
+
+    if let Some(permission) = host.permission {
+        let shell_policy = config
+            .harness
+            .get_or_insert_with(HarnessConfig::default)
+            .shell_policy
+            .get_or_insert_with(ShellPolicyConfig::default);
+        let (mode, edit_mode) = match permission {
+            HostPermissionMode::Ask => ("ask", "ask"),
+            HostPermissionMode::AutoEdit => ("ask", "allow"),
+            HostPermissionMode::Plan => ("deny", "deny"),
+            HostPermissionMode::Bypass => ("allow", "allow"),
+        };
+        shell_policy.mode = Some(mode.to_string());
+        shell_policy.edit_mode = Some(edit_mode.to_string());
+    }
+
+    Ok(())
+}
+
 async fn wait_for_external_shutdown(receiver: &mut Option<mpsc::UnboundedReceiver<()>>) {
     match receiver {
         Some(receiver) => {
@@ -1558,6 +1615,53 @@ mod tests {
         assert!(config.workspace.is_none());
         assert!(config.config.is_none());
         assert!(config.sandbox.is_none());
+        assert!(config.model.is_none());
+        assert!(config.permission.is_none());
+    }
+
+    #[test]
+    fn host_model_override_selects_provider_and_model() {
+        let mut config = AppConfig::default();
+        apply_host_overrides(
+            &mut config,
+            &HostConfig {
+                model: Some("anthropic/claude-test".to_string()),
+                ..HostConfig::default()
+            },
+        )
+        .expect("valid model override");
+
+        let provider = config.provider.expect("provider override");
+        assert_eq!(provider.provider_name, "anthropic");
+        assert_eq!(provider.model_name, "claude-test");
+        assert!(provider.api_key_env.is_empty());
+    }
+
+    #[test]
+    fn host_permission_modes_map_to_shell_and_edit_policy() {
+        for (permission, mode, edit_mode) in [
+            (HostPermissionMode::Ask, "ask", "ask"),
+            (HostPermissionMode::AutoEdit, "ask", "allow"),
+            (HostPermissionMode::Plan, "deny", "deny"),
+            (HostPermissionMode::Bypass, "allow", "allow"),
+        ] {
+            let mut config = AppConfig::default();
+            apply_host_overrides(
+                &mut config,
+                &HostConfig {
+                    permission: Some(permission),
+                    ..HostConfig::default()
+                },
+            )
+            .expect("valid permission override");
+
+            let policy = config
+                .harness
+                .and_then(|harness| harness.shell_policy)
+                .expect("shell policy override");
+            assert_eq!(policy.mode.as_deref(), Some(mode));
+            assert_eq!(policy.edit_mode.as_deref(), Some(edit_mode));
+        }
     }
 
     #[tokio::test]
@@ -1574,6 +1678,8 @@ mod tests {
             workspace: Some(temp.path().to_path_buf()),
             config: Some(config_path),
             sandbox: None,
+            model: None,
+            permission: None,
         });
         assert_eq!(host.next_event().await, Some(HostEvent::Starting));
         assert!(host.shutdown());

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,63 +1,59 @@
+//! Public host entry point for embedding the full IsanAgent runtime.
+//!
+//! This module owns the same runtime construction that powers the isanagent
+//! binary. Embedders can now start that runtime without spawning a second
+//! process.
+
 use std::collections::HashMap;
 use std::io::{self, IsTerminal, Write};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, watch, RwLock};
 
-use clap::{Args as ClapArgs, Parser, Subcommand};
-use colored::Colorize;
-use isanagent::agent::{AgentLogic, AgentLogicParams};
-use isanagent::bus::{BusMessage, InboundMessage, LoggerControlMessage, TelemetryEvent};
-use isanagent::channels::terminal::{
+use crate::agent::{AgentLogic, AgentLogicParams};
+use crate::bus::{BusMessage, InboundMessage, LoggerControlMessage, TelemetryEvent};
+use crate::channels::terminal::{
     build_agent_thought_terminal_notice, build_tool_call_terminal_notice,
     build_tool_progress_terminal_notice, build_tool_result_terminal_notice,
     terminal_startup_suppresses_plain_banner, TerminalChannelConfig,
 };
-use isanagent::channels::{
+use crate::channels::{
     api::ApiChannel, email::EmailChannel, slack::SlackChannel, terminal::TerminalChannel, Channel,
 };
-use isanagent::clarification::ClarificationHub;
-use isanagent::execution::ExecutionJobManager;
-use isanagent::execution::InflightSyncRegistry;
-use isanagent::logging::{
+use crate::clarification::ClarificationHub;
+use crate::execution::{ExecutionJobManager, InflightSyncRegistry};
+use crate::logging::{
     create_logger_channel, create_logging_actor_or_fallback, init_runtime_logger,
     LOGGER_QUEUE_CAPACITY,
 };
-use isanagent::onboarding::{
-    build_interactive_config_toml, onboard_workspace, BootstrapReport, OnboardOptions,
-};
-use isanagent::onboarding_interactive;
-
-use isanagent::scheduler::{
+use crate::scheduler::{
     validate_multi_tenant_edge_runtime, CronActor, CronSchedulingMode, MultiTenantEdgeCronScheduler,
 };
-use isanagent::session::SessionManager;
-use isanagent::skills::SkillRegistry;
-use isanagent::tools::builtin::{
+use crate::session::SessionManager;
+use crate::skills::SkillRegistry;
+use crate::tools::builtin::{
     CronTool, EditFileTool, GetEnvTool, GitWorktreeTool, GlobFilesTool, ListDirTool, MessageTool,
     PythonRunTool, ReadFileTool, SearchTextTool, ShellExecTool, WebFetchTool, WebSearchTool,
     WriteFileTool,
 };
-use isanagent::tools::execution::{
+use crate::tools::execution::{
     ExecutionArtifactListTool, ExecutionCancelTool, ExecutionEnvInfoTool, ExecutionJobCancelTool,
     ExecutionJobListTool, ExecutionJobResultTool, ExecutionJobStatusTool,
     ExecutionRunBackgroundTool, ExecutionRunTool, ExecutionSessionCloseTool,
     ExecutionSessionCreateTool,
 };
-use isanagent::tools::ml_domain::{ArxivFetchTool, ArxivSearchTool, HfHubFileFetchTool};
-use isanagent::tools::workflow::{AskUserTool, TodoWriteTool, ToolSearchTool};
-use isanagent::tools::ToolRegistry;
-use isanagent::workspace::{resolve_workspace_root, IsanagentWorkspace};
-use isanagent::{NodeHandle, Supervisor, SupervisorPolicy};
+use crate::tools::ml_domain::{ArxivFetchTool, ArxivSearchTool, HfHubFileFetchTool};
+use crate::tools::workflow::{AskUserTool, TodoWriteTool, ToolSearchTool};
+use crate::tools::ToolRegistry;
+use crate::workspace::{resolve_workspace_root, IsanagentWorkspace};
+use crate::{NodeHandle, Supervisor, SupervisorPolicy};
+use colored::Colorize;
 
-// Fallback constants used only when `[provider]` is missing from `config.toml`. With auto-onboard
-// in place these are exercised mainly by tests / unusual configs; the URL is resolved through
-// `provider_registry::lookup` so the registry stays the single source of truth.
 const DEFAULT_PROVIDER_NAME: &str = "gemini";
 const DEFAULT_PROVIDER_MODEL_NAME: &str = "gemini-2.5-flash";
 const DEFAULT_PROVIDER_API_KEY_ENV: &str = "GEMINI_API_KEY";
 
-/// Appended to the workspace system prompt when the execution harness is enabled.
 const EXECUTION_HARNESS_SYSTEM_GUIDANCE: &str = r#"
 
 --- Execution harness ---
@@ -69,145 +65,27 @@ const EXECUTION_HARNESS_SYSTEM_GUIDANCE: &str = r#"
 - Prefer grep-friendly logging in training scripts (plain text lines) so stdout stays searchable in captured logs.
 - Know where outputs live: sandbox-relative paths, execution_artifact_list, run journals under workspace_dir/.system_generated/execution_history/, and execution_runs.jsonl.
 - For Jupyter/SSH: confirm interpreter and (if needed) GPU visibility with a tiny execution_run before a long job.
-- For **Google Colab**: use the **`colab-cli`** skill (invoke `colab` commands via `exec`) instead of `execution_run` with a built-in provider.
+- For Google Colab: use the colab-cli skill (invoke colab commands via exec) instead of execution_run with a built-in provider.
 "#;
 
-/// isanagent: A terminal chat interface and autonomous agent engine
-#[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
-struct Cli {
-    #[command(subcommand)]
-    command: Option<Commands>,
-
-    /// Optional explicit path to the workspace directory. Defaults to ~/.isanagent
-    #[arg(short, long)]
-    workspace: Option<String>,
-
-    /// Optional path to a config.toml file. Defaults to <workspace>/config.toml
-    #[arg(short, long)]
-    config: Option<String>,
+#[derive(Debug, Clone, Default)]
+pub struct HostConfig {
+    pub workspace: Option<PathBuf>,
+    pub config: Option<PathBuf>,
 }
 
-#[derive(Subcommand, Debug)]
-enum Commands {
-    /// Create workspace layout and starter files; optional flags override generated config.toml
-    Onboard(OnboardArgs),
-    /// Manage skills (add, list, etc.)
-    Skills(SkillsArgs),
-}
-
-#[derive(ClapArgs, Debug)]
-struct SkillsArgs {
-    #[command(subcommand)]
-    command: SkillCommands,
-}
-
-#[derive(Subcommand, Debug)]
-enum SkillCommands {
-    /// Add skills from a remote GitHub repository
-    Add {
-        /// Repository URL (e.g., https://github.com/vercel-labs/skills) or shorthand (owner/repo)
-        repo_url: String,
-        /// Optional specific skill name to install
-        #[arg(short, long)]
-        skill: Option<String>,
-    },
-    /// List all installed skills
-    List,
-}
-
-#[derive(ClapArgs, Debug)]
-struct OnboardArgs {
-    /// Optional explicit path to the workspace directory. Defaults to ~/.isanagent
-    #[arg(short, long)]
-    workspace: Option<String>,
-    /// Textual wizard (ratatui): provider → optional base URL → API key env var name → pick model from /models
-    #[arg(long)]
-    interactive: bool,
-    /// Override embedded defaults for `config.toml` (see `isanagent onboard --help`)
-    #[command(flatten)]
-    options: OnboardOptions,
-}
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cli = Cli::parse();
-
-    match cli.command {
-        Some(Commands::Onboard(args)) => run_onboard(cli.workspace, args).await,
-        Some(Commands::Skills(args)) => run_skills(cli.workspace, args).await,
-        None => {
-            // First-run UX: when the user invokes `isanagent` with no `--workspace` and the
-            // default `~/.isanagent` directory does not yet exist, auto-launch the interactive
-            // onboard wizard before starting the agent. Subsequent runs see the directory and
-            // skip straight to `run_isanagent`.
-            if cli.workspace.is_none() {
-                let default_root = resolve_workspace_root(None);
-                if !default_root.exists() {
-                    auto_onboard_then_run(cli.config).await?;
-                    return Ok(());
-                }
-            }
-            start_embedded_host(cli.workspace, cli.config).await
-        }
-    }
-}
-
-/// Runs the interactive onboard against the default workspace path then transitions into
-/// `run_isanagent` in the same invocation. Cancelling the wizard (Ctrl+C / Esc) returns
-/// `Ok(())` without launching the agent so the user can retry on the next run.
-async fn auto_onboard_then_run(
-    config_arg: Option<String>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Welcome to isanagent. No workspace detected at the default location.");
-    println!("Launching the interactive onboard wizard...");
-    println!();
-
-    let onboard_result = run_onboard_inner(
-        None,
-        OnboardArgs {
-            workspace: None,
-            interactive: true,
-            options: OnboardOptions::default(),
-        },
-        /* chained = */ true,
-    )
-    .await;
-
-    match onboard_result {
-        Ok(()) => {
-            println!();
-            println!("Workspace ready. Launching isanagent...");
-            println!();
-            start_embedded_host(None, config_arg).await
-        }
-        Err(e) => {
-            // The interactive wizard signalled abort (Ctrl+C / Esc) or a concrete failure.
-            // Surface the message and exit cleanly so the shell prompt returns; the user can
-            // re-run when ready.
-            eprintln!("Onboard did not complete: {e}");
-            eprintln!("Run `isanagent onboard --interactive` to try again.");
-            Ok(())
-        }
-    }
-}
-
-async fn start_embedded_host(
-    workspace_arg: Option<String>,
-    config_arg: Option<String>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    isanagent::host::start_host(isanagent::host::HostConfig {
-        workspace: workspace_arg.map(std::path::PathBuf::from),
-        config: config_arg.map(std::path::PathBuf::from),
-    })
-    .await
-}
-
-#[allow(dead_code)]
-async fn run_isanagent_legacy(
-    workspace_arg: Option<String>,
-    config_arg: Option<String>,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub type HostResult<T> = Result<T, Box<dyn std::error::Error>>;
+/// Start the complete IsanAgent runtime, including its terminal channel when
+/// enabled by the selected configuration.
+pub async fn start_host(config: HostConfig) -> HostResult<()> {
+    let workspace_arg = config
+        .workspace
+        .as_ref()
+        .map(|path| path.to_string_lossy().to_string());
+    let config_arg = config
+        .config
+        .as_ref()
+        .map(|path| path.to_string_lossy().to_string());
     let workspace_dir = resolve_workspace_root(workspace_arg.as_deref());
 
     let (logger_bus_tx, logger_bus_rx) = create_logger_channel(LOGGER_QUEUE_CAPACITY);
@@ -273,10 +151,10 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     let db_path_str = db_path
         .to_str()
         .ok_or_else(|| std::io::Error::other("workspace DB path is not valid UTF-8"))?;
-    let memory_actor = isanagent::memory::SqliteMemoryActor::new(db_path_str).map_err(|e| {
+    let memory_actor = crate::memory::SqliteMemoryActor::new(db_path_str).map_err(|e| {
         std::io::Error::other(format!("Failed to initialize SqliteMemoryActor: {}", e))
     })?;
-    let memory_node = NodeHandle::<isanagent::memory::MemoryMessage>::new(
+    let memory_node = NodeHandle::<crate::memory::MemoryMessage>::new(
         memory_actor,
         100,
         1,
@@ -311,7 +189,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             .unwrap_or(false);
         validate_multi_tenant_edge_runtime(api_enabled).map_err(std::io::Error::other)?;
 
-        let client = isanagent::multi_tenant_edge::CronRegistrationClient::from_env()
+        let client = crate::multi_tenant_edge::CronRegistrationClient::from_env()
             .map_err(std::io::Error::other)?;
         let scheduler = Arc::new(
             MultiTenantEdgeCronScheduler::new(db_path_str, client)
@@ -397,17 +275,16 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     if workspace.config.checkpoint_enabled() {
         // Backups live in the outer rim (never inside the agent's editable sandbox); restores are
         // confined to the sandbox when the file tools are workspace-restricted.
-        isanagent::checkpoint::init(
+        crate::checkpoint::init(
             workspace.dir.join(".system_generated").join("checkpoints"),
             restrict.then(|| workspace.sandbox_dir.clone()),
         );
-        tools.register(Box::new(isanagent::checkpoint::CheckpointTool));
+        tools.register(Box::new(crate::checkpoint::CheckpointTool));
     }
     let mut inflight_sync_outer: Option<Arc<InflightSyncRegistry>> = None;
-    let mut execution_harness_for_shutdown: Option<Arc<isanagent::execution::ExecutionHarness>> =
-        None;
+    let mut execution_harness_for_shutdown: Option<Arc<crate::execution::ExecutionHarness>> = None;
     if workspace.config.execution_harness_enabled() {
-        let harness = isanagent::execution::build_execution_harness(
+        let harness = crate::execution::build_execution_harness(
             workspace.dir.clone(),
             workspace.sandbox_dir.clone(),
             restrict,
@@ -443,12 +320,10 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             jobs: execution_jobs.clone(),
             max_tool_output_chars,
         }));
-        tools.register(Box::new(
-            isanagent::tools::execution::ExecutionReadLogTool {
-                jobs: execution_jobs.clone(),
-                harness: harness.clone(),
-            },
-        ));
+        tools.register(Box::new(crate::tools::execution::ExecutionReadLogTool {
+            jobs: execution_jobs.clone(),
+            harness: harness.clone(),
+        }));
         tools.register(Box::new(ExecutionJobListTool {
             jobs: execution_jobs.clone(),
         }));
@@ -505,19 +380,19 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     // PR-10: agent-triggered compaction. Tool posts a TriggerCompaction bus
     // message with `AgentSelf` reason; the agent processes it between turns
     // to respect the per-chat FIFO invariant (AGENTS.md).
-    tools.register(Box::new(isanagent::tools::compact::CompactContextTool {
+    tools.register(Box::new(crate::tools::compact::CompactContextTool {
         outbound_tx: global_outbound_tx.clone(),
     }));
     // PR-7: re-materialize tool results that were compacted out of the active
     // conversation. Reads the cache populated by `do_compaction`'s swap step.
-    tools.register(Box::new(isanagent::tools::recall::RecallToolResultTool {
+    tools.register(Box::new(crate::tools::recall::RecallToolResultTool {
         memory_node: memory_node.clone(),
         outbound_tx: global_outbound_tx.clone(),
     }));
-    tools.register(Box::new(isanagent::tools::builtin::SearchMemoryTool {
+    tools.register(Box::new(crate::tools::builtin::SearchMemoryTool {
         memory_node: memory_node.clone(),
     }));
-    tools.register(Box::new(isanagent::tools::builtin::FetchMemoryByDateTool {
+    tools.register(Box::new(crate::tools::builtin::FetchMemoryByDateTool {
         memory_node: memory_node.clone(),
     }));
 
@@ -525,14 +400,14 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         memory_node: memory_node.clone(),
     }));
     if workspace.config.kernel_porting_harness_enabled() {
-        isanagent::tools::kernel_porting::register_kernel_porting_tools(
+        crate::tools::kernel_porting::register_kernel_porting_tools(
             &mut tools,
             workspace.sandbox_dir.clone(),
             std::sync::Arc::new(workspace.config.clone()),
         );
     }
     if workspace.config.autotrainess_harness_enabled() {
-        isanagent::tools::autotrainess::register_autotrainess_tools(
+        crate::tools::autotrainess::register_autotrainess_tools(
             &mut tools,
             workspace.sandbox_dir.clone(),
             std::sync::Arc::new(workspace.config.clone()),
@@ -549,7 +424,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             .config
             .provider
             .clone()
-            .unwrap_or_else(|| isanagent::config::ProviderConfig {
+            .unwrap_or_else(|| crate::config::ProviderConfig {
                 provider_name: DEFAULT_PROVIDER_NAME.to_string(),
                 model_name: DEFAULT_PROVIDER_MODEL_NAME.to_string(),
                 models: None,
@@ -569,7 +444,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty());
 
-    let (provider_cfg, api_key): (Option<isanagent::config::ProviderConfig>, Option<String>) = {
+    let (provider_cfg, api_key): (Option<crate::config::ProviderConfig>, Option<String>) = {
         // 0. Try remembered last model choice
         let mut found_remembered = None;
         if let Some(ref key_name) = remembered_key {
@@ -587,7 +462,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             (Some(default_provider_cfg.clone()), Some(key))
         } else {
             // 2. Try any expanded [providers.*] entry
-            let mut found: Option<(isanagent::config::ProviderConfig, String)> = None;
+            let mut found: Option<(crate::config::ProviderConfig, String)> = None;
             for cfg in expanded_providers.values() {
                 if let Ok(key) = cfg.resolve_api_key() {
                     found = Some((cfg.clone(), key));
@@ -609,25 +484,23 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         .unwrap_or_else(|| "(no model)".to_string());
 
     let (provider, reflection_provider, fallback_providers): (
-        Box<dyn isanagent::traits::Provider>,
-        Box<dyn isanagent::traits::Provider>,
-        Vec<isanagent::agent::FallbackProviderSpec>,
+        Box<dyn crate::traits::Provider>,
+        Box<dyn crate::traits::Provider>,
+        Vec<crate::agent::FallbackProviderSpec>,
     ) = if let (Some(cfg), Some(key)) = (&provider_cfg, &api_key) {
         let base_url = cfg.resolved_base_url().map_err(std::io::Error::other)?;
-        let p1 =
-            isanagent::provider::create_provider(&cfg.provider_name, &base_url, key, &model_name);
-        let p2 =
-            isanagent::provider::create_provider(&cfg.provider_name, &base_url, key, &model_name);
+        let p1 = crate::provider::create_provider(&cfg.provider_name, &base_url, key, &model_name);
+        let p2 = crate::provider::create_provider(&cfg.provider_name, &base_url, key, &model_name);
 
         // Keep all configured providers as immutable candidates owned by this AgentLogic. Each run
         // filters its own primary by full (provider, base_url, model) identity while snapshotting,
         // so concurrent runs and `/model` switches cannot rewrite one another's fallback policy.
-        let candidates: Vec<isanagent::agent::FallbackProviderSpec> = expanded_providers
+        let candidates: Vec<crate::agent::FallbackProviderSpec> = expanded_providers
             .values()
             .filter_map(|fb_cfg| {
                 let fb_key = fb_cfg.resolve_api_key().ok()?;
                 let fb_base = fb_cfg.resolved_base_url().ok()?;
-                Some(isanagent::agent::FallbackProviderSpec {
+                Some(crate::agent::FallbackProviderSpec {
                     provider_name: fb_cfg.provider_name.clone(),
                     base_url: fb_base,
                     api_key: fb_key,
@@ -635,7 +508,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                 })
             })
             .collect();
-        let initial_fallbacks = isanagent::agent::build_fallback_specs(
+        let initial_fallbacks = crate::agent::build_fallback_specs(
             &cfg.provider_name,
             &base_url,
             &model_name,
@@ -665,26 +538,26 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         eprintln!("Or run `isanagent onboard` to create a config.toml, then replace \"<changethis>\" with your key.");
         eprintln!("Use /model at runtime to configure one.");
         (
-            Box::new(isanagent::provider::NoKeyProvider),
-            Box::new(isanagent::provider::NoKeyProvider),
+            Box::new(crate::provider::NoKeyProvider),
+            Box::new(crate::provider::NoKeyProvider),
             Vec::new(),
         )
     };
 
     let provider_credentials = if let (Some(cfg), Some(key)) = (&provider_cfg, &api_key) {
-        isanagent::provider::ProviderCredentials {
+        crate::provider::ProviderCredentials {
             provider_name: cfg.provider_name.clone(),
             base_url: cfg.resolved_base_url().unwrap_or_default(),
             api_key: key.clone(),
             model_name: model_name.clone(),
         }
     } else {
-        isanagent::provider::ProviderCredentials::empty()
+        crate::provider::ProviderCredentials::empty()
     };
 
     // 5.5 Setup Reflection Engine
     let memory_config = workspace.config.memory.clone().unwrap_or_default();
-    let reflection_engine = isanagent::reflection::ReflectionEngine::new(
+    let reflection_engine = crate::reflection::ReflectionEngine::new(
         memory_node.clone(),
         workspace.sandbox_dir.clone(),
         reflection_provider,
@@ -698,7 +571,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     let mut system_prompt = workspace.compile_system_prompt();
     if workspace.config.ml_engineer_harness_enabled() {
         system_prompt.push_str("\n\n");
-        system_prompt.push_str(isanagent::ml_engineer::HARNESS_OVERLAY);
+        system_prompt.push_str(crate::ml_engineer::HARNESS_OVERLAY);
     }
     if workspace.config.execution_harness_enabled() {
         system_prompt.push_str(EXECUTION_HARNESS_SYSTEM_GUIDANCE);
@@ -707,7 +580,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         format!(
             "{}\n{}",
             system_prompt,
-            isanagent::ml_engineer::SUBAGENT_RESEARCH_APPEND
+            crate::ml_engineer::SUBAGENT_RESEARCH_APPEND
         )
     } else {
         system_prompt.clone()
@@ -716,13 +589,13 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     let harness_runtime_summary = workspace.config.runtime_harness_summary_lines().join("\n");
     let forbid_final_without_tools = workspace.config.ml_engineer_forbid_final_without_tools();
     let shell_policy = workspace.config.resolved_shell_policy();
-    let default_harness = isanagent::config::HarnessConfig::default();
+    let default_harness = crate::config::HarnessConfig::default();
     let harness_ref = workspace
         .config
         .harness
         .as_ref()
         .unwrap_or(&default_harness);
-    let hook_tool_ctx = isanagent::hooks::ToolCallHookContext::from_harness_config(
+    let hook_tool_ctx = crate::hooks::ToolCallHookContext::from_harness_config(
         &workspace.dir,
         &workspace.sandbox_dir,
         harness_ref,
@@ -761,11 +634,10 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         .activity_heartbeat_enabled
         .unwrap_or(false)
     {
-        match isanagent::multi_tenant_edge::ActivityHeartbeatClient::from_env(logger_bus_tx.clone())
-        {
+        match crate::multi_tenant_edge::ActivityHeartbeatClient::from_env(logger_bus_tx.clone()) {
             Ok(client) => Some(std::sync::Arc::new(client)),
             Err(error) => {
-                let _ = logger_bus_tx.send(BusMessage::Log(isanagent::bus::LogEvent::warn(
+                let _ = logger_bus_tx.send(BusMessage::Log(crate::bus::LogEvent::warn(
                     "isanagent",
                     &error,
                 )));
@@ -779,11 +651,11 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     // Load agent definitions from config; use built-in defaults when none configured.
     let agent_defs = workspace.config.agent_definitions();
     let agent_defs = if agent_defs.is_empty() {
-        isanagent::agent::registry::default_agent_definitions()
+        crate::agent::registry::default_agent_definitions()
     } else {
         agent_defs
     };
-    let agent_registry = std::sync::Arc::new(isanagent::agent::AgentRegistry::from_definitions(
+    let agent_registry = std::sync::Arc::new(crate::agent::AgentRegistry::from_definitions(
         &agent_defs,
         &workspace.sandbox_dir,
     ));
@@ -795,7 +667,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     }
 
     let subagent = if workspace.config.subagent_harness_enabled() {
-        Some(isanagent::agent::SubagentHarnessParams {
+        Some(crate::agent::SubagentHarnessParams {
             cancel_children_on_parent_cancel: workspace
                 .config
                 .subagent_cancel_children_on_parent_cancel(),
@@ -1027,7 +899,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     let agent_outbound_tx = global_outbound_tx.clone();
     tokio::spawn(async move {
         while let Some(bus_msg) = agent_rx.recv().await {
-            if let isanagent::Message::Packet(packet) = bus_msg {
+            if let crate::Message::Packet(packet) = bus_msg {
                 match packet {
                     BusMessage::Outbound(out) => {
                         let _ = agent_outbound_tx.send(BusMessage::Outbound(out)).await;
@@ -1152,7 +1024,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                     tool_call_id,
                     background_job_id,
                 }) if channel == "terminal" => {
-                    if isanagent::channels::terminal::should_suppress_tool_notice_for_terminal(
+                    if crate::channels::terminal::should_suppress_tool_notice_for_terminal(
                         tool_name, args,
                     ) {
                         // MessageTool already emits its own user-visible Outbound to the
@@ -1184,7 +1056,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                     tool_call_id,
                     background_job_id,
                 }) if channel == "terminal" => {
-                    if isanagent::channels::terminal::should_suppress_tool_notice_for_terminal(
+                    if crate::channels::terminal::should_suppress_tool_notice_for_terminal(
                         tool_name, result,
                     ) {
                         // See ToolCall arm: avoid duplicating the user-visible MessageTool
@@ -1257,7 +1129,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     let _ = logger_bus_tx.send(BusMessage::LoggerControl(LoggerControlMessage::Flush));
     let flush_result = tokio::time::timeout(Duration::from_secs(5), async {
         while let Some(msg) = logger_control_rx.recv().await {
-            if let isanagent::Message::Packet(BusMessage::LoggerControl(
+            if let crate::Message::Packet(BusMessage::LoggerControl(
                 LoggerControlMessage::Flushed,
             )) = msg
             {
@@ -1299,7 +1171,7 @@ provider's environment, or set default_provider=\"local\" and local_python_runti
         return;
     }
     let uv_bin = workspace.config.execution_uv_binary();
-    if !isanagent::execution::uv_binary_available(&uv_bin) {
+    if !crate::execution::uv_binary_available(&uv_bin) {
         let interactive = workspace.config.terminal_enabled()
             && io::stdin().is_terminal()
             && io::stdout().is_terminal();
@@ -1329,7 +1201,7 @@ Install uv manually or run /install-python from terminal mode.",
                 }
                 let ans = line.trim().to_ascii_lowercase();
                 if matches!(ans.as_str(), "yes" | "y") {
-                    match isanagent::execution::install_uv_best_effort() {
+                    match crate::execution::install_uv_best_effort() {
                         Ok(msg) => println!("{msg}"),
                         Err(err) => println!("Auto-install failed: {err}"),
                     }
@@ -1359,11 +1231,11 @@ Install uv manually or run /install-python from terminal mode.",
 }
 
 async fn recover_background_jobs_on_startup(
-    memory_node: &NodeHandle<isanagent::memory::MemoryMessage>,
+    memory_node: &NodeHandle<crate::memory::MemoryMessage>,
     bus_tx: &mpsc::Sender<BusMessage>,
     _outbound_tx: &mpsc::Sender<BusMessage>,
 ) {
-    use isanagent::memory::{MemoryMessage, SharedReply};
+    use crate::memory::{MemoryMessage, SharedReply};
     let (tx, rx) = tokio::sync::oneshot::channel();
     if memory_node
         .send_packet(MemoryMessage::ListBackgroundJobs {
@@ -1395,11 +1267,11 @@ async fn recover_background_jobs_on_startup(
         }
         let mut metadata = std::collections::HashMap::new();
         metadata.insert(
-            isanagent::bus::METADATA_SYNTHETIC_BACKGROUND_RESUME.to_string(),
+            crate::bus::METADATA_SYNTHETIC_BACKGROUND_RESUME.to_string(),
             serde_json::Value::Bool(true),
         );
         metadata.insert(
-            isanagent::bus::METADATA_BACKGROUND_JOB_ID.to_string(),
+            crate::bus::METADATA_BACKGROUND_JOB_ID.to_string(),
             serde_json::Value::String(row.job_id.clone()),
         );
         if let Err(e) = bus_tx
@@ -1439,7 +1311,7 @@ async fn maybe_prompt_uv_requirements_install(
     uv_bin: &str,
     requirements: &[String],
 ) {
-    let local_cfg = isanagent::execution::LocalExecutionConfig {
+    let local_cfg = crate::execution::LocalExecutionConfig {
         sandbox_dir: workspace.sandbox_dir.clone(),
         workspace_dir: workspace.dir.clone(),
         restrict_to_workspace: true,
@@ -1448,7 +1320,7 @@ async fn maybe_prompt_uv_requirements_install(
         max_sessions: workspace.config.execution_max_sessions(),
         python_executable: workspace.config.execution_python_executable(),
         python_repl: workspace.config.execution_local_python_repl_enabled(),
-        python_runtime: isanagent::execution::LocalPythonRuntime::UvManaged,
+        python_runtime: crate::execution::LocalPythonRuntime::UvManaged,
         uv_binary: uv_bin.to_string(),
         uv_python: workspace.config.execution_uv_python(),
         uv_requirements: requirements.to_vec(),
@@ -1458,7 +1330,7 @@ async fn maybe_prompt_uv_requirements_install(
             .join("uv")
             .join("envs"),
     };
-    let Some(env_python) = isanagent::execution::uv_managed_env_python(&local_cfg) else {
+    let Some(env_python) = crate::execution::uv_managed_env_python(&local_cfg) else {
         return;
     };
     if !env_python.exists() {
@@ -1469,7 +1341,7 @@ async fn maybe_prompt_uv_requirements_install(
     let env_python_owned = env_python.clone();
     let requirements_owned = requirements.to_vec();
     let status = tokio::task::spawn_blocking(move || {
-        isanagent::execution::uv_requirements_status(
+        crate::execution::uv_requirements_status(
             &uv_bin_owned,
             &env_python_owned,
             &requirements_owned,
@@ -1573,213 +1445,14 @@ venv is touched."
     }
 }
 
-async fn run_skills(
-    workspace_arg: Option<String>,
-    args: SkillsArgs,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let workspace = IsanagentWorkspace::new(workspace_arg.as_deref(), None)?;
-    let mut skills = SkillRegistry::new(workspace.skills_path());
-
-    match args.command {
-        SkillCommands::Add { repo_url, skill } => {
-            if let Some(ref name) = skill {
-                println!("Adding skill '{}' from {}...", name, repo_url);
-            } else {
-                println!("Adding all skills from {}...", repo_url);
-            }
-            match skills
-                .install_skills_from_repo(&repo_url, skill.as_deref())
-                .await
-            {
-                Ok(installed) => {
-                    if installed.is_empty() {
-                        println!("No skills found in the repository.");
-                    } else {
-                        println!("Successfully installed {} skills:", installed.len());
-                        for name in installed {
-                            println!("  - {}", name);
-                        }
-                    }
-                }
-                Err(e) => {
-                    return Err(format!("Error installing skills: {}", e).into());
-                }
-            }
-        }
-        SkillCommands::List => {
-            println!("{}", skills.format_skill_directory());
-        }
-    }
-
-    Ok(())
-}
-
-async fn run_onboard(
-    global_workspace: Option<String>,
-    args: OnboardArgs,
-) -> Result<(), Box<dyn std::error::Error>> {
-    run_onboard_inner(global_workspace, args, /* chained = */ false).await
-}
-
-/// Underlying onboard implementation. When `chained` is true the final "Run: isanagent" tip is
-/// suppressed because the caller is about to launch the agent in the same process.
-async fn run_onboard_inner(
-    global_workspace: Option<String>,
-    args: OnboardArgs,
-    chained: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let workspace_arg = args.workspace.or(global_workspace);
-
-    if args.interactive && args.options.has_overrides() {
-        return Err(std::io::Error::other(
-            "Cannot combine --interactive with other config override flags; run `onboard --interactive` alone.",
-        )
-        .into());
-    }
-
-    let interactive_outcome = if args.interactive {
-        let handle = tokio::runtime::Handle::current();
-        Some(
-            tokio::task::spawn_blocking(move || {
-                onboarding_interactive::run_interactive_collect(&handle)
-            })
-            .await?
-            .map_err(std::io::Error::other)?,
-        )
-    } else {
-        None
-    };
-
-    let options = interactive_outcome
-        .as_ref()
-        .map(|o| o.options.clone())
-        .unwrap_or_else(|| args.options);
-
-    let config_overrides_used = options.has_overrides();
-
-    let interactive_merged_toml = if interactive_outcome.is_some() {
-        Some(build_interactive_config_toml(&options).map_err(std::io::Error::other)?)
-    } else {
-        None
-    };
-
-    let options_for_workspace = options.clone();
-    let report = tokio::task::spawn_blocking(move || {
-        let workspace_root = resolve_workspace_root(workspace_arg.as_deref());
-        onboard_workspace(
-            &workspace_root,
-            &options_for_workspace,
-            interactive_merged_toml.as_deref(),
-        )
-    })
-    .await?
-    .map_err(std::io::Error::other)?;
-
-    let env_name = interactive_outcome
-        .as_ref()
-        .and_then(|c| c.options.provider_api_key_env.clone());
-    print_onboarding_report(&report, config_overrides_used, env_name.as_deref(), chained);
-    Ok(())
-}
-
-fn print_onboarding_report(
-    report: &BootstrapReport,
-    config_overrides_used: bool,
-    api_key_env: Option<&str>,
-    chained: bool,
-) {
-    println!("Workspace onboarded at {}", report.root.display());
-    println!();
-
-    if !report.created.is_empty() {
-        println!("Created:");
-        for path in &report.created {
-            println!("- {}", path.display());
-        }
-        println!();
-    }
-
-    if !report.skipped.is_empty() {
-        println!("Skipped:");
-        for path in &report.skipped {
-            println!("- {}", path.display());
-        }
-        println!();
-    }
-
-    if config_overrides_used {
-        println!(
-            "Note: config.toml was generated from merged settings (template comments were omitted)."
-        );
-        println!();
-    }
-
-    println!("Next steps:");
-    match api_key_env {
-        Some(env) => {
-            println!(
-                "1. Ensure {} is set in your environment (see config.toml provider.api_key_env)",
-                env
-            );
-        }
-        None => {
-            println!("1. Set GEMINI_API_KEY (or the env named in provider.api_key_env)");
-        }
-    }
-    println!("2. Update <changethis> placeholders or disable unused channels in config.toml");
-    if !chained {
-        // When the agent is about to launch in the same invocation, suppress the redundant
-        // "Run:" line so the user sees one transition message instead of two competing tips.
-        println!("3. Run: {}", format_next_steps_run_line(&report.root));
-    }
-}
-
-/// Build the `Run:` line for the onboarding banner. When `report_root` resolves to the same path
-/// as the default (`~/.isanagent`), the `--workspace` flag is redundant and is omitted so the
-/// user sees the cleanest invocation that will work.
-fn format_next_steps_run_line(report_root: &std::path::Path) -> String {
-    let default_root = isanagent::workspace::resolve_workspace_root(None);
-    let same = paths_equivalent(report_root, &default_root);
-    if same {
-        "isanagent".to_string()
-    } else {
-        format!("isanagent --workspace {}", report_root.display())
-    }
-}
-
-/// Compare two paths after best-effort canonicalization. Falls back to direct equality when
-/// canonicalize fails (e.g. one of the paths is on a not-yet-existing filesystem branch).
-fn paths_equivalent(a: &std::path::Path, b: &std::path::Path) -> bool {
-    let canon_a = std::fs::canonicalize(a).ok();
-    let canon_b = std::fs::canonicalize(b).ok();
-    match (canon_a, canon_b) {
-        (Some(a), Some(b)) => a == b,
-        _ => a == b,
-    }
-}
-
 #[cfg(test)]
-mod next_steps_tests {
+mod tests {
     use super::*;
 
     #[test]
-    fn omits_workspace_flag_when_root_is_default() {
-        let default_root = isanagent::workspace::resolve_workspace_root(None);
-        let line = format_next_steps_run_line(&default_root);
-        assert_eq!(line, "isanagent", "got {line}");
-    }
-
-    #[test]
-    fn includes_workspace_flag_for_custom_root() {
-        let custom = std::env::temp_dir().join("isanagent-next-steps-test-custom");
-        let line = format_next_steps_run_line(&custom);
-        assert!(
-            line.starts_with("isanagent --workspace "),
-            "expected --workspace prefix, got {line}"
-        );
-        assert!(
-            line.contains(custom.to_string_lossy().as_ref()),
-            "got {line}"
-        );
+    fn host_config_defaults_to_the_existing_workspace_resolution() {
+        let config = HostConfig::default();
+        assert!(config.workspace.is_none());
+        assert!(config.config.is_none());
     }
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -1265,7 +1265,7 @@ fn apply_host_overrides(config: &mut AppConfig, host: &HostConfig) -> Result<(),
 
         let provider = config.provider.get_or_insert_with(ProviderConfig::default);
         if let Some((provider_name, model_name)) = model.split_once('/') {
-            if provider_name.is_empty() || model_name.is_empty() || model_name.contains('/') {
+            if provider_name.is_empty() || model_name.is_empty() {
                 return Err(format!("invalid provider/model override: {model}"));
             }
             provider.provider_name = provider_name.to_string();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod clarification;
 pub mod config;
 pub mod execution;
 pub mod hooks;
+pub mod host;
 pub mod log_rotation;
 pub mod logging;
 pub mod memory;

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,8 @@ async fn start_embedded_host(
         config: config_arg.map(std::path::PathBuf::from),
     })
     .await
+    .map_err(std::io::Error::other)?;
+    Ok(())
 }
 
 #[allow(dead_code)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,7 @@ async fn start_embedded_host(
         sandbox: None,
         model: None,
         permission: None,
+        no_color: false,
     })
     .await
     .map_err(std::io::Error::other)?;
@@ -881,6 +882,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                 }
                 all_providers
             },
+            color_enabled: !matches!(std::env::var_os("NO_COLOR"), Some(value) if !value.is_empty()),
         }));
         terminal.start(bus_tx.clone()).await?;
         out_channels.insert(terminal.name().to_string(), terminal);

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,7 @@ async fn start_embedded_host(
         model: None,
         permission: None,
         no_color: false,
+        resume: None,
     })
     .await
     .map_err(std::io::Error::other)?;
@@ -883,6 +884,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                 all_providers
             },
             color_enabled: !matches!(std::env::var_os("NO_COLOR"), Some(value) if !value.is_empty()),
+            resume_session: false,
         }));
         terminal.start(bus_tx.clone()).await?;
         out_channels.insert(terminal.name().to_string(), terminal);

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,6 +199,7 @@ async fn start_embedded_host(
     isanagent::host::start_host(isanagent::host::HostConfig {
         workspace: workspace_arg.map(std::path::PathBuf::from),
         config: config_arg.map(std::path::PathBuf::from),
+        sandbox: None,
     })
     .await
     .map_err(std::io::Error::other)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use isanagent::bus::{BusMessage, InboundMessage, LoggerControlMessage, Telemetry
 use isanagent::channels::terminal::{
     build_agent_thought_terminal_notice, build_tool_call_terminal_notice,
     build_tool_progress_terminal_notice, build_tool_result_terminal_notice,
-    terminal_startup_suppresses_plain_banner, TerminalChannelConfig,
+    terminal_startup_suppresses_plain_banner, TerminalChannelConfig, TerminalMode,
 };
 use isanagent::channels::{
     api::ApiChannel, email::EmailChannel, slack::SlackChannel, terminal::TerminalChannel, Channel,
@@ -888,6 +888,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             color_enabled: !matches!(std::env::var_os("NO_COLOR"), Some(value) if !value.is_empty()),
             resume_session: false,
             initial_files: Vec::new(),
+            mode: TerminalMode::Tui,
         }));
         terminal.start(bus_tx.clone()).await?;
         out_channels.insert(terminal.name().to_string(), terminal);

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,6 +200,8 @@ async fn start_embedded_host(
         workspace: workspace_arg.map(std::path::PathBuf::from),
         config: config_arg.map(std::path::PathBuf::from),
         sandbox: None,
+        model: None,
+        permission: None,
     })
     .await
     .map_err(std::io::Error::other)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,7 @@ async fn start_embedded_host(
         config: config_arg.map(std::path::PathBuf::from),
         sandbox: None,
         model: None,
+        fallback_model: None,
         permission: None,
         no_color: false,
         resume: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,6 +206,7 @@ async fn start_embedded_host(
         no_color: false,
         resume: None,
         files: Vec::new(),
+        line_mode: false,
     })
     .await
     .map_err(std::io::Error::other)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,6 +205,7 @@ async fn start_embedded_host(
         permission: None,
         no_color: false,
         resume: None,
+        files: Vec::new(),
     })
     .await
     .map_err(std::io::Error::other)?;
@@ -886,6 +887,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             },
             color_enabled: !matches!(std::env::var_os("NO_COLOR"), Some(value) if !value.is_empty()),
             resume_session: false,
+            initial_files: Vec::new(),
         }));
         terminal.start(bus_tx.clone()).await?;
         out_channels.insert(terminal.name().to_string(), terminal);

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -46,6 +46,7 @@ pub fn ensure_workspace_layout(root: &Path) -> Result<WorkspaceLayout, String> {
 pub struct IsanagentWorkspace {
     pub dir: std::path::PathBuf,
     pub sandbox_dir: std::path::PathBuf,
+    pub skills_dir: std::path::PathBuf,
     pub config: AppConfig,
 }
 
@@ -53,8 +54,32 @@ impl IsanagentWorkspace {
     /// Initializes a new workspace at the given path.
     /// If no path is provided, it defaults to `~/.isanagent`.
     pub fn new(path_override: Option<&str>, config_override: Option<&str>) -> Result<Self, String> {
+        Self::new_with_sandbox(path_override, config_override, None)
+    }
+
+    /// Initializes an IsanAgent state workspace with an optional, distinct
+    /// project sandbox. Embedders use this to keep durable state separate from
+    /// the project files that agent tools may read and edit.
+    pub fn new_with_sandbox(
+        path_override: Option<&str>,
+        config_override: Option<&str>,
+        sandbox_override: Option<&Path>,
+    ) -> Result<Self, String> {
         let target_dir = resolve_workspace_root(path_override);
         let layout = ensure_workspace_layout(&target_dir)?;
+        let sandbox_dir = match sandbox_override {
+            Some(path) => {
+                if !path.is_dir() {
+                    return Err(format!(
+                        "Configured sandbox is not a directory: {}",
+                        path.display()
+                    ));
+                }
+                path.canonicalize()
+                    .map_err(|error| format!("Failed to resolve sandbox directory: {error}"))?
+            }
+            None => layout.sandbox_dir,
+        };
 
         // 3. Load config.toml if it exists
         let config_path = config_override
@@ -71,7 +96,8 @@ impl IsanagentWorkspace {
 
         Ok(Self {
             dir: layout.root,
-            sandbox_dir: layout.sandbox_dir,
+            sandbox_dir,
+            skills_dir: layout.skills_dir,
             config,
         })
     }
@@ -81,7 +107,7 @@ impl IsanagentWorkspace {
     }
 
     pub fn skills_path(&self) -> PathBuf {
-        self.sandbox_dir.join("skills")
+        self.skills_dir.clone()
     }
 
     /// Reads an optional markdown file from the workspace sandbox (e.g., AGENTS.md, USER.md, SOUL.md).
@@ -131,5 +157,33 @@ impl IsanagentWorkspace {
         } else {
             prompt_parts.join("\n")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sandbox_override_keeps_state_and_project_roots_distinct() {
+        let state = tempfile::tempdir().expect("state directory");
+        let project = tempfile::tempdir().expect("project directory");
+
+        let workspace = IsanagentWorkspace::new_with_sandbox(
+            Some(state.path().to_str().expect("utf-8 state path")),
+            None,
+            Some(project.path()),
+        )
+        .expect("workspace should initialize");
+
+        assert_eq!(workspace.dir, state.path());
+        assert_eq!(
+            workspace.sandbox_dir,
+            project.path().canonicalize().unwrap()
+        );
+        assert_eq!(
+            workspace.skills_path(),
+            state.path().join("workspace/skills")
+        );
     }
 }


### PR DESCRIPTION
## Summary\n- move the complete runtime startup path behind public `isanagent::host::start_host`\n- add public `HostConfig` for workspace and config selection\n- route the existing binary through the same host entry point\n\n## Validation\n- `cargo check --bin isanagent`\n- `cargo test --lib host::tests::host_config_defaults_to_the_existing_workspace_resolution -- --exact`\n\n## Follow-up\nThis draft establishes the embedding boundary for ALTAI. The next change adds a typed handle/event stream and ALTAI workspace-state adapter before enabling the production `altai agent` command.