### PR TITLE
feat(host): oneshot, theme, approvals, attachments, compaction

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -455,7 +455,24 @@ fn should_require_shell_approval(command: &str, patterns: &[String]) -> bool {
 /// negative sentence ("never approve", "i can't approve", "approve? actually nope"). The prompt
 /// constrains the choices to approve/deny with `allow_empty = false`, so the strictness is
 /// UX-compatible; an unrecognized reply simply skips execution and the user can re-confirm.
+#[cfg(test)]
 fn shell_approval_reply_is_grant(reply: &str) -> bool {
+    matches!(
+        classify_approval_reply(reply),
+        ApprovalReply::Grant | ApprovalReply::AlwaysThisRun
+    )
+}
+
+/// Four-way approval reply classification for ALTAI CLI / TUI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApprovalReply {
+    Grant,
+    AlwaysThisRun,
+    Deny,
+    Abort,
+}
+
+fn classify_approval_reply(reply: &str) -> ApprovalReply {
     const AFFIRM: &[&str] = &[
         "approve",
         "approved",
@@ -477,25 +494,65 @@ fn shell_approval_reply_is_grant(reply: &str) -> bool {
         "go",
         "sure",
     ];
-    const FILLER: &[&str] = &["please", "it", "this", "that", "ahead", "now", "run", "do"];
+    const FILLER: &[&str] = &[
+        "please", "it", "this", "that", "ahead", "now", "run", "do", "for",
+    ];
+    const ALWAYS: &[&str] = &["always"];
+    const ABORT: &[&str] = &["abort", "cancel", "quit", "stop"];
 
     let r = reply.trim().to_ascii_lowercase();
     if r.is_empty() {
-        return false;
+        return ApprovalReply::Deny;
     }
-    let mut saw_affirmative = false;
-    for tok in r
+
+    let tokens: Vec<&str> = r
         .split(|c: char| !c.is_alphanumeric())
         .filter(|t| !t.is_empty())
+        .collect();
+
+    if tokens.iter().any(|t| ABORT.contains(t))
+        && !tokens.iter().any(|t| AFFIRM.contains(t) || ALWAYS.contains(t))
     {
-        if AFFIRM.contains(&tok) {
+        return ApprovalReply::Abort;
+    }
+
+    // "always" / "always for this run" — allow only known filler around always.
+    if tokens.iter().any(|t| ALWAYS.contains(t)) {
+        let ok = tokens
+            .iter()
+            .all(|t| ALWAYS.contains(t) || FILLER.contains(t) || AFFIRM.contains(t));
+        if ok {
+            return ApprovalReply::AlwaysThisRun;
+        }
+        return ApprovalReply::Deny;
+    }
+
+    let mut saw_affirmative = false;
+    for tok in &tokens {
+        if AFFIRM.contains(tok) {
             saw_affirmative = true;
-        } else if !FILLER.contains(&tok) {
-            // Negation, caveat, or unmodeled prose -> deny.
-            return false;
+        } else if !FILLER.contains(tok) {
+            return ApprovalReply::Deny;
         }
     }
-    saw_affirmative
+    if saw_affirmative {
+        ApprovalReply::Grant
+    } else {
+        ApprovalReply::Deny
+    }
+}
+
+fn command_preview_with_flag(command: &str) -> (String, bool) {
+    const MAX_PREVIEW: usize = 160;
+    if command.len() <= MAX_PREVIEW {
+        (command.to_string(), false)
+    } else {
+        (format!("{}…", &command[..MAX_PREVIEW]), true)
+    }
+}
+
+fn command_preview(command: &str) -> String {
+    command_preview_with_flag(command).0
 }
 
 fn shell_policy_mode_for_session(
@@ -528,15 +585,6 @@ fn edit_policy_block_reason(unattended_session: bool) -> &'static str {
         "File edit blocked by policy: unattended edit mode is active."
     } else {
         "File edit blocked by policy: plan mode active — finalize or apply the plan first."
-    }
-}
-
-fn command_preview(command: &str) -> String {
-    const MAX_PREVIEW: usize = 160;
-    if command.len() <= MAX_PREVIEW {
-        command.to_string()
-    } else {
-        format!("{}...", &command[..MAX_PREVIEW])
     }
 }
 
@@ -738,6 +786,23 @@ mod code_exec_gate_tests {
         assert!(shell_approval_reply_is_grant("yes do it"));
         assert!(shell_approval_reply_is_grant("yes, please do"));
         assert!(!shell_approval_reply_is_grant("do it"));
+    }
+
+    #[test]
+    fn approval_reply_classifies_always_and_abort() {
+        assert_eq!(
+            classify_approval_reply("always"),
+            ApprovalReply::AlwaysThisRun
+        );
+        assert_eq!(
+            classify_approval_reply("always for this run"),
+            ApprovalReply::AlwaysThisRun
+        );
+        assert_eq!(classify_approval_reply("abort"), ApprovalReply::Abort);
+        assert_eq!(classify_approval_reply("cancel"), ApprovalReply::Abort);
+        assert_eq!(classify_approval_reply("deny"), ApprovalReply::Deny);
+        assert!(shell_approval_reply_is_grant("always"));
+        assert!(!shell_approval_reply_is_grant("abort"));
     }
 
     #[test]
@@ -951,6 +1016,21 @@ struct ToolCallRuntime {
     inbound_metadata: Arc<HashMap<String, serde_json::Value>>,
 }
 
+/// Process-scoped "always for this run" grants (`shell:…` / `edit:…`).
+fn process_approval_grants() -> &'static tokio::sync::Mutex<HashSet<String>> {
+    static GRANTS: std::sync::OnceLock<tokio::sync::Mutex<HashSet<String>>> =
+        std::sync::OnceLock::new();
+    GRANTS.get_or_init(|| tokio::sync::Mutex::new(HashSet::new()))
+}
+
+async fn approval_already_granted(key: &str) -> bool {
+    process_approval_grants().lock().await.contains(key)
+}
+
+async fn remember_approval_grant(key: String) {
+    process_approval_grants().lock().await.insert(key);
+}
+
 /// Runs a tool with optional per-call activity heartbeats and optional cooperative cancellation.
 #[allow(clippy::too_many_arguments)] // Central tool-dispatch path; grouping would obscure call sites.
 async fn execute_tool_call_with_activity(
@@ -1030,21 +1110,30 @@ async fn execute_tool_call_with_activity(
                     }
                     ShellPolicyMode::Ask => {
                         if requires_approval {
+                            let grant_key = format!("shell:{tool_name}:{command}");
+                            if !approval_already_granted(&grant_key).await {
+                            let (preview, preview_truncated) = command_preview_with_flag(&command);
                             let _ = outbound_tx
                                 .send(BusMessage::Telemetry(TelemetryEvent::ShellPolicyDecision {
                                     chat_id: chat_id.clone(),
                                     channel: channel.clone(),
                                     mode: "ask".to_string(),
                                     decision: "approval_requested".to_string(),
-                                    command_preview: preview.clone(),
+                                    command_preview: if preview_truncated {
+                                        format!("{preview} [truncated]")
+                                    } else {
+                                        preview.clone()
+                                    },
                                 }))
                                 .await;
                             let ask_payload = serde_json::json!({
                                 "prompt": format!(
-                                    "Approve running `{}`?\n\n```\n{}\n```\n\nReply with approve or deny.",
-                                    tool_name, command
+                                    "Approve running `{}`?\n\n```\n{}\n```\n\nReply with approve, deny, always (this run), or abort.{}",
+                                    tool_name,
+                                    command,
+                                    if preview_truncated { "\n[command preview truncated in telemetry]" } else { "" }
                                 ),
-                                "choices": ["approve", "deny"],
+                                "choices": ["approve", "deny", "always", "abort"],
                                 "timeout_secs": 1800,
                                 "allow_empty": false
                             });
@@ -1061,37 +1150,62 @@ async fn execute_tool_call_with_activity(
                                 .await;
                             match ask_result {
                                 Ok(reply) => {
-                                    // Deny-default parse: an explicit grant runs; anything else
-                                    // (incl. "do not approve") skips execution.
-                                    let approved = shell_approval_reply_is_grant(&reply);
-                                    if !approved {
-                                        let _ = outbound_tx
-                                            .send(BusMessage::Telemetry(
-                                                TelemetryEvent::ShellPolicyDecision {
-                                                    chat_id: chat_id.clone(),
-                                                    channel: channel.clone(),
-                                                    mode: "ask".to_string(),
-                                                    decision: "approval_denied".to_string(),
-                                                    command_preview: preview,
-                                                },
-                                            ))
-                                            .await;
-                                        return ToolExecutionFinished::error(
-                                            ToolErrorCode::PolicyDenied,
-                                            "Command not approved by user; execution skipped.",
-                                        );
+                                    let classified = classify_approval_reply(&reply);
+                                    match classified {
+                                        ApprovalReply::Grant | ApprovalReply::AlwaysThisRun => {
+                                            if matches!(classified, ApprovalReply::AlwaysThisRun) {
+                                                remember_approval_grant(grant_key).await;
+                                            }
+                                            let _ = outbound_tx
+                                                .send(BusMessage::Telemetry(
+                                                    TelemetryEvent::ShellPolicyDecision {
+                                                        chat_id: chat_id.clone(),
+                                                        channel: channel.clone(),
+                                                        mode: "ask".to_string(),
+                                                        decision: "approval_granted".to_string(),
+                                                        command_preview: preview,
+                                                    },
+                                                ))
+                                                .await;
+                                        }
+                                        ApprovalReply::Abort => {
+                                            let _ = outbound_tx
+                                                .send(BusMessage::Telemetry(
+                                                    TelemetryEvent::ShellPolicyDecision {
+                                                        chat_id: chat_id.clone(),
+                                                        channel: channel.clone(),
+                                                        mode: "ask".to_string(),
+                                                        decision: "approval_denied".to_string(),
+                                                        command_preview: preview,
+                                                    },
+                                                ))
+                                                .await;
+                                            if let Some(token) = cancel_owned.as_ref() {
+                                                token.cancel();
+                                            }
+                                            return ToolExecutionFinished::error(
+                                                ToolErrorCode::PolicyDenied,
+                                                "Command approval aborted by user; execution skipped.",
+                                            );
+                                        }
+                                        ApprovalReply::Deny => {
+                                            let _ = outbound_tx
+                                                .send(BusMessage::Telemetry(
+                                                    TelemetryEvent::ShellPolicyDecision {
+                                                        chat_id: chat_id.clone(),
+                                                        channel: channel.clone(),
+                                                        mode: "ask".to_string(),
+                                                        decision: "approval_denied".to_string(),
+                                                        command_preview: preview,
+                                                    },
+                                                ))
+                                                .await;
+                                            return ToolExecutionFinished::error(
+                                                ToolErrorCode::PolicyDenied,
+                                                "Command not approved by user; execution skipped.",
+                                            );
+                                        }
                                     }
-                                    let _ = outbound_tx
-                                        .send(BusMessage::Telemetry(
-                                            TelemetryEvent::ShellPolicyDecision {
-                                                chat_id: chat_id.clone(),
-                                                channel: channel.clone(),
-                                                mode: "ask".to_string(),
-                                                decision: "approval_granted".to_string(),
-                                                command_preview: preview,
-                                            },
-                                        ))
-                                        .await;
                                 }
                                 Err(e) => {
                                     return ToolExecutionFinished::error(
@@ -1100,6 +1214,7 @@ async fn execute_tool_call_with_activity(
                                     );
                                 }
                             }
+                            } // end if !already_granted
                         }
                     }
                 }
@@ -1161,12 +1276,14 @@ async fn execute_tool_call_with_activity(
                         }
                     };
                     if let Some(preview) = preview {
+                        let grant_key = format!("edit:{}", preview.path);
+                        if !approval_already_granted(&grant_key).await {
                         let ask_payload = serde_json::json!({
                             "prompt": format!(
-                                "Approve edit to `{}`? Review the attached diff, then reply with approve or deny.",
+                                "Approve edit to `{}`? Review the attached diff, then reply with approve, deny, always (this run), or abort.",
                                 preview.path
                             ),
-                            "choices": ["approve", "deny"],
+                            "choices": ["approve", "deny", "always", "abort"],
                             "timeout_secs": 1800,
                             "allow_empty": false,
                             "metadata": {
@@ -1197,12 +1314,28 @@ async fn execute_tool_call_with_activity(
                                 );
                             }
                         };
-                        if !shell_approval_reply_is_grant(&reply) {
-                            return ToolExecutionFinished::error(
-                                ToolErrorCode::PolicyDenied,
-                                "Edit not approved by user; mutation skipped.",
-                            );
+                        match classify_approval_reply(&reply) {
+                            ApprovalReply::Grant => {}
+                            ApprovalReply::AlwaysThisRun => {
+                                remember_approval_grant(grant_key).await;
+                            }
+                            ApprovalReply::Abort => {
+                                if let Some(token) = cancel_owned.as_ref() {
+                                    token.cancel();
+                                }
+                                return ToolExecutionFinished::error(
+                                    ToolErrorCode::PolicyDenied,
+                                    "Edit approval aborted by user; mutation skipped.",
+                                );
+                            }
+                            ApprovalReply::Deny => {
+                                return ToolExecutionFinished::error(
+                                    ToolErrorCode::PolicyDenied,
+                                    "Edit not approved by user; mutation skipped.",
+                                );
+                            }
                         }
+                        } // end if !already_granted
                         approved_mutation_preview = Some(preview);
                     }
                 }

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -27,7 +27,9 @@ pub trait Channel: Send + Sync {
 pub mod api;
 pub(crate) mod api_store;
 pub mod email;
+pub mod oneshot;
 pub mod slack;
 pub(crate) mod slack_store;
 pub mod terminal;
 pub(crate) mod terminal_ui;
+pub mod tty_prompt;

--- a/src/channels/oneshot.rs
+++ b/src/channels/oneshot.rs
@@ -1,8 +1,9 @@
 //! Headless one-shot channel used by embedding hosts such as ALTAI CLI.
 //!
 //! The channel injects a single inbound prompt, captures the final outbound
-//! assistant message, and rejects interactive clarification/approval waits so
-//! non-TTY callers never hang or silently approve.
+//! assistant message, and either resumes approvals on the controlling TTY
+//! (`/dev/tty`) or rejects them so non-TTY callers never hang or silently
+//! approve.
 
 use std::any::Any;
 use std::collections::HashMap;
@@ -13,6 +14,7 @@ use async_trait::async_trait;
 use tokio::sync::{mpsc, oneshot, watch};
 
 use crate::bus::{BusMessage, InboundMessage, OutboundMessage, RunLifecycleEvent, RunOutcome};
+use crate::channels::tty_prompt::{prompt_on_tty, tty_available};
 use crate::channels::Channel;
 use crate::utils::ContentPart;
 
@@ -59,8 +61,10 @@ struct OneshotState {
     finished: bool,
 }
 
-/// Captures one-shot progress and completes when the run terminates or an
-/// interactive approval/clarification would otherwise block a non-TTY host.
+/// Captures one-shot progress and completes when the run terminates.
+///
+/// Interactive approvals/clarifications resume via `/dev/tty` when available;
+/// otherwise the run exits with an approval/clarification outcome.
 pub struct OneshotChannel {
     chat_id: String,
     prompt: String,
@@ -70,6 +74,7 @@ pub struct OneshotChannel {
     result_tx: Mutex<Option<oneshot::Sender<OneshotResult>>>,
     shutdown_tx: mpsc::UnboundedSender<()>,
     observe_tx: Option<mpsc::UnboundedSender<BusMessage>>,
+    bus_tx: Mutex<Option<mpsc::Sender<BusMessage>>>,
     started: watch::Sender<bool>,
 }
 
@@ -93,6 +98,7 @@ impl OneshotChannel {
             result_tx: Mutex::new(Some(result_tx)),
             shutdown_tx,
             observe_tx,
+            bus_tx: Mutex::new(None),
             started,
         }
     }
@@ -120,6 +126,59 @@ impl OneshotChannel {
             let _ = tx.send(result);
         }
         let _ = self.shutdown_tx.send(());
+    }
+
+    fn normalize_tty_reply(raw: &str) -> String {
+        let trimmed = raw.trim();
+        if trimmed.chars().count() == 1 {
+            if let Some(mapped) =
+                crate::channels::terminal_ui::approval_hotkey_reply(trimmed.chars().next().unwrap())
+            {
+                return mapped.to_string();
+            }
+        }
+        trimmed.to_string()
+    }
+
+    async fn resume_approval_on_tty(&self, detail: &str) -> Result<bool, String> {
+        let bus_tx = self
+            .bus_tx
+            .lock()
+            .expect("oneshot bus")
+            .clone()
+            .ok_or_else(|| "oneshot bus is not ready for approval resume".to_string())?;
+
+        let prompt = format!(
+            "\n[altai] Approval required\n{detail}\nChoices: approve / deny / always / abort  (y/n/a/x)\n> "
+        );
+        let reply = tokio::task::spawn_blocking(move || prompt_on_tty(&prompt))
+            .await
+            .map_err(|error| format!("tty prompt join failed: {error}"))?
+            .map_err(|error| format!("tty prompt failed: {error}"))?;
+        let reply = Self::normalize_tty_reply(&reply);
+        if reply.eq_ignore_ascii_case("abort")
+            || reply.eq_ignore_ascii_case("cancel")
+            || reply.eq_ignore_ascii_case("quit")
+        {
+            self.complete(OneshotOutcome::Cancelled);
+            return Ok(true);
+        }
+
+        let inbound = InboundMessage {
+            channel: ONESHOT_CHANNEL_NAME.to_string(),
+            sender_id: "altai-cli".to_string(),
+            chat_id: self.chat_id.clone(),
+            thread_id: None,
+            content: reply,
+            attachments: Vec::new(),
+            metadata: HashMap::new(),
+        };
+        self.observe(BusMessage::Inbound(inbound.clone()));
+        bus_tx
+            .send(BusMessage::Inbound(inbound))
+            .await
+            .map_err(|error| format!("failed to enqueue tty approval reply: {error}"))?;
+        Ok(true)
     }
 
     /// Observe host bus traffic that is not delivered through [`Channel::send`].
@@ -151,6 +210,11 @@ impl OneshotChannel {
                 ..
             }) if chat_id == &self.chat_id && decision == "approval_requested" =>
             {
+                // When a controlling TTY is available, wait for the clarification
+                // outbound (handled in `send`) so the user can approve interactively.
+                if tty_available() {
+                    return;
+                }
                 self.complete(OneshotOutcome::ApprovalRequired {
                     detail: command_preview.clone(),
                 });
@@ -184,6 +248,7 @@ impl Channel for OneshotChannel {
     }
 
     async fn start(&self, bus_tx: mpsc::Sender<BusMessage>) -> Result<(), String> {
+        *self.bus_tx.lock().expect("oneshot bus") = Some(bus_tx.clone());
         let mut content = self.prompt.clone();
         // Prefer real multimodal attachments; only keep a path note when loading failed.
         if self.attachments.is_empty() {
@@ -225,7 +290,7 @@ impl Channel for OneshotChannel {
                 .get(crate::bus::METADATA_CLARIFICATION_TICKET_ID)
                 .is_some()
         {
-            if let Some(edit) = msg.metadata.get("edit_diff") {
+            let detail = if let Some(edit) = msg.metadata.get("edit_diff") {
                 let file = edit
                     .get("file")
                     .and_then(|v| v.as_str())
@@ -246,11 +311,25 @@ impl Channel for OneshotChannel {
                     detail.push('\n');
                     detail.push_str(&msg.content);
                 }
+                detail
+            } else {
+                msg.content.clone()
+            };
+
+            if tty_available() {
+                match self.resume_approval_on_tty(&detail).await {
+                    Ok(true) => return Ok(()),
+                    Ok(false) => {}
+                    Err(error) => {
+                        eprintln!("altai-cli: tty approval resume failed: {error}");
+                    }
+                }
+            }
+
+            if msg.metadata.get("edit_diff").is_some() {
                 self.complete(OneshotOutcome::ApprovalRequired { detail });
             } else {
-                self.complete(OneshotOutcome::ClarificationRequired {
-                    detail: msg.content.clone(),
-                });
+                self.complete(OneshotOutcome::ClarificationRequired { detail });
             }
             return Ok(());
         }
@@ -290,5 +369,12 @@ mod tests {
             OneshotOutcome::from_run_outcome(&RunOutcome::Cancelled),
             OneshotOutcome::Cancelled
         );
+    }
+
+    #[test]
+    fn normalizes_hotkey_replies() {
+        assert_eq!(OneshotChannel::normalize_tty_reply("y\n"), "approve");
+        assert_eq!(OneshotChannel::normalize_tty_reply("3"), "always");
+        assert_eq!(OneshotChannel::normalize_tty_reply("deny"), "deny");
     }
 }

--- a/src/channels/oneshot.rs
+++ b/src/channels/oneshot.rs
@@ -1,0 +1,294 @@
+//! Headless one-shot channel used by embedding hosts such as ALTAI CLI.
+//!
+//! The channel injects a single inbound prompt, captures the final outbound
+//! assistant message, and rejects interactive clarification/approval waits so
+//! non-TTY callers never hang or silently approve.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use tokio::sync::{mpsc, oneshot, watch};
+
+use crate::bus::{BusMessage, InboundMessage, OutboundMessage, RunLifecycleEvent, RunOutcome};
+use crate::channels::Channel;
+use crate::utils::ContentPart;
+
+pub const ONESHOT_CHANNEL_NAME: &str = "altai-cli";
+
+/// Terminal result of a one-shot host run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OneshotResult {
+    pub chat_id: String,
+    pub run_id: Option<String>,
+    pub outcome: OneshotOutcome,
+    pub final_text: Option<String>,
+}
+
+/// Why a one-shot run stopped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OneshotOutcome {
+    Completed,
+    Failed(String),
+    Cancelled,
+    TimedOut,
+    ApprovalRequired { detail: String },
+    ClarificationRequired { detail: String },
+}
+
+impl OneshotOutcome {
+    pub fn from_run_outcome(outcome: &RunOutcome) -> Self {
+        match outcome {
+            RunOutcome::Completed => Self::Completed,
+            RunOutcome::Cancelled => Self::Cancelled,
+            RunOutcome::Failed { failure, .. } => Self::Failed(format!("{failure:?}")),
+            RunOutcome::Stuck { reason } => Self::Failed(format!("stuck:{reason:?}")),
+            RunOutcome::BudgetExhausted { budget } => {
+                Self::Failed(format!("budget_exhausted:{budget:?}"))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct OneshotState {
+    final_text: Option<String>,
+    run_id: Option<String>,
+    finished: bool,
+}
+
+/// Captures one-shot progress and completes when the run terminates or an
+/// interactive approval/clarification would otherwise block a non-TTY host.
+pub struct OneshotChannel {
+    chat_id: String,
+    prompt: String,
+    attachments: Vec<ContentPart>,
+    files: Vec<PathBuf>,
+    state: Arc<Mutex<OneshotState>>,
+    result_tx: Mutex<Option<oneshot::Sender<OneshotResult>>>,
+    shutdown_tx: mpsc::UnboundedSender<()>,
+    observe_tx: Option<mpsc::UnboundedSender<BusMessage>>,
+    started: watch::Sender<bool>,
+}
+
+impl OneshotChannel {
+    pub fn new(
+        chat_id: String,
+        prompt: String,
+        files: Vec<PathBuf>,
+        attachments: Vec<ContentPart>,
+        result_tx: oneshot::Sender<OneshotResult>,
+        shutdown_tx: mpsc::UnboundedSender<()>,
+        observe_tx: Option<mpsc::UnboundedSender<BusMessage>>,
+    ) -> Self {
+        let (started, _) = watch::channel(false);
+        Self {
+            chat_id,
+            prompt,
+            attachments,
+            files,
+            state: Arc::new(Mutex::new(OneshotState::default())),
+            result_tx: Mutex::new(Some(result_tx)),
+            shutdown_tx,
+            observe_tx,
+            started,
+        }
+    }
+
+    fn observe(&self, msg: BusMessage) {
+        if let Some(tx) = &self.observe_tx {
+            let _ = tx.send(msg);
+        }
+    }
+
+    fn complete(&self, outcome: OneshotOutcome) {
+        let mut state = self.state.lock().expect("oneshot state");
+        if state.finished {
+            return;
+        }
+        state.finished = true;
+        let result = OneshotResult {
+            chat_id: self.chat_id.clone(),
+            run_id: state.run_id.clone(),
+            outcome,
+            final_text: state.final_text.clone(),
+        };
+        drop(state);
+        if let Some(tx) = self.result_tx.lock().expect("oneshot result").take() {
+            let _ = tx.send(result);
+        }
+        let _ = self.shutdown_tx.send(());
+    }
+
+    /// Observe host bus traffic that is not delivered through [`Channel::send`].
+    pub fn observe_bus_message(&self, msg: &BusMessage) {
+        self.observe(msg.clone());
+        match msg {
+            BusMessage::RunLifecycle(RunLifecycleEvent::Started { run_id, chat_id })
+                if chat_id == &self.chat_id =>
+            {
+                let mut state = self.state.lock().expect("oneshot state");
+                state.run_id = Some(run_id.clone());
+            }
+            BusMessage::RunLifecycle(RunLifecycleEvent::Terminated {
+                chat_id,
+                run_id,
+                outcome,
+            }) if chat_id == &self.chat_id =>
+            {
+                {
+                    let mut state = self.state.lock().expect("oneshot state");
+                    state.run_id = Some(run_id.clone());
+                }
+                self.complete(OneshotOutcome::from_run_outcome(outcome));
+            }
+            BusMessage::Telemetry(crate::bus::TelemetryEvent::ShellPolicyDecision {
+                chat_id,
+                decision,
+                command_preview,
+                ..
+            }) if chat_id == &self.chat_id && decision == "approval_requested" =>
+            {
+                self.complete(OneshotOutcome::ApprovalRequired {
+                    detail: command_preview.clone(),
+                });
+            }
+            BusMessage::Outbound(out)
+                if out.channel == ONESHOT_CHANNEL_NAME && out.chat_id == self.chat_id =>
+            {
+                // Captured via Channel::send as well; keep observe path consistent.
+            }
+            _ => {}
+        }
+    }
+
+    fn attachment_note(files: &[PathBuf]) -> String {
+        if files.is_empty() {
+            return String::new();
+        }
+        let list = files
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("\n\n[Attached files: {list}]")
+    }
+}
+
+#[async_trait]
+impl Channel for OneshotChannel {
+    fn name(&self) -> &str {
+        ONESHOT_CHANNEL_NAME
+    }
+
+    async fn start(&self, bus_tx: mpsc::Sender<BusMessage>) -> Result<(), String> {
+        let mut content = self.prompt.clone();
+        // Prefer real multimodal attachments; only keep a path note when loading failed.
+        if self.attachments.is_empty() {
+            content.push_str(&Self::attachment_note(&self.files));
+        }
+
+        let inbound = InboundMessage {
+            channel: ONESHOT_CHANNEL_NAME.to_string(),
+            sender_id: "altai-cli".to_string(),
+            chat_id: self.chat_id.clone(),
+            thread_id: None,
+            content,
+            attachments: self.attachments.clone(),
+            metadata: HashMap::new(),
+        };
+        self.observe(BusMessage::Inbound(inbound.clone()));
+        bus_tx
+            .send(BusMessage::Inbound(inbound))
+            .await
+            .map_err(|error| format!("failed to enqueue oneshot prompt: {error}"))?;
+        let _ = self.started.send(true);
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn send(&self, msg: OutboundMessage) -> Result<(), String> {
+        self.observe(BusMessage::Outbound(msg.clone()));
+
+        if msg
+            .metadata
+            .get(crate::clarification::METADATA_CLARIFICATION)
+            .and_then(|value| value.as_bool())
+            == Some(true)
+            || msg
+                .metadata
+                .get(crate::bus::METADATA_CLARIFICATION_TICKET_ID)
+                .is_some()
+        {
+            if let Some(edit) = msg.metadata.get("edit_diff") {
+                let file = edit
+                    .get("file")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("(unknown)");
+                let truncated = edit
+                    .get("truncated")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let diff = edit.get("diff").and_then(|v| v.as_str()).unwrap_or("");
+                let mut detail = format!("edit approval required for {file}");
+                if truncated {
+                    detail.push_str(" [diff truncated]");
+                }
+                if !diff.is_empty() {
+                    detail.push('\n');
+                    detail.push_str(diff);
+                } else if !msg.content.is_empty() {
+                    detail.push('\n');
+                    detail.push_str(&msg.content);
+                }
+                self.complete(OneshotOutcome::ApprovalRequired { detail });
+            } else {
+                self.complete(OneshotOutcome::ClarificationRequired {
+                    detail: msg.content.clone(),
+                });
+            }
+            return Ok(());
+        }
+
+        if msg
+            .metadata
+            .get("isanagent_notification")
+            .and_then(|value| value.as_bool())
+            == Some(true)
+        {
+            return Ok(());
+        }
+
+        {
+            let mut state = self.state.lock().expect("oneshot state");
+            state.final_text = Some(msg.content);
+        }
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_completed_run_outcome() {
+        assert_eq!(
+            OneshotOutcome::from_run_outcome(&RunOutcome::Completed),
+            OneshotOutcome::Completed
+        );
+        assert_eq!(
+            OneshotOutcome::from_run_outcome(&RunOutcome::Cancelled),
+            OneshotOutcome::Cancelled
+        );
+    }
+}

--- a/src/channels/terminal.rs
+++ b/src/channels/terminal.rs
@@ -531,10 +531,14 @@ pub struct TerminalChannelConfig {
     pub workspace_dir: PathBuf,
     pub sandbox_dir: PathBuf,
     pub status_model: String,
+    /// Short permission label for the status bar (`ask`, `plan`, …).
+    pub status_permission: String,
     pub memory_node: NodeHandle<MemoryMessage>,
     pub providers: std::collections::HashMap<String, crate::config::ProviderConfig>,
     /// Whether the TUI should render ANSI foreground colors.
     pub color_enabled: bool,
+    /// Host-selected ALTAI theme (resolved with `color_enabled` / NO_COLOR).
+    pub theme: crate::channels::terminal_ui::HostThemeMode,
     /// Load the configured chat's persisted transcript before accepting input.
     pub resume_session: bool,
     /// File references composed into the first user message.
@@ -560,6 +564,7 @@ pub struct TerminalChannel {
     sandbox_dir: PathBuf,
     /// Provider model id for the status line (e.g. from config).
     status_model: String,
+    status_permission: String,
     /// Workspace memory actor (for past-session list + transcript load in the TUI thread).
     memory_node: NodeHandle<MemoryMessage>,
     /// Outbound messages for the Ratatui thread (set when `start` succeeds).
@@ -567,6 +572,7 @@ pub struct TerminalChannel {
     /// Named alternative providers for `/model` switching.
     providers: std::collections::HashMap<String, crate::config::ProviderConfig>,
     color_enabled: bool,
+    theme: crate::channels::terminal_ui::HostThemeMode,
     resume_session: bool,
     initial_files: Vec<PathBuf>,
     mode: TerminalMode,
@@ -581,10 +587,12 @@ impl TerminalChannel {
             workspace_dir: config.workspace_dir,
             sandbox_dir: config.sandbox_dir,
             status_model: config.status_model,
+            status_permission: config.status_permission,
             memory_node: config.memory_node,
             outbound_ui_tx: Arc::new(Mutex::new(None)),
             providers: config.providers,
             color_enabled: config.color_enabled,
+            theme: config.theme,
             resume_session: config.resume_session,
             initial_files: config.initial_files,
             mode: config.mode,
@@ -611,6 +619,7 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
 
         let channel_name = self.name().to_string();
         if self.mode == TerminalMode::Line {
+            crate::channels::terminal_ui::init_from_host(self.theme, !self.color_enabled);
             let (tx, rx) = std::sync::mpsc::channel::<OutboundMessage>();
             *self
                 .outbound_ui_tx
@@ -618,21 +627,198 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
                 .map_err(|_| "terminal outbound bridge poisoned".to_string())? = Some(tx);
             let chat_id = self.chat_id.clone();
             let shutdown = self.shutdown_tx.clone();
+            let status_model = self.status_model.clone();
+            let status_permission = self.status_permission.clone();
+            let sandbox_label = self
+                .sandbox_dir
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("workspace")
+                .to_string();
+            let session_short = truncate_leading_ellipsis(&chat_id, 13);
             std::thread::spawn(move || {
                 for message in rx {
-                    println!("{}", message.content);
+                    let is_clarification = message
+                        .metadata
+                        .get(crate::clarification::METADATA_CLARIFICATION)
+                        .and_then(|v| v.as_bool())
+                        == Some(true);
+                    let prefix = if is_clarification {
+                        "approval"
+                    } else if message
+                        .metadata
+                        .get(ISANAGENT_TOOL_NOTIFY)
+                        .and_then(|v| v.as_bool())
+                        == Some(true)
+                    {
+                        "tool"
+                    } else {
+                        "assistant"
+                    };
+                    println!("[{prefix}] {}", message.content);
+                    if let Some(edit) = message.metadata.get("edit_diff") {
+                        let file = edit
+                            .get("file")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("(unknown)");
+                        let truncated = edit
+                            .get("truncated")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        let badge = if truncated { " [truncated]" } else { "" };
+                        println!("[edit_diff] {file}{badge}");
+                        if let Some(diff) = edit.get("diff").and_then(|v| v.as_str()) {
+                            println!("{diff}");
+                        }
+                    }
+                    if is_clarification {
+                        println!(
+                            "[choices] 1=approve 2=deny 3=always 4=abort  (type the word or number)"
+                        );
+                    }
                 }
             });
+            let sandbox_dir = self.sandbox_dir.clone();
+            let memory_node = self.memory_node.clone();
+            let channel_name_for_line = channel_name.clone();
+            let mut pending_host_files = self.initial_files.clone();
             std::thread::spawn(move || {
                 use std::io::BufRead;
-                println!("ALTAI line mode. Type /exit to quit.");
+                println!(
+                    "ALTAI line mode · {sandbox_label} · {status_model} · {status_permission} · session {session_short}"
+                );
+                println!(
+                    "Commands: /exit · /context · /compact [focus] · @file attachments. Color: {}",
+                    if crate::channels::terminal_ui::uses_ansi_color() {
+                        "on"
+                    } else {
+                        "off (plain)"
+                    }
+                );
+                if !pending_host_files.is_empty() {
+                    let refs = pending_host_files
+                        .iter()
+                        .map(|path| format!("@{}", path.display()))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    println!(
+                        "Pending --file attachments ({refs}) will load with your first message."
+                    );
+                }
+                print!("> ");
+                let _ = std::io::Write::flush(&mut std::io::stdout());
+                let rt = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(error) => {
+                        eprintln!("line mode runtime failed: {error}");
+                        return;
+                    }
+                };
                 for line in std::io::stdin().lock().lines() {
                     let Ok(content) = line else { break };
-                    if matches!(content.trim(), "/exit" | "/quit") {
+                    let trimmed = content.trim();
+                    if matches!(trimmed, "/exit" | "/quit") {
                         let _ = shutdown.send(());
                         break;
                     }
-                    if content.trim().is_empty() {
+                    if trimmed.is_empty() {
+                        print!("> ");
+                        let _ = std::io::Write::flush(&mut std::io::stdout());
+                        continue;
+                    }
+                    if trimmed.eq_ignore_ascii_case("/context") {
+                        let session_key = crate::bus::clarification_session_key(
+                            &channel_name_for_line,
+                            &chat_id,
+                            None,
+                        );
+                        let messages = rt.block_on(async {
+                            let (tx, rx) = tokio::sync::oneshot::channel();
+                            let _ = memory_node
+                                .send_packet(crate::memory::MemoryMessage::GetContext {
+                                    thread_id: session_key.clone(),
+                                    reply: crate::memory::SharedReply::new(tx),
+                                })
+                                .await;
+                            rx.await.ok().and_then(|r| r.ok()).unwrap_or_default()
+                        });
+                        let user_turns = messages.iter().filter(|m| m.role == "user").count();
+                        let approx_tokens: usize = messages
+                            .iter()
+                            .map(|m| m.content.as_ref().map_or(0, |c| c.text_content().len()) / 4)
+                            .sum();
+                        println!(
+                            "[context] {} message(s) · {} user turn(s) · ~{} tokens (rough estimate). Use /compact to force compaction.",
+                            messages.len(),
+                            user_turns,
+                            approx_tokens
+                        );
+                        print!("> ");
+                        let _ = std::io::Write::flush(&mut std::io::stdout());
+                        continue;
+                    }
+                    if trimmed.eq_ignore_ascii_case("/compact")
+                        || trimmed.to_ascii_lowercase().starts_with("/compact ")
+                    {
+                        let focus = trimmed
+                            .strip_prefix("/compact")
+                            .or_else(|| trimmed.strip_prefix("/COMPACT"))
+                            .unwrap_or("")
+                            .trim()
+                            .to_string();
+                        let session_key = crate::bus::clarification_session_key(
+                            &channel_name_for_line,
+                            &chat_id,
+                            None,
+                        );
+                        let msg = BusMessage::TriggerCompaction {
+                            session_key,
+                            focus_instructions: if focus.is_empty() {
+                                None
+                            } else {
+                                Some(focus.clone())
+                            },
+                            trigger: Some(crate::bus::CompactionTrigger::Manual),
+                        };
+                        if bus_tx.blocking_send(msg).is_err() {
+                            println!("[system] Bus closed; cannot trigger compaction.");
+                            break;
+                        }
+                        if focus.is_empty() {
+                            println!("[system] Compaction requested. It will run between turns.");
+                        } else {
+                            println!(
+                                "[system] Compaction requested with focus: \"{focus}\"."
+                            );
+                        }
+                        print!("> ");
+                        let _ = std::io::Write::flush(&mut std::io::stdout());
+                        continue;
+                    }
+
+                    let (clean_text, mut attachments) =
+                        crate::channels::terminal_ui::parse_terminal_attachments(
+                            &content,
+                            &sandbox_dir,
+                        );
+                    if !pending_host_files.is_empty() {
+                        let (host_parts, warnings) =
+                            crate::channels::terminal_ui::load_host_file_attachments(
+                                &sandbox_dir,
+                                &pending_host_files,
+                            );
+                        for warning in warnings {
+                            eprintln!("Warning: {warning}");
+                        }
+                        attachments.extend(host_parts);
+                        pending_host_files.clear();
+                    }
+                    if clean_text.trim().is_empty() && attachments.is_empty() {
+                        print!("> ");
+                        let _ = std::io::Write::flush(&mut std::io::stdout());
                         continue;
                     }
                     if bus_tx
@@ -641,14 +827,20 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
                             sender_id: "local_user".into(),
                             chat_id: chat_id.clone(),
                             thread_id: None,
-                            content,
-                            attachments: Vec::new(),
+                            content: if clean_text.is_empty() {
+                                "(attached files)".into()
+                            } else {
+                                clean_text
+                            },
+                            attachments,
                             metadata: Default::default(),
                         }))
                         .is_err()
                     {
                         break;
                     }
+                    print!("> ");
+                    let _ = std::io::Write::flush(&mut std::io::stdout());
                 }
             });
             return Ok(());
@@ -681,12 +873,14 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
         let log_clone = logger_tx.clone();
         let memory_node_clone = self.memory_node.clone();
         let color_enabled = self.color_enabled;
+        let theme = self.theme;
         let resume_session = self.resume_session;
         let initial_files = self.initial_files.clone();
+        let status_permission = self.status_permission.clone();
 
         let opening_banner = format!(
             "ALTAI isanagent v{} — thread {}\n\
-             Commands: /exit, /new  ·  Images: @path/to/file inside the workspace.",
+             Commands: /exit, /new, /context, /compact  ·  Attachments: @path (text/image/PDF) inside the workspace.",
             env!("CARGO_PKG_VERSION"),
             truncate_leading_ellipsis(&chat_id_clone, 13)
         );
@@ -705,9 +899,11 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
                         channel_name,
                         opening_banner,
                         status_model,
+                        status_permission,
                         memory_node: memory_node_clone,
                         providers: providers_clone,
                         color_enabled,
+                        theme,
                         resume_session,
                         initial_files,
                     },

--- a/src/channels/terminal_ui/app.rs
+++ b/src/channels/terminal_ui/app.rs
@@ -238,6 +238,8 @@ pub enum Cell {
         text: String,
         /// From `ask_user` when provided; shown as a numbered list in the terminal.
         choices: Vec<String>,
+        /// Optional unified-diff payload for file-edit approvals.
+        edit_diff: Option<crate::channels::terminal_ui::EditDiffPayload>,
     },
     System {
         message: String,
@@ -387,6 +389,14 @@ pub struct App {
     pub model_selector: Option<ModelSelector>,
     /// Active model name displayed in the status bar (updated on `/model` switch).
     pub status_model: String,
+    /// Workspace label (usually sandbox basename) for the dense status header.
+    pub status_workspace: String,
+    /// Permission mode label (`ask`, `plan`, …).
+    pub status_permission: String,
+    /// Short session / chat id for the status header.
+    pub status_session: String,
+    /// Blocking approval overlay (shell / edit) awaiting a four-way reply.
+    pub pending_approval: bool,
 }
 
 impl Default for App {
@@ -485,6 +495,10 @@ impl App {
             crons_count: 0,
             model_selector: None,
             status_model: String::new(),
+            status_workspace: String::new(),
+            status_permission: String::new(),
+            status_session: String::new(),
+            pending_approval: false,
         }
     }
 
@@ -519,7 +533,17 @@ impl App {
         self.scroll_offset == 0
     }
 
+    fn reduce_motion_enabled() -> bool {
+        matches!(
+            std::env::var("ALTAI_TUI_REDUCE_MOTION").as_deref(),
+            Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes") | Ok("on")
+        )
+    }
+
     pub fn get_spinner_frame(&self) -> char {
+        if Self::reduce_motion_enabled() {
+            return '●';
+        }
         const FRAMES: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
         FRAMES[self.spinner_tick % FRAMES.len()]
     }

--- a/src/channels/terminal_ui/approval.rs
+++ b/src/channels/terminal_ui/approval.rs
@@ -1,0 +1,116 @@
+//! Approval / edit-diff helpers for the Ratatui terminal UI.
+
+use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
+
+use super::theme::Theme;
+
+/// Workspace-relative edit preview carried on clarification metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditDiffPayload {
+    pub file: String,
+    pub diff: String,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffLineKind {
+    Add,
+    Del,
+    Hunk,
+    Meta,
+    Context,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffLine {
+    pub kind: DiffLineKind,
+    pub gutter: &'static str,
+    pub text: String,
+}
+
+/// Parse unified-diff text into styled line descriptors (mirrors desktop EditApprovalCard).
+pub fn parse_diff_lines(diff: &str) -> Vec<DiffLine> {
+    diff.lines()
+        .map(|raw| {
+            let (kind, gutter, text) = if raw.starts_with("+++") || raw.starts_with("---") {
+                (DiffLineKind::Meta, " ", raw.to_string())
+            } else if raw.starts_with("@@") {
+                (DiffLineKind::Hunk, " ", raw.to_string())
+            } else if let Some(rest) = raw.strip_prefix('+') {
+                (DiffLineKind::Add, "+", rest.to_string())
+            } else if let Some(rest) = raw.strip_prefix('-') {
+                (DiffLineKind::Del, "-", rest.to_string())
+            } else if let Some(rest) = raw.strip_prefix(' ') {
+                (DiffLineKind::Context, " ", rest.to_string())
+            } else {
+                (DiffLineKind::Context, " ", raw.to_string())
+            };
+            DiffLine { kind, gutter, text }
+        })
+        .collect()
+}
+
+pub fn diff_lines_to_spans(diff: &str, max_lines: usize) -> Vec<Line<'static>> {
+    let parsed = parse_diff_lines(diff);
+    let truncated_input = parsed.len() > max_lines;
+    let mut out = Vec::new();
+    for line in parsed.into_iter().take(max_lines) {
+        let style = match line.kind {
+            DiffLineKind::Add => Theme::tool_done(),
+            DiffLineKind::Del => Theme::error(),
+            DiffLineKind::Hunk => Theme::clarification(),
+            DiffLineKind::Meta => Theme::dim(),
+            DiffLineKind::Context => Theme::text(),
+        };
+        out.push(Line::from(vec![
+            Span::styled(line.gutter.to_string(), Theme::dim()),
+            Span::styled(line.text, style),
+        ]));
+    }
+    if truncated_input {
+        out.push(Line::from(Span::styled(
+            "… [diff truncated for display]",
+            Theme::dim().add_modifier(Modifier::ITALIC),
+        )));
+    }
+    out
+}
+
+/// Four canonical approval choices shown in overlays / line mode.
+pub const APPROVAL_CHOICES: &[&str] = &["approve", "deny", "always", "abort"];
+
+/// Map a hotkey / digit to a canonical approval reply.
+pub fn approval_hotkey_reply(ch: char) -> Option<&'static str> {
+    match ch {
+        'y' | 'Y' | '1' => Some("approve"),
+        'n' | 'N' | '2' => Some("deny"),
+        'a' | 'A' | '3' => Some("always"),
+        'x' | 'X' | '4' | '\u{1b}' => Some("abort"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_unified_diff_kinds() {
+        let lines = parse_diff_lines(
+            "--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new\n context\n",
+        );
+        assert_eq!(lines[0].kind, DiffLineKind::Meta);
+        assert_eq!(lines[2].kind, DiffLineKind::Hunk);
+        assert_eq!(lines[3].kind, DiffLineKind::Del);
+        assert_eq!(lines[4].kind, DiffLineKind::Add);
+        assert_eq!(lines[5].kind, DiffLineKind::Context);
+    }
+
+    #[test]
+    fn hotkeys_map_four_way_choices() {
+        assert_eq!(approval_hotkey_reply('y'), Some("approve"));
+        assert_eq!(approval_hotkey_reply('3'), Some("always"));
+        assert_eq!(approval_hotkey_reply('x'), Some("abort"));
+    }
+}

--- a/src/channels/terminal_ui/attachments.rs
+++ b/src/channels/terminal_ui/attachments.rs
@@ -1,7 +1,8 @@
-//! `@path` image attachment parsing for terminal input (Ratatui compose line).
+//! `@path` attachment parsing for terminal input (Ratatui compose + line mode).
 
-use crate::utils::{resolve_path, ContentPart, ImageUrl};
+use crate::utils::{resolve_path, ContentPart, Document, ImageUrl};
 use base64::Engine as _;
+use std::path::{Path, PathBuf};
 
 /// Detects the MIME type of an image file from its extension.
 pub(crate) fn image_mime_from_extension(path: &std::path::Path) -> Option<&'static str> {
@@ -19,21 +20,187 @@ pub(crate) fn image_mime_from_extension(path: &std::path::Path) -> Option<&'stat
     }
 }
 
+fn is_probably_text_extension(path: &Path) -> bool {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_lowercase())
+        .as_deref()
+    {
+        None => true, // extensionless (Dockerfile, Makefile, LICENSE, …)
+        Some(ext) => matches!(
+            ext,
+            "rs" | "ts" | "tsx" | "js" | "jsx" | "json" | "toml" | "yaml" | "yml"
+                | "md" | "txt" | "css" | "html" | "py" | "go" | "java" | "kt"
+                | "swift" | "c" | "h" | "cpp" | "hpp" | "cs" | "rb" | "php"
+                | "sh" | "bash" | "zsh" | "sql" | "graphql" | "xml" | "svg"
+                | "env" | "ini" | "cfg" | "conf" | "lock" | "gitignore"
+                | "dockerfile" | "makefile" | "cmake" | "gradle" | "properties"
+        ),
+    }
+}
+
+fn is_pdf(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("pdf"))
+}
+
+const MAX_TEXT_ATTACH_CHARS: usize = 200_000;
+
+/// Load a sandbox-scoped file into a multimodal content part.
+pub fn load_sandbox_file_attachment(
+    sandbox_dir: &Path,
+    path: &Path,
+) -> Result<ContentPart, String> {
+    let expanded = shellexpand::tilde(&path.display().to_string()).into_owned();
+    let resolved = resolve_path(sandbox_dir, &expanded)
+        .or_else(|| fuzzy_resolve_in_sandbox(sandbox_dir, &expanded))
+        .ok_or_else(|| {
+            format!(
+                "could not resolve attachment path inside workspace: {}",
+                path.display()
+            )
+        })?;
+
+    if let Some(mime) = image_mime_from_extension(&resolved) {
+        let bytes = std::fs::read(&resolved)
+            .map_err(|error| format!("could not read {}: {error}", resolved.display()))?;
+        let engine = base64::engine::general_purpose::STANDARD;
+        let data_uri = format!("data:{mime};base64,{}", engine.encode(&bytes));
+        return Ok(ContentPart::ImageUrl {
+            image_url: ImageUrl {
+                url: data_uri,
+                detail: None,
+            },
+        });
+    }
+
+    if is_pdf(&resolved) {
+        let bytes = std::fs::read(&resolved)
+            .map_err(|error| format!("could not read {}: {error}", resolved.display()))?;
+        let engine = base64::engine::general_purpose::STANDARD;
+        let name = resolved
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(str::to_string);
+        return Ok(ContentPart::Document {
+            document: Document {
+                data: engine.encode(&bytes),
+                media_type: "application/pdf".into(),
+                name,
+            },
+        });
+    }
+
+    if !is_probably_text_extension(&resolved) {
+        return Err(format!(
+            "unsupported attachment type for {}: use text, image, or PDF",
+            resolved.display()
+        ));
+    }
+
+    let mut text = std::fs::read_to_string(&resolved)
+        .map_err(|error| format!("could not read {}: {error}", resolved.display()))?;
+    let truncated = text.chars().count() > MAX_TEXT_ATTACH_CHARS;
+    if truncated {
+        text = text.chars().take(MAX_TEXT_ATTACH_CHARS).collect();
+        text.push_str("\n… [truncated]");
+    }
+    let sandbox_canon = std::fs::canonicalize(sandbox_dir).unwrap_or_else(|_| sandbox_dir.to_path_buf());
+    let resolved_canon = std::fs::canonicalize(&resolved).unwrap_or(resolved.clone());
+    let rel = resolved_canon
+        .strip_prefix(&sandbox_canon)
+        .unwrap_or(resolved_canon.as_path());
+    let label = rel.display();
+    let body = format!("<context-file path=\"{label}\">\n{text}\n</context-file>");
+    Ok(ContentPart::Text { text: body })
+}
+
+/// Load many host `--file` paths into attachments; returns warnings for failures.
+pub fn load_host_file_attachments(
+    sandbox_dir: &Path,
+    files: &[PathBuf],
+) -> (Vec<ContentPart>, Vec<String>) {
+    let mut attachments = Vec::new();
+    let mut warnings = Vec::new();
+    for path in files {
+        match load_sandbox_file_attachment(sandbox_dir, path) {
+            Ok(part) => attachments.push(part),
+            Err(error) => warnings.push(error),
+        }
+    }
+    (attachments, warnings)
+}
+
+/// Fuzzy-resolve a partial path / basename under the sandbox (depth-limited walk).
+pub fn fuzzy_resolve_in_sandbox(sandbox_dir: &Path, query: &str) -> Option<PathBuf> {
+    let query = query.trim().trim_start_matches("./");
+    if query.is_empty() {
+        return None;
+    }
+    let query_lower = query.to_ascii_lowercase();
+    let mut matches: Vec<PathBuf> = Vec::new();
+    let mut stack = vec![(sandbox_dir.to_path_buf(), 0u32)];
+    while let Some((dir, depth)) = stack.pop() {
+        if depth > 6 || matches.len() >= 32 {
+            break;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().to_ascii_lowercase();
+            if name == ".git" || name == "node_modules" || name == "target" || name == ".isanagent"
+            {
+                continue;
+            }
+            if path.is_dir() {
+                stack.push((path, depth + 1));
+                continue;
+            }
+            let rel = path
+                .strip_prefix(sandbox_dir)
+                .unwrap_or(path.as_path())
+                .to_string_lossy()
+                .to_ascii_lowercase();
+            if name == query_lower
+                || rel == query_lower
+                || rel.ends_with(&format!("/{query_lower}"))
+                || rel.contains(&query_lower)
+            {
+                matches.push(path);
+            }
+        }
+    }
+    if matches.len() == 1 {
+        return matches.pop();
+    }
+    // Prefer exact basename match when multiple fuzzy hits.
+    let exact: Vec<_> = matches
+        .iter()
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.eq_ignore_ascii_case(query))
+        })
+        .cloned()
+        .collect();
+    if exact.len() == 1 {
+        return exact.into_iter().next();
+    }
+    None
+}
+
 /// Parses a terminal input string for `@<filepath>` references.
 ///
-/// Each `@<path>` token that resolves to a supported image file (png/jpeg/gif/webp)
-/// inside the sandbox is consumed: removed from the returned text, base64-encoded,
-/// and returned as a `ContentPart::ImageUrl` attachment using a data URI.
-///
-/// `@<token>` references that do NOT resolve to an image (missing files, non-image
-/// extensions, outside sandbox) are preserved in the text so they can serve as
-/// agent mentions or other syntax.
-pub(crate) fn parse_terminal_attachments(
+/// Supported attachments: images, PDFs, and common text source files.
+/// Unresolvable `@token`s are preserved as literal text (agent mentions).
+pub fn parse_terminal_attachments(
     input: &str,
     sandbox_dir: &std::path::Path,
 ) -> (String, Vec<ContentPart>) {
-    let engine = base64::engine::general_purpose::STANDARD;
-
     let mut clean_parts: Vec<&str> = Vec::new();
     let mut attachments: Vec<ContentPart> = Vec::new();
     let mut last_end = 0;
@@ -51,41 +218,18 @@ pub(crate) fn parse_terminal_attachments(
             let raw_path = &input[path_start..path_end];
             let expanded = shellexpand::tilde(raw_path).into_owned();
 
-            let expanded_path = std::path::Path::new(&expanded);
-            let path_exists = expanded_path.exists() || sandbox_dir.join(expanded_path).exists();
-
-            // Only strip @token from text when it resolves to a supported image file.
-            // Unresolvable tokens (missing files, non-image types, outside sandbox) are
-            // preserved as regular text so that @agent mentions and similar syntax survive.
             let mut consumed = false;
-            match resolve_path(sandbox_dir, &expanded) {
-                None if path_exists => {
-                    eprintln!("Warning: @<path> is outside the sandbox boundary, skipping.");
+            match load_sandbox_file_attachment(sandbox_dir, Path::new(&expanded)) {
+                Ok(part) => {
+                    attachments.push(part);
+                    consumed = true;
                 }
-                None => {
-                    // File doesn't exist — leave @token as text (may be an agent mention).
-                }
-                Some(file_path) => match image_mime_from_extension(&file_path) {
-                    None => {
-                        // Not a supported image type — leave @token as text.
+                Err(error) => {
+                    // Keep @token when it looks like an agent mention (no slash / no extension).
+                    if expanded.contains('/') || expanded.contains('.') {
+                        eprintln!("Warning: {error}");
                     }
-                    Some(mime) => match std::fs::read(&file_path) {
-                        Err(_) => {
-                            eprintln!("Warning: could not read @<path>, skipping.");
-                        }
-                        Ok(file_bytes) => {
-                            let data_uri =
-                                format!("data:{};base64,{}", mime, engine.encode(&file_bytes));
-                            attachments.push(ContentPart::ImageUrl {
-                                image_url: ImageUrl {
-                                    url: data_uri,
-                                    detail: None,
-                                },
-                            });
-                            consumed = true;
-                        }
-                    },
-                },
+                }
             }
 
             if consumed {
@@ -108,7 +252,8 @@ pub(crate) fn parse_terminal_attachments(
 
 #[cfg(test)]
 mod tests {
-    use super::parse_terminal_attachments;
+    use super::*;
+    use std::fs;
 
     #[test]
     fn no_at_references_returns_text_unchanged() {
@@ -119,94 +264,37 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_extension_is_skipped() {
-        let sandbox = std::env::temp_dir();
-        let path = sandbox.join("isanagent_test_skip.txt");
-        std::fs::write(&path, b"hello").ok();
-        let input = format!("show @{} please", path.display());
-        let (text, attachments) = parse_terminal_attachments(&input, &sandbox);
-        assert!(
-            text.contains('@'),
-            "non-image @reference must stay in text (may be an agent mention)"
-        );
-        assert!(attachments.is_empty(), "non-image files must be skipped");
-        let _ = std::fs::remove_file(&path);
-    }
-
-    #[test]
-    fn missing_file_is_skipped() {
-        let sandbox = std::env::temp_dir();
-        let path = sandbox.join("isanagent_nonexistent_image.png");
-        let _ = std::fs::remove_file(&path);
-        let input = format!("see @{} thanks", path.display());
-        let (text, attachments) = parse_terminal_attachments(&input, &sandbox);
-        assert!(
-            text.contains('@'),
-            "unresolved @reference must stay in text (may be an agent mention)"
-        );
-        assert!(
-            attachments.is_empty(),
-            "missing file must be skipped gracefully"
-        );
-    }
-
-    #[test]
-    fn path_outside_sandbox_is_rejected() {
-        use std::io::Write as _;
-        let tmp = std::env::temp_dir();
-        let sandbox = tmp.join("isanagent_sandbox_test");
-        std::fs::create_dir_all(&sandbox).expect("create sandbox");
-
-        let outside = tmp.join("isanagent_outside_test.png");
-        let png_bytes: &[u8] = &[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
-        let mut f = std::fs::File::create(&outside).expect("create outside png");
-        f.write_all(png_bytes).expect("write png");
-        drop(f);
-
-        let input = format!("describe @{} please", outside.display());
-        let (_text, attachments) = parse_terminal_attachments(&input, &sandbox);
-        assert!(
-            attachments.is_empty(),
-            "file outside sandbox must be rejected"
-        );
-
-        let _ = std::fs::remove_file(&outside);
-        let _ = std::fs::remove_dir_all(&sandbox);
-    }
-
-    #[test]
-    fn existing_image_is_attached_as_data_uri() {
-        use std::io::Write;
-        let sandbox = std::env::temp_dir().join("isanagent_sandbox_image_test");
-        std::fs::create_dir_all(&sandbox).expect("create sandbox");
-        let tmp = sandbox.join("isanagent_terminal_test.png");
-        let png_bytes: &[u8] = &[
-            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48,
-            0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00,
-            0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08,
-            0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21, 0xbc,
-            0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
-        ];
-        let mut f = std::fs::File::create(&tmp).expect("create temp png");
-        f.write_all(png_bytes).expect("write png");
-        drop(f);
-
-        let input = format!("describe this image @{} please", tmp.display());
-        let (text, attachments) = parse_terminal_attachments(&input, &sandbox);
-
-        assert!(!text.contains('@'));
-        assert_eq!(attachments.len(), 1, "should have one image attachment");
-
-        if let crate::utils::ContentPart::ImageUrl { image_url } = &attachments[0] {
-            assert!(
-                image_url.url.starts_with("data:image/png;base64,"),
-                "expected a PNG data URI, got: {}",
-                &image_url.url[..40.min(image_url.url.len())]
-            );
-        } else {
-            panic!("expected ContentPart::ImageUrl");
+    fn loads_text_file_as_context_part() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("note.md");
+        fs::write(&path, "# hello\n").expect("write");
+        let part = load_sandbox_file_attachment(dir.path(), Path::new("note.md")).expect("load");
+        match part {
+            ContentPart::Text { text } => {
+                assert!(text.contains("path=\"note.md\""));
+                assert!(text.contains("# hello"));
+            }
+            other => panic!("expected text part, got {other:?}"),
         }
+    }
 
-        let _ = std::fs::remove_dir_all(&sandbox);
+    #[test]
+    fn fuzzy_resolves_unique_basename() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let nested = dir.path().join("src");
+        fs::create_dir_all(&nested).expect("mkdir");
+        fs::write(nested.join("unique_m4_file.rs"), "fn main() {}\n").expect("write");
+        let found = fuzzy_resolve_in_sandbox(dir.path(), "unique_m4_file.rs").expect("fuzzy");
+        assert!(found.ends_with("unique_m4_file.rs"));
+    }
+
+    #[test]
+    fn at_text_reference_is_consumed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("README.md"), "docs\n").expect("write");
+        let (text, attachments) =
+            parse_terminal_attachments("summarize @README.md please", dir.path());
+        assert_eq!(text, "summarize  please");
+        assert_eq!(attachments.len(), 1);
     }
 }

--- a/src/channels/terminal_ui/mod.rs
+++ b/src/channels/terminal_ui/mod.rs
@@ -4,6 +4,7 @@
 #![allow(dead_code, unused_imports)]
 
 mod app;
+pub(crate) mod approval;
 mod attachments;
 mod execution_browser;
 mod history_cells;
@@ -20,9 +21,15 @@ pub use app::{
     TerminalUiFocus, TerminalUiMode, ToastKind, ToolNoticePhase, ToolRailEntry,
     TranscriptSelection,
 };
-pub use theme::{init, init_from_env, uses_ansi_color, Theme};
+pub use approval::{approval_hotkey_reply, EditDiffPayload, APPROVAL_CHOICES};
+pub use attachments::{
+    load_host_file_attachments, load_sandbox_file_attachment, parse_terminal_attachments,
+};
+pub use theme::{
+    current_appearance, init, init_appearance, init_from_env, init_from_host,
+    resolve_host_appearance, uses_ansi_color, HostThemeMode, Theme, ThemeAppearance,
+};
 
-pub(crate) use attachments::parse_terminal_attachments;
 pub(crate) use run::{run_ratatui_main, RatatuiMainConfig};
 
 use unicode_width::UnicodeWidthStr;

--- a/src/channels/terminal_ui/panes/cell_render.rs
+++ b/src/channels/terminal_ui/panes/cell_render.rs
@@ -111,22 +111,55 @@ pub(crate) fn cell_block_lines(cell: &Cell, inner_width: usize) -> Vec<Line<'sta
             v.push(Line::from(""));
             v
         }
-        Cell::Clarification { text, choices } => {
+        Cell::Clarification {
+            text,
+            choices,
+            edit_diff,
+        } => {
             let inner = w.saturating_sub(2).max(8);
+            let title = if edit_diff.is_some() {
+                "edit approval"
+            } else {
+                "approval"
+            };
             let mut v = vec![Line::from(vec![
                 Span::styled(" ? ", Theme::clarification()),
-                Span::styled("question", Theme::clarification()),
+                Span::styled(title, Theme::clarification().add_modifier(Modifier::BOLD)),
             ])];
+            if let Some(diff) = edit_diff {
+                v.push(Line::from(vec![
+                    Span::styled(" file ", Theme::dim()),
+                    Span::styled(diff.file.clone(), Theme::active()),
+                ]));
+                if diff.truncated {
+                    v.push(Line::from(Span::styled(
+                        " [truncated]",
+                        Theme::tool_call(),
+                    )));
+                }
+                v.extend(crate::channels::terminal_ui::approval::diff_lines_to_spans(
+                    &diff.diff,
+                    40,
+                ));
+            }
             for ln in wrap_text(text, inner) {
                 v.push(Line::from(Span::styled(ln, Theme::clarification())));
             }
-            if !choices.is_empty() {
+            let shown_choices = if choices.is_empty() {
+                crate::channels::terminal_ui::APPROVAL_CHOICES
+                    .iter()
+                    .map(|s| (*s).to_string())
+                    .collect::<Vec<_>>()
+            } else {
+                choices.clone()
+            };
+            if !shown_choices.is_empty() {
                 v.push(Line::from(Span::styled(
-                    "Reply with a number (1–n) or the exact option text.",
+                    "1 approve · 2 deny · 3 always · 4 abort  (or type the option)",
                     Theme::dim(),
                 )));
                 let indent = "   ";
-                for (i, choice) in choices.iter().enumerate() {
+                for (i, choice) in shown_choices.iter().enumerate() {
                     let n = i + 1;
                     let head = format!("{n}. ");
                     let first = format!("{head}{choice}");

--- a/src/channels/terminal_ui/run.rs
+++ b/src/channels/terminal_ui/run.rs
@@ -42,9 +42,8 @@ use crate::channels::terminal_ui::protocol::{
 };
 use crate::channels::terminal_ui::text_format::truncate_chars_display;
 use crate::channels::terminal_ui::{
-    execution_browser, init, uses_ansi_color, AgentTaskStatus, App, Cell, JobStripStatus,
-    ModelSelector, TerminalUiFocus, Theme, ToastKind, ToolNoticePhase, ToolRailEntry,
-    TranscriptSelection,
+    execution_browser, uses_ansi_color, AgentTaskStatus, App, Cell, JobStripStatus, ModelSelector,
+    TerminalUiFocus, Theme, ToastKind, ToolNoticePhase, ToolRailEntry, TranscriptSelection,
 };
 use crate::clarification::{METADATA_CLARIFICATION, METADATA_CLARIFICATION_CHOICES};
 use crate::memory::{chat_id_from_root_thread_id, MemoryMessage, SharedReply};
@@ -391,9 +390,20 @@ fn outbound_to_cell(msg: &OutboundMessage) -> Cell {
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
+        let edit_diff = msg.metadata.get("edit_diff").and_then(|v| {
+            let file = v.get("file")?.as_str()?.to_string();
+            let diff = v.get("diff")?.as_str()?.to_string();
+            let truncated = v.get("truncated").and_then(|t| t.as_bool()).unwrap_or(false);
+            Some(crate::channels::terminal_ui::EditDiffPayload {
+                file,
+                diff,
+                truncated,
+            })
+        });
         Cell::Clarification {
             text: msg.content.clone(),
             choices,
+            edit_diff,
         }
     } else {
         Cell::Assistant {
@@ -423,6 +433,44 @@ fn layout_chunks(area: Rect, exec_panel_h: u16, active_tool_h: u16, input_h: u16
     [
         chunks[0], chunks[1], chunks[2], chunks[3], chunks[4], chunks[5],
     ]
+}
+
+/// ALTAI Task Session density breakpoints (cols).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LayoutDensity {
+    Narrow,
+    Medium,
+    Wide,
+}
+
+impl LayoutDensity {
+    pub(crate) fn from_cols(cols: u16) -> Self {
+        if cols < 80 {
+            Self::Narrow
+        } else if cols < 120 {
+            Self::Medium
+        } else {
+            Self::Wide
+        }
+    }
+}
+
+/// Split the main content region for wide terminals when a secondary pane is focused.
+fn split_main_content(
+    area: Rect,
+    density: LayoutDensity,
+    focus: TerminalUiFocus,
+) -> (Rect, Option<Rect>) {
+    if density == LayoutDensity::Wide && focus != TerminalUiFocus::Transcript {
+        let side = (area.width / 3).clamp(28, 56);
+        let parts = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Min(24), Constraint::Length(side)])
+            .split(area);
+        (parts[0], Some(parts[1]))
+    } else {
+        (area, None)
+    }
 }
 
 fn chunks_line_width(spans: &[Span<'static>]) -> usize {
@@ -677,11 +725,53 @@ fn line_from_chunk_groups(groups: Vec<Vec<Span<'static>>>, max_width: usize) -> 
     }
 }
 
-fn build_title_line(max_width: usize) -> Line<'static> {
-    let groups = vec![vec![Span::styled(
-        " ALTAI isanagent ",
-        Theme::input_prompt(),
-    )]];
+fn build_title_line(max_width: usize, app: &App) -> Line<'static> {
+    let dim = Theme::dim();
+    let workspace = if app.status_workspace.is_empty() {
+        "workspace".to_string()
+    } else {
+        app.status_workspace.clone()
+    };
+    let model = if app.status_model.is_empty() {
+        "model?".to_string()
+    } else {
+        app.status_model.clone()
+    };
+    let permission = if app.status_permission.is_empty() {
+        "default".to_string()
+    } else {
+        app.status_permission.clone()
+    };
+    let session = if app.status_session.is_empty() {
+        "—".to_string()
+    } else {
+        app.status_session.clone()
+    };
+    let mut groups: Vec<Vec<Span<'static>>> = vec![
+        vec![Span::styled(" ALTAI ", Theme::active())],
+        vec![
+            Span::styled("· ", dim),
+            Span::styled(workspace, Theme::text()),
+        ],
+        vec![
+            Span::styled(" · ", dim),
+            Span::styled(model, Theme::active()),
+        ],
+        vec![
+            Span::styled(" · ", dim),
+            Span::styled(permission, dim),
+        ],
+        vec![
+            Span::styled(" · ", dim),
+            Span::styled(format!("session {session}"), dim),
+        ],
+    ];
+    if !uses_ansi_color() {
+        groups.push(vec![
+            Span::styled(" · ", dim),
+            Span::styled("[plain]", dim),
+        ]);
+    }
     line_from_chunk_groups(groups, max_width)
 }
 
@@ -694,12 +784,12 @@ fn build_status_line(
 ) -> Line<'static> {
     let dim = Theme::dim();
     let activity_label = if thinking {
-        format!("🦾 {} thinking", app.get_spinner_frame())
+        format!("running {} thinking", app.get_spinner_frame())
     } else {
-        "🦾 idle".to_string()
+        "idle".to_string()
     };
     let activity_style = if thinking {
-        Theme::tool_call()
+        Theme::active()
     } else {
         Theme::dim()
     };
@@ -711,21 +801,21 @@ fn build_status_line(
         first_row,
         vec![
             Span::styled(" · ", dim),
-            Span::styled(format!("[ 📋 {} Todos ]", app.todos_count), dim),
+            Span::styled(format!("todos {}", app.todos_count), dim),
         ],
         vec![
             Span::styled(" · ", dim),
-            Span::styled(format!("[ 🕒 {} Crons ]", app.crons_count), dim),
+            Span::styled(format!("crons {}", app.crons_count), dim),
         ],
         vec![
             Span::styled(" · ", dim),
-            Span::styled(format!("[ 🛠 {} Jobs ]", app.jobs_strip.len()), dim),
+            Span::styled(format!("jobs {}", app.jobs_strip.len()), dim),
         ],
         vec![
             Span::styled(" · ", dim),
             Span::styled(
                 format!(
-                    "[ 🤖 {} Agents ]",
+                    "agents {}",
                     app.agent_tasks.iter().filter(|e| !e.status.is_terminal()).count()
                 ),
                 dim,
@@ -738,7 +828,7 @@ fn build_status_line(
         vec![
             Span::styled(" · ", dim),
             Span::styled(
-                "Enter send · ^G background · ^Shift+Y copy last · ^Shift+M wheel · ^W word · ^U clear · ^C cancel · ^D exit",
+                "Enter send · ^G jobs · Tab panes · ^C cancel · ^D exit",
                 Theme::status_bar(),
             ),
         ],
@@ -1291,12 +1381,15 @@ pub(crate) struct RatatuiMainConfig {
     pub channel_name: String,
     pub opening_banner: String,
     pub status_model: String,
+    pub status_permission: String,
     /// Workspace memory (same as agent) for past-session list and transcript load.
     pub memory_node: NodeHandle<MemoryMessage>,
     /// Named alternative providers for `/model` switching.
     pub providers: std::collections::HashMap<String, crate::config::ProviderConfig>,
     /// Whether the host permits ANSI foreground colors for this session.
     pub color_enabled: bool,
+    /// Host-selected ALTAI theme mode.
+    pub theme: super::HostThemeMode,
     /// Whether `chat_id` names a persisted chat that should be loaded.
     pub resume_session: bool,
     /// File references composed into the first user message.
@@ -1315,9 +1408,11 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
         channel_name,
         opening_banner,
         status_model,
+        status_permission,
         memory_node,
         providers,
         color_enabled,
+        theme,
         resume_session,
         initial_files,
     } = config;
@@ -1327,7 +1422,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
         .build()
         .map_err(io::Error::other)?;
 
-    init(color_enabled);
+    super::init_from_host(theme, !color_enabled);
 
     let mut stdout = stdout();
     enable_raw_mode()?;
@@ -1352,6 +1447,21 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
 
     let mut app = App::new();
     app.status_model = status_model;
+    app.status_permission = status_permission;
+    app.status_workspace = sandbox_dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("workspace")
+        .to_string();
+    app.status_session = {
+        let n = chat_id.chars().count();
+        if n <= 13 {
+            chat_id.clone()
+        } else {
+            let tail: String = chat_id.chars().skip(n - 12).collect();
+            format!("…{tail}")
+        }
+    };
     app.cells.push(Cell::System {
         message: opening_banner,
     });
@@ -1690,6 +1800,9 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                     app.upsert_tool_notice(tool_call_id, phase, content);
                 }
                 other => {
+                    if matches!(other, Cell::Clarification { .. }) {
+                        app.pending_approval = true;
+                    }
                     append_cell_merging_thought(&mut app.cells, other);
                 }
             }
@@ -1738,11 +1851,122 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
             }
             let input_h = (visual_lines + 2).clamp(3, 12);
             let ch = layout_chunks(area, exec_h, active_strip_h, input_h);
+            let density = LayoutDensity::from_cols(area.width);
 
             let title_w = ch[0].width as usize;
-            let title = Paragraph::new(build_title_line(title_w.max(1)));
+            let title = Paragraph::new(build_title_line(title_w.max(1), &app));
             f.render_widget(title, ch[0]);
 
+            let (main_left, side_opt) = split_main_content(ch[1], density, app.ui_focus);
+            if let Some(side) = side_opt {
+                let (w, max_s, vis_start) = transcript_paragraph(
+                    &app.cells,
+                    main_left,
+                    app.scroll_offset,
+                    app.transcript_selection.as_ref(),
+                );
+                max_transcript_scroll_holder.set(max_s);
+                app.last_transcript_visible_start = vis_start;
+                f.render_widget(w, main_left);
+                app.last_transcript_rect = Some(main_left);
+                // Focused secondary pane occupies the right column.
+                let pane = side;
+                match app.ui_focus {
+                    TerminalUiFocus::Transcript => {}
+                    TerminalUiFocus::Conversations => {
+                        let (w, max_s) = conversations_list_paragraph(&app, pane);
+                        max_conversations_list_scroll_holder.set(max_s);
+                        f.render_widget(w, pane);
+                        app.last_conversations_list_rect = Some(pane);
+                        app.last_tool_history_rect = None;
+                        app.last_executions_list_rect = None;
+                        app.last_executions_code_rect = None;
+                        app.last_executions_output_rect = None;
+                        app.last_agent_tasks_rect = None;
+                    }
+                    TerminalUiFocus::Executions => {
+                        let list_w = (pane.width / 3).clamp(18, 36);
+                        let hareas = Layout::default()
+                            .direction(Direction::Horizontal)
+                            .constraints([Constraint::Length(list_w), Constraint::Min(6)])
+                            .split(pane);
+                        let (pl, max_l) = executions_list_paragraph(&app, hareas[0]);
+                        max_exec_list_scroll_holder.set(max_l);
+                        f.render_widget(pl, hareas[0]);
+                        app.last_executions_list_rect = Some(hareas[0]);
+                        app.last_conversations_list_rect = None;
+                        app.last_tool_history_rect = None;
+                        app.last_agent_tasks_rect = None;
+                        match &app.executions_detail {
+                            Some(d) => {
+                                let vareas = Layout::default()
+                                    .direction(Direction::Vertical)
+                                    .constraints([
+                                        Constraint::Percentage(52),
+                                        Constraint::Percentage(48),
+                                    ])
+                                    .split(hareas[1]);
+                                let (pc, max_c) = executions_code_paragraph(
+                                    d,
+                                    vareas[0],
+                                    app.executions_code_scroll_top,
+                                );
+                                max_exec_code_scroll_holder.set(max_c);
+                                f.render_widget(pc, vareas[0]);
+                                let (po, max_o) = executions_output_paragraph(
+                                    &d.journal,
+                                    vareas[1],
+                                    app.executions_output_scroll_top,
+                                );
+                                max_exec_out_scroll_holder.set(max_o);
+                                f.render_widget(po, vareas[1]);
+                                app.last_executions_code_rect = Some(vareas[0]);
+                                app.last_executions_output_rect = Some(vareas[1]);
+                            }
+                            None => {
+                                max_exec_code_scroll_holder.set(0);
+                                max_exec_out_scroll_holder.set(0);
+                                app.last_executions_code_rect = None;
+                                app.last_executions_output_rect = None;
+                            }
+                        }
+                    }
+                    TerminalUiFocus::ToolHistory => {
+                        let (w, max_s) = tool_history_paragraph(
+                            &app.tool_rail,
+                            pane,
+                            app.tool_history_scroll,
+                        );
+                        max_tool_history_scroll_holder.set(max_s);
+                        f.render_widget(w, pane);
+                        app.last_tool_history_rect = Some(pane);
+                        app.last_conversations_list_rect = None;
+                        app.last_executions_list_rect = None;
+                        app.last_agent_tasks_rect = None;
+                    }
+                    TerminalUiFocus::AgentTasks | TerminalUiFocus::BackgroundJobs => {
+                        let list = background_pane_paragraph(&app);
+                        let title = if app.ui_focus == TerminalUiFocus::BackgroundJobs {
+                            " background "
+                        } else {
+                            " sub-agents "
+                        };
+                        let w = Paragraph::new(Text::from(list))
+                            .block(
+                                Block::default()
+                                    .borders(Borders::ALL)
+                                    .title(Span::styled(title, Theme::tool_call()))
+                                    .border_style(Theme::dim()),
+                            )
+                            .scroll((app.agent_tasks_scroll_top as u16, 0));
+                        f.render_widget(w, pane);
+                        app.last_agent_tasks_rect = Some(pane);
+                        app.last_conversations_list_rect = None;
+                        app.last_tool_history_rect = None;
+                        app.last_executions_list_rect = None;
+                    }
+                }
+            } else {
             match app.ui_focus {
                 TerminalUiFocus::Transcript => {
                     let (w, max_s, vis_start) = transcript_paragraph(
@@ -1875,6 +2099,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                     app.last_conversations_list_rect = None;
                 }
             }
+            } // end single-pane (non-wide) branch
 
             if exec_h > 0 {
                 let exec_block = Block::default()
@@ -2665,6 +2890,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
 
                         app.cells.push(Cell::User { text: raw.clone() });
                         app.thinking = true;
+                        app.pending_approval = false;
                         app.last_inbound_text = Some(text.to_string());
                         app.llm_retry_available = false;
                         let (clean_text, attachments) =
@@ -2967,6 +3193,37 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                             }
                         }
                     }
+                    KeyCode::Char(c) if app.pending_approval && app.input.is_empty() => {
+                        if let Some(reply) =
+                            crate::channels::terminal_ui::approval_hotkey_reply(c)
+                        {
+                            app.cells.push(Cell::User {
+                                text: reply.to_string(),
+                            });
+                            app.thinking = true;
+                            app.pending_approval = false;
+                            app.last_inbound_text = Some(reply.to_string());
+                            let msg = InboundMessage {
+                                channel: channel_name.clone(),
+                                sender_id: "local_user".to_string(),
+                                chat_id: chat_id.clone(),
+                                thread_id: None,
+                                content: reply.to_string(),
+                                attachments: Vec::new(),
+                                metadata: Default::default(),
+                            };
+                            if bus_tx.blocking_send(BusMessage::Inbound(msg)).is_err() {
+                                app.thinking = false;
+                                app.cells.push(Cell::System {
+                                    message: "Bus closed; exiting.".into(),
+                                });
+                                app.request_quit();
+                            }
+                            app.scroll_to_bottom();
+                        } else {
+                            app.insert_char(c);
+                        }
+                    }
                     KeyCode::Char(c) => app.insert_char(c),
                     _ => {}
                 }
@@ -3249,10 +3506,14 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
 
 #[cfg(test)]
 mod width_fit_tests {
-    use super::{build_status_line, build_title_line};
+    use super::{
+        build_status_line, build_title_line, split_main_content, LayoutDensity,
+    };
     use crate::channels::terminal_ui::app::App;
     use crate::channels::terminal_ui::display_width;
     use crate::channels::terminal_ui::text_format::truncate_chars_display;
+    use crate::channels::terminal_ui::TerminalUiFocus;
+    use ratatui::layout::Rect;
     use ratatui::text::Line;
 
     fn flat(line: &Line) -> String {
@@ -3261,6 +3522,15 @@ mod width_fit_tests {
             .map(|s| s.content.as_ref())
             .collect::<Vec<_>>()
             .join("")
+    }
+
+    fn sample_app() -> App {
+        let mut app = App::new();
+        app.status_workspace = "altai-app".into();
+        app.status_model = "anthropic/claude-sonnet".into();
+        app.status_permission = "plan".into();
+        app.status_session = "…abc123".into();
+        app
     }
 
     #[test]
@@ -3276,12 +3546,10 @@ mod width_fit_tests {
 
     #[test]
     fn status_drops_low_priority_when_narrow() {
-        let app = App::new();
+        let app = sample_app();
         let line = build_status_line(26, false, 3, None, &app);
         let t = flat(&line);
-        assert!(t.contains("🦾"), "{t}");
-        assert!(t.contains("idle"));
-        assert!(!t.contains("thread"), "{t}");
+        assert!(t.contains("idle"), "{t}");
         assert!(
             !t.contains("Enter send"),
             "hints should drop first when tight: {t}"
@@ -3289,11 +3557,54 @@ mod width_fit_tests {
     }
 
     #[test]
-    fn title_shows_brand_only() {
-        let line = build_title_line(120);
+    fn title_shows_brand_workspace_model() {
+        let app = sample_app();
+        let line = build_title_line(160, &app);
         let t = flat(&line);
-        assert!(t.contains("ALTAI isanagent"), "{t}");
-        assert!(!t.contains("thread "), "{t}");
+        assert!(t.contains("ALTAI"), "{t}");
+        assert!(t.contains("altai-app"), "{t}");
+        assert!(t.contains("anthropic/claude-sonnet"), "{t}");
+        assert!(t.contains("plan"), "{t}");
+    }
+
+    #[test]
+    fn title_and_status_fit_snapshot_widths() {
+        let app = sample_app();
+        for width in [80usize, 100, 160] {
+            let title = flat(&build_title_line(width, &app));
+            let status = flat(&build_status_line(width, false, 3, None, &app));
+            assert!(
+                display_width(&title) <= width,
+                "title overflow at {width}: {title:?}"
+            );
+            assert!(
+                display_width(&status) <= width,
+                "status overflow at {width}: {status:?}"
+            );
+            assert!(title.contains("ALTAI"), "{title}");
+            assert!(status.contains("idle"), "{status}");
+        }
+    }
+
+    #[test]
+    fn layout_density_breakpoints() {
+        assert_eq!(LayoutDensity::from_cols(79), LayoutDensity::Narrow);
+        assert_eq!(LayoutDensity::from_cols(80), LayoutDensity::Medium);
+        assert_eq!(LayoutDensity::from_cols(119), LayoutDensity::Medium);
+        assert_eq!(LayoutDensity::from_cols(120), LayoutDensity::Wide);
+    }
+
+    #[test]
+    fn wide_layout_splits_secondary_pane() {
+        let area = Rect::new(0, 0, 160, 40);
+        let (left, right) =
+            split_main_content(area, LayoutDensity::Wide, TerminalUiFocus::ToolHistory);
+        assert!(right.is_some());
+        assert!(left.width + right.unwrap().width <= area.width);
+        let (only, none) =
+            split_main_content(area, LayoutDensity::Medium, TerminalUiFocus::ToolHistory);
+        assert!(none.is_none());
+        assert_eq!(only, area);
     }
 }
 

--- a/src/channels/terminal_ui/theme.rs
+++ b/src/channels/terminal_ui/theme.rs
@@ -1,10 +1,48 @@
 #![allow(dead_code)]
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
 use ratatui::style::{Color, Modifier, Style};
 
 static USE_ANSI_COLOR: AtomicBool = AtomicBool::new(true);
+/// 0 = dark, 1 = light, 2 = no-color (structure only).
+static APPEARANCE: AtomicU8 = AtomicU8::new(0);
+
+/// Host-selected theme mode before auto / NO_COLOR resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HostThemeMode {
+    #[default]
+    Auto,
+    Dark,
+    Light,
+    NoColor,
+}
+
+/// Effective appearance applied to the TUI for this process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThemeAppearance {
+    Dark,
+    Light,
+    NoColor,
+}
+
+impl ThemeAppearance {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Light,
+            2 => Self::NoColor,
+            _ => Self::Dark,
+        }
+    }
+
+    fn as_u8(self) -> u8 {
+        match self {
+            Self::Dark => 0,
+            Self::Light => 1,
+            Self::NoColor => 2,
+        }
+    }
+}
 
 /// Read [`NO_COLOR`](https://no-color.org/) and store whether to emit ANSI colors. Call once from the Ratatui entry before the first draw.
 pub fn init_from_env() {
@@ -18,6 +56,51 @@ pub fn init_from_env() {
 /// Set the color capability chosen by an embedding host for this TUI session.
 pub fn init(allow: bool) {
     USE_ANSI_COLOR.store(allow, Ordering::Relaxed);
+    if !allow {
+        APPEARANCE.store(ThemeAppearance::NoColor.as_u8(), Ordering::Relaxed);
+    }
+}
+
+/// Apply a resolved ALTAI appearance (dark / light / no-color).
+pub fn init_appearance(appearance: ThemeAppearance) {
+    APPEARANCE.store(appearance.as_u8(), Ordering::Relaxed);
+    USE_ANSI_COLOR.store(appearance != ThemeAppearance::NoColor, Ordering::Relaxed);
+}
+
+/// Resolve host theme + NO_COLOR into an appearance and apply it.
+pub fn init_from_host(theme: HostThemeMode, no_color: bool) {
+    let appearance = resolve_host_appearance(theme, no_color);
+    init_appearance(appearance);
+}
+
+/// Resolve without mutating global theme state (for tests and adapters).
+pub fn resolve_host_appearance(theme: HostThemeMode, no_color: bool) -> ThemeAppearance {
+    if no_color || theme == HostThemeMode::NoColor {
+        return ThemeAppearance::NoColor;
+    }
+    match theme {
+        HostThemeMode::Dark => ThemeAppearance::Dark,
+        HostThemeMode::Light => ThemeAppearance::Light,
+        HostThemeMode::NoColor => ThemeAppearance::NoColor,
+        HostThemeMode::Auto => detect_auto_appearance(),
+    }
+}
+
+fn detect_auto_appearance() -> ThemeAppearance {
+    if let Ok(raw) = std::env::var("COLORFGBG") {
+        if let Some(bg) = raw
+            .split(';')
+            .nth(1)
+            .and_then(|part| part.trim().parse::<u8>().ok())
+        {
+            return if bg >= 8 {
+                ThemeAppearance::Light
+            } else {
+                ThemeAppearance::Dark
+            };
+        }
+    }
+    ThemeAppearance::Dark
 }
 
 #[inline]
@@ -29,6 +112,54 @@ fn ansi_color() -> bool {
 #[inline]
 pub fn uses_ansi_color() -> bool {
     ansi_color()
+}
+
+#[inline]
+pub fn current_appearance() -> ThemeAppearance {
+    ThemeAppearance::from_u8(APPEARANCE.load(Ordering::Relaxed))
+}
+
+/// Truecolor roles derived from ALTAI App `globals.css` OKLCH tokens.
+#[derive(Debug, Clone, Copy)]
+struct Palette {
+    text: Color,
+    muted: Color,
+    active: Color,
+    warning: Color,
+    success: Color,
+    info: Color,
+    error: Color,
+    focus: Color,
+}
+
+const DARK: Palette = Palette {
+    text: Color::Rgb(240, 242, 244),
+    muted: Color::Rgb(137, 140, 146),
+    active: Color::Rgb(181, 234, 38),
+    warning: Color::Rgb(245, 174, 57),
+    success: Color::Rgb(81, 198, 114),
+    info: Color::Rgb(75, 174, 237),
+    error: Color::Rgb(248, 75, 75),
+    focus: Color::Rgb(93, 114, 149),
+};
+
+const LIGHT: Palette = Palette {
+    text: Color::Rgb(19, 22, 28),
+    muted: Color::Rgb(81, 85, 92),
+    active: Color::Rgb(154, 211, 53),
+    warning: Color::Rgb(201, 105, 0),
+    success: Color::Rgb(0, 127, 53),
+    info: Color::Rgb(0, 106, 175),
+    error: Color::Rgb(212, 9, 36),
+    focus: Color::Rgb(79, 100, 134),
+};
+
+fn palette() -> Option<&'static Palette> {
+    match current_appearance() {
+        ThemeAppearance::Dark => Some(&DARK),
+        ThemeAppearance::Light => Some(&LIGHT),
+        ThemeAppearance::NoColor => None,
+    }
 }
 
 #[inline]
@@ -49,63 +180,153 @@ fn fg_mod(c: Color, m: Modifier) -> Style {
     }
 }
 
-/// Default palette for the TUI (tuned for dark terminals). Honors `NO_COLOR` (no foreground colors; modifiers kept for structure).
+/// Default palette for the TUI. Honors host theme + `NO_COLOR`.
 #[derive(Debug, Clone, Copy)]
 pub struct Theme;
 
 impl Theme {
     pub fn text() -> Style {
-        fg(Color::White)
+        match palette() {
+            Some(p) => fg(p.text),
+            None => Style::default(),
+        }
     }
 
     pub fn dim() -> Style {
-        fg(Color::DarkGray)
+        match palette() {
+            Some(p) => fg(p.muted),
+            None => Style::default().add_modifier(Modifier::DIM),
+        }
     }
 
     pub fn user_prefix() -> Style {
-        fg_mod(Color::Cyan, Modifier::BOLD)
+        match palette() {
+            Some(p) => fg_mod(p.info, Modifier::BOLD),
+            None => Style::default().add_modifier(Modifier::BOLD),
+        }
     }
 
     pub fn assistant_bullet() -> Style {
-        fg(Color::DarkGray)
+        Theme::dim()
     }
 
     pub fn thinking() -> Style {
-        fg_mod(Color::DarkGray, Modifier::ITALIC)
+        match palette() {
+            Some(p) => fg_mod(p.muted, Modifier::ITALIC),
+            None => Style::default().add_modifier(Modifier::ITALIC | Modifier::DIM),
+        }
     }
 
     pub fn tool_call() -> Style {
-        fg(Color::Yellow)
+        match palette() {
+            Some(p) => fg(p.warning),
+            None => Style::default().add_modifier(Modifier::BOLD),
+        }
     }
 
     /// Yellow + dim/italic, used for in-flight `Cell::ToolNotice` cells whose result
     /// has not yet arrived. Distinguishes "waiting" from a finished green/red result.
     pub fn tool_pending() -> Style {
-        fg_mod(Color::Yellow, Modifier::DIM | Modifier::ITALIC)
+        match palette() {
+            Some(p) => fg_mod(p.warning, Modifier::DIM | Modifier::ITALIC),
+            None => Style::default().add_modifier(Modifier::DIM | Modifier::ITALIC),
+        }
     }
 
     pub fn tool_done() -> Style {
-        fg(Color::Green)
+        match palette() {
+            Some(p) => fg(p.success),
+            None => Style::default().add_modifier(Modifier::BOLD),
+        }
     }
 
     pub fn clarification() -> Style {
-        fg(Color::Magenta)
+        match palette() {
+            Some(p) => fg(p.focus),
+            None => Style::default().add_modifier(Modifier::BOLD),
+        }
     }
 
     pub fn error() -> Style {
-        fg(Color::Red)
+        match palette() {
+            Some(p) => fg(p.error),
+            None => Style::default().add_modifier(Modifier::BOLD),
+        }
     }
 
     pub fn status_bar() -> Style {
-        fg(Color::Gray)
+        Theme::dim()
+    }
+
+    /// Lime/active accent — focused control, brand mark, progress.
+    pub fn active() -> Style {
+        match palette() {
+            Some(p) => fg_mod(p.active, Modifier::BOLD),
+            None => Style::default().add_modifier(Modifier::BOLD),
+        }
     }
 
     pub fn input_prompt() -> Style {
-        fg_mod(Color::Green, Modifier::BOLD)
+        Theme::active()
     }
 
     /// Highlight style for mouse-selected text in the transcript.
     pub fn selection() -> Style {
         Style::default().add_modifier(Modifier::REVERSED)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_color_disables_ansi() {
+        assert_eq!(
+            resolve_host_appearance(HostThemeMode::Dark, true),
+            ThemeAppearance::NoColor
+        );
+        assert_eq!(
+            resolve_host_appearance(HostThemeMode::NoColor, false),
+            ThemeAppearance::NoColor
+        );
+    }
+
+    #[test]
+    fn light_theme_sets_appearance() {
+        assert_eq!(
+            resolve_host_appearance(HostThemeMode::Light, false),
+            ThemeAppearance::Light
+        );
+        assert_eq!(
+            resolve_host_appearance(HostThemeMode::Dark, false),
+            ThemeAppearance::Dark
+        );
+    }
+
+    #[test]
+    fn resolve_respects_explicit_modes() {
+        assert_eq!(
+            resolve_host_appearance(HostThemeMode::Dark, false),
+            ThemeAppearance::Dark
+        );
+        assert_eq!(
+            resolve_host_appearance(HostThemeMode::Light, false),
+            ThemeAppearance::Light
+        );
+        assert_eq!(
+            resolve_host_appearance(HostThemeMode::Auto, true),
+            ThemeAppearance::NoColor
+        );
+    }
+
+    #[test]
+    fn init_from_host_applies_no_color() {
+        init_from_host(HostThemeMode::Dark, true);
+        assert!(!uses_ansi_color());
+        assert_eq!(current_appearance(), ThemeAppearance::NoColor);
+        // Restore a colored dark default for other single-threaded callers.
+        init_from_host(HostThemeMode::Dark, false);
+        assert!(uses_ansi_color());
     }
 }

--- a/src/channels/tty_prompt.rs
+++ b/src/channels/tty_prompt.rs
@@ -1,0 +1,60 @@
+//! Interactive approval prompts against the controlling terminal (`/dev/tty` / `CONIN$`).
+
+use std::io::{self, BufRead, Write};
+
+/// Open the process-controlling terminal for interactive prompts even when stdin/stdout are pipes.
+pub fn open_tty() -> io::Result<(Box<dyn Write + Send>, Box<dyn BufRead + Send>)> {
+    #[cfg(unix)]
+    {
+        use std::fs::OpenOptions;
+        let writer = OpenOptions::new().write(true).open("/dev/tty")?;
+        let reader = OpenOptions::new().read(true).open("/dev/tty")?;
+        Ok((
+            Box::new(io::BufWriter::new(writer)),
+            Box::new(io::BufReader::new(reader)),
+        ))
+    }
+    #[cfg(windows)]
+    {
+        use std::fs::OpenOptions;
+        let writer = OpenOptions::new().write(true).open("CONOUT$")?;
+        let reader = OpenOptions::new().read(true).open("CONIN$")?;
+        Ok((
+            Box::new(io::BufWriter::new(writer)),
+            Box::new(io::BufReader::new(reader)),
+        ))
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "no controlling TTY API on this platform",
+        ))
+    }
+}
+
+/// Returns true when a controlling TTY can be opened for interactive approval.
+pub fn tty_available() -> bool {
+    open_tty().is_ok()
+}
+
+/// Print `prompt` to the controlling TTY and read one line of reply.
+pub fn prompt_on_tty(prompt: &str) -> io::Result<String> {
+    let (mut writer, mut reader) = open_tty()?;
+    write!(writer, "{prompt}")?;
+    writer.flush()?;
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    Ok(line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tty_probe_does_not_panic() {
+        // In CI / sandboxes /dev/tty may be absent; just ensure the probe is safe.
+        let _ = tty_available();
+    }
+}

--- a/src/host.rs
+++ b/src/host.rs
@@ -18,6 +18,7 @@ use crate::channels::terminal::{
     build_tool_progress_terminal_notice, build_tool_result_terminal_notice,
     terminal_startup_suppresses_plain_banner, TerminalChannelConfig, TerminalMode,
 };
+use crate::channels::oneshot::OneshotChannel;
 use crate::channels::{
     api::ApiChannel, email::EmailChannel, slack::SlackChannel, terminal::TerminalChannel, Channel,
 };
@@ -87,12 +88,32 @@ pub struct HostConfig {
     pub permission: Option<HostPermissionMode>,
     /// Disable ANSI foreground colors while retaining terminal structure.
     pub no_color: bool,
+    /// ALTAI terminal appearance. `no_color` / `NO_COLOR` still win.
+    pub theme: HostThemeMode,
     /// Existing terminal chat identifier to load on startup.
     pub resume: Option<String>,
     /// Files preloaded into the terminal's next composed message.
     pub files: Vec<PathBuf>,
     pub line_mode: bool,
+    /// Optional override for between-turn auto-compaction (`None` = config default).
+    pub compact_auto: Option<bool>,
+    /// Optional override for the auto-compaction token threshold.
+    pub compact_threshold_tokens: Option<usize>,
+    /// Optional override for recent-summary / tail retention.
+    pub compact_tail_turns: Option<usize>,
+    /// When set, disable the interactive terminal, inject this prompt once through
+    /// the headless `altai-cli` channel, and shut down after the run terminates.
+    pub oneshot_prompt: Option<String>,
+    /// Optional observer for raw host bus messages during interactive or oneshot runs.
+    pub observe_tx: Option<mpsc::UnboundedSender<BusMessage>>,
+    /// Deterministic in-process assistant replies for tests and CI smokes.
+    /// When set, the host skips network providers and returns these responses
+    /// in order (the last response repeats).
+    pub scripted_responses: Option<Vec<String>>,
 }
+
+pub use crate::channels::oneshot::{OneshotOutcome, OneshotResult};
+pub use crate::channels::terminal_ui::HostThemeMode;
 
 /// Interactive permission modes exposed to embedding hosts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -161,7 +182,7 @@ pub fn spawn_host(config: HostConfig) -> HostHandle {
     let (events_tx, events) = mpsc::unbounded_channel();
     let task = tokio::spawn(async move {
         let _ = events_tx.send(HostEvent::Starting);
-        let result = run_host(config, Some(shutdown_rx)).await;
+        let result = run_host(config, Some(shutdown_rx), None).await;
         let outcome = match &result {
             Ok(()) => HostExit::Completed,
             Err(error) => HostExit::Failed(error.to_string()),
@@ -180,12 +201,38 @@ pub fn spawn_host(config: HostConfig) -> HostHandle {
 /// Start the complete IsanAgent runtime, including its terminal channel when
 /// enabled by the selected configuration.
 pub async fn start_host(config: HostConfig) -> HostResult<()> {
-    run_host(config, None).await
+    let _ = run_host(config, None, None).await?;
+    Ok(())
+}
+
+/// Run a single headless prompt through the shared host runtime and shut down
+/// after the matching reasoning run terminates.
+pub async fn run_oneshot(mut config: HostConfig) -> HostResult<OneshotResult> {
+    if config
+        .oneshot_prompt
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or_default()
+        .is_empty()
+    {
+        return Err(std::io::Error::other("oneshot prompt must be non-empty").into());
+    }
+    // One-shot runs never own an interactive TTY channel.
+    config.line_mode = false;
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+    let host_result = run_host(config, None, Some(result_tx)).await;
+    match result_rx.await {
+        Ok(result) => Ok(result),
+        Err(_) => Err(host_result.err().unwrap_or_else(|| {
+            std::io::Error::other("oneshot host exited without a terminal result").into()
+        })),
+    }
 }
 
 async fn run_host(
     config: HostConfig,
     mut external_shutdown_rx: Option<mpsc::UnboundedReceiver<()>>,
+    oneshot_result_tx: Option<tokio::sync::oneshot::Sender<OneshotResult>>,
 ) -> HostResult<()> {
     let workspace_arg = config
         .workspace
@@ -232,7 +279,16 @@ async fn run_host(
             }
         })?;
 
-    println!("Starting Advanced isanagent System...");
+    let oneshot_mode = config
+        .oneshot_prompt
+        .as_ref()
+        .map(|prompt| prompt.trim())
+        .is_some_and(|prompt| !prompt.is_empty());
+    if oneshot_mode {
+        eprintln!("Starting Advanced isanagent System...");
+    } else {
+        println!("Starting Advanced isanagent System...");
+    }
     log::info!("Starting Advanced isanagent System.");
 
     let mut workspace = IsanagentWorkspace::new_with_sandbox(
@@ -241,10 +297,24 @@ async fn run_host(
         sandbox,
     )?;
     apply_host_overrides(&mut workspace.config, &config).map_err(std::io::Error::other)?;
-    println!("Loading isanagent workspace at: {:?}", workspace.dir);
+    let oneshot_prompt = config
+        .oneshot_prompt
+        .as_ref()
+        .map(|prompt| prompt.trim().to_string())
+        .filter(|prompt| !prompt.is_empty());
+    if oneshot_mode {
+        // One-shot hosts never attach the interactive terminal channel.
+        let terminal = workspace.config.terminal.get_or_insert_with(Default::default);
+        terminal.enabled = Some(false);
+        eprintln!("Loading isanagent workspace at: {:?}", workspace.dir);
+    } else {
+        println!("Loading isanagent workspace at: {:?}", workspace.dir);
+    }
     log::info!("Loading isanagent workspace at {:?}", workspace.dir);
 
-    if !workspace.config.terminal_enabled() && !workspace.config.has_non_terminal_inbound_channel()
+    if oneshot_prompt.is_none()
+        && !workspace.config.terminal_enabled()
+        && !workspace.config.has_non_terminal_inbound_channel()
     {
         return Err(std::io::Error::other(
             "Invalid config: [terminal] enabled = false requires at least one other inbound channel. \
@@ -253,7 +323,9 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         .into());
     }
 
-    maybe_prompt_uv_install_on_launch(&workspace).await;
+    if !oneshot_mode {
+        maybe_prompt_uv_install_on_launch(&workspace).await;
+    }
 
     // 1. Setup SqliteMemoryActor and SessionManager
     let db_path = workspace
@@ -602,7 +674,13 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         Box<dyn crate::traits::Provider>,
         Box<dyn crate::traits::Provider>,
         Vec<crate::agent::FallbackProviderSpec>,
-    ) = if let (Some(cfg), Some(key)) = (&provider_cfg, &api_key) {
+    ) = if let Some(responses) = config.scripted_responses.clone() {
+        (
+            Box::new(crate::provider::ScriptedProvider::new(responses.clone())),
+            Box::new(crate::provider::ScriptedProvider::new(responses)),
+            Vec::new(),
+        )
+    } else if let (Some(cfg), Some(key)) = (&provider_cfg, &api_key) {
         let base_url = cfg.resolved_base_url().map_err(std::io::Error::other)?;
         let p1 = crate::provider::create_provider(&cfg.provider_name, &base_url, key, &model_name);
         let p2 = crate::provider::create_provider(&cfg.provider_name, &base_url, key, &model_name);
@@ -727,7 +805,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
 
     // 7. Create Agent Logic
     let max_iterations = workspace.config.resolved_max_iterations().unwrap_or(50);
-    let max_recent_summaries = workspace
+    let mut max_recent_summaries = workspace
         .config
         .memory
         .as_ref()
@@ -739,12 +817,20 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         .as_ref()
         .and_then(|m| m.short_term_threshold_turns)
         .unwrap_or(20);
-    let short_term_threshold_tokens = workspace
+    let mut short_term_threshold_tokens = workspace
         .config
         .memory
         .as_ref()
         .and_then(|m| m.short_term_threshold_tokens)
         .unwrap_or(100000);
+    if config.compact_auto == Some(false) {
+        short_term_threshold_tokens = usize::MAX;
+    } else if let Some(tokens) = config.compact_threshold_tokens {
+        short_term_threshold_tokens = tokens.max(8_000);
+    }
+    if let Some(tail) = config.compact_tail_turns {
+        max_recent_summaries = tail.max(1);
+    }
     let tool_execution_activity = if multi_tenant_edge_cfg
         .activity_heartbeat_enabled
         .unwrap_or(false)
@@ -858,6 +944,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             workspace_dir: workspace.dir.clone(),
             sandbox_dir: workspace.sandbox_dir.clone(),
             status_model: model_name.clone(),
+            status_permission: host_permission_label(config.permission),
             memory_node: memory_node.clone(),
             providers: {
                 // Merge default [provider] + expanded [providers.*] into one map for /model selector
@@ -868,7 +955,8 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                 }
                 all_providers
             },
-            color_enabled: !config.no_color,
+            color_enabled: !config.no_color && config.theme != HostThemeMode::NoColor,
+            theme: config.theme,
             resume_session: config.resume.is_some(),
             initial_files: config.files.clone(),
             mode: if config.line_mode {
@@ -882,6 +970,50 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         Some(id)
     } else {
         log::info!("Terminal channel disabled via config; stdin will not be read.");
+        None
+    };
+
+    let oneshot_channel = if let Some(prompt) = oneshot_prompt.clone() {
+        let result_tx = oneshot_result_tx.ok_or_else(|| {
+            std::io::Error::other("oneshot prompt requires run_oneshot or an explicit result channel")
+        })?;
+        let id = config
+            .resume
+            .as_deref()
+            .filter(|id| !id.trim().is_empty())
+            .map(str::to_owned)
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let (attachments, attach_warnings) =
+            crate::channels::terminal_ui::load_host_file_attachments(
+                &workspace.sandbox_dir,
+                &config.files,
+            );
+        for warning in attach_warnings {
+            log::warn!("oneshot attachment: {warning}");
+            let _ = logger_bus_tx.send(BusMessage::Log(crate::bus::LogEvent::warn(
+                "altai-cli",
+                &warning,
+            )));
+        }
+        let channel = Arc::new(OneshotChannel::new(
+            id,
+            prompt,
+            config.files.clone(),
+            attachments,
+            result_tx,
+            shutdown_tx.clone(),
+            config.observe_tx.clone(),
+        ));
+        channel.start(bus_tx.clone()).await?;
+        out_channels.insert(channel.name().to_string(), channel.clone());
+        Some(channel)
+    } else {
+        if oneshot_result_tx.is_some() {
+            return Err(std::io::Error::other(
+                "oneshot result channel provided without oneshot_prompt",
+            )
+            .into());
+        }
         None
     };
 
@@ -935,7 +1067,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     }
 
     // 14. Print clean startup banner (skipped when Ratatui owns the alternate screen)
-    if !terminal_startup_suppresses_plain_banner(&workspace.config) {
+    if !oneshot_mode && !terminal_startup_suppresses_plain_banner(&workspace.config) {
         println!(
             "\n{}",
             "=============================================".blue()
@@ -989,8 +1121,16 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     let logger_tx = logger_bus_tx.clone();
     let inflight_promote = inflight_sync_outer.clone();
     let active_terminal_session_for_bus = active_terminal_session_chat.clone();
+    let oneshot_for_bus = oneshot_channel.clone();
+    let observe_tx = config.observe_tx.clone();
     tokio::spawn(async move {
         while let Some(msg) = bus_rx.recv().await {
+            if let Some(tx) = observe_tx.as_ref() {
+                let _ = tx.send(msg.clone());
+            }
+            if let Some(oneshot) = oneshot_for_bus.as_ref() {
+                oneshot.observe_bus_message(&msg);
+            }
             let _ = logger_tx.send(msg.clone());
             // Intercept /background slash commands and fire the in-flight oneshot.
             if let BusMessage::PromoteSyncToBackground(chat_id) = &msg {
@@ -1035,6 +1175,9 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                     BusMessage::Telemetry(tel) => {
                         let _ = agent_outbound_tx.send(BusMessage::Telemetry(tel)).await;
                     }
+                    lifecycle @ BusMessage::RunLifecycle(_) => {
+                        let _ = agent_outbound_tx.send(lifecycle).await;
+                    }
                     _ => {}
                 }
             }
@@ -1044,8 +1187,18 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     let logger_tx_outbound = logger_bus_tx.clone();
     let delivery_channels = out_channels.clone();
     let active_terminal_for_outbound = active_terminal_session_chat.clone();
+    let oneshot_for_outbound = oneshot_channel.clone();
+    let observe_tx_outbound = config.observe_tx.clone();
     tokio::spawn(async move {
         while let Some(msg) = global_outbound_rx.recv().await {
+            if let Some(tx) = observe_tx_outbound.as_ref() {
+                let _ = tx.send(msg.clone());
+            }
+            if let Some(oneshot) = oneshot_for_outbound.as_ref() {
+                if !matches!(&msg, BusMessage::Outbound(_)) {
+                    oneshot.observe_bus_message(&msg);
+                }
+            }
             // Deliver user-visible terminal traffic first. `LoggerHandle::send` uses a blocking
             // `sync_channel::send`; doing it before channel delivery can stall this task and make
             // tool-call lines and agent replies appear only after the run finishes.
@@ -1073,6 +1226,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                         }
                     }
                 }
+                BusMessage::RunLifecycle(_) => {}
                 BusMessage::Telemetry(TelemetryEvent::AgentThought {
                     chat_id,
                     thought,
@@ -1331,7 +1485,9 @@ fn apply_host_overrides(config: &mut AppConfig, host: &HostConfig) -> Result<(),
         let (mode, edit_mode) = match permission {
             HostPermissionMode::Ask => ("ask", "ask"),
             HostPermissionMode::AutoEdit => ("ask", "allow"),
-            HostPermissionMode::Plan => ("deny", "deny"),
+            // Match desktop: plan keeps shell at ask (read-only inspection with
+            // approval for destructive commands) while denying file edits.
+            HostPermissionMode::Plan => ("ask", "deny"),
             HostPermissionMode::Bypass => ("allow", "allow"),
         };
         shell_policy.mode = Some(mode.to_string());
@@ -1339,6 +1495,16 @@ fn apply_host_overrides(config: &mut AppConfig, host: &HostConfig) -> Result<(),
     }
 
     Ok(())
+}
+
+fn host_permission_label(permission: Option<HostPermissionMode>) -> String {
+    match permission {
+        Some(HostPermissionMode::Ask) => "ask".into(),
+        Some(HostPermissionMode::AutoEdit) => "auto-edit".into(),
+        Some(HostPermissionMode::Plan) => "plan".into(),
+        Some(HostPermissionMode::Bypass) => "bypass".into(),
+        None => "default".into(),
+    }
 }
 
 async fn wait_for_external_shutdown(receiver: &mut Option<mpsc::UnboundedReceiver<()>>) {
@@ -1663,9 +1829,13 @@ mod tests {
         assert!(config.fallback_model.is_none());
         assert!(config.permission.is_none());
         assert!(!config.no_color);
+        assert_eq!(config.theme, HostThemeMode::Auto);
         assert!(config.resume.is_none());
         assert!(config.files.is_empty());
         assert!(!config.line_mode);
+        assert!(config.oneshot_prompt.is_none());
+        assert!(config.observe_tx.is_none());
+        assert!(config.scripted_responses.is_none());
     }
 
     #[test]
@@ -1691,7 +1861,7 @@ mod tests {
         for (permission, mode, edit_mode) in [
             (HostPermissionMode::Ask, "ask", "ask"),
             (HostPermissionMode::AutoEdit, "ask", "allow"),
-            (HostPermissionMode::Plan, "deny", "deny"),
+            (HostPermissionMode::Plan, "ask", "deny"),
             (HostPermissionMode::Bypass, "allow", "allow"),
         ] {
             let mut config = AppConfig::default();
@@ -1750,9 +1920,16 @@ mod tests {
             fallback_model: None,
             permission: None,
             no_color: false,
+            theme: HostThemeMode::Auto,
             resume: None,
             files: Vec::new(),
             line_mode: false,
+            compact_auto: None,
+            compact_threshold_tokens: None,
+            compact_tail_turns: None,
+            oneshot_prompt: None,
+            observe_tx: None,
+            scripted_responses: None,
         });
         assert_eq!(host.next_event().await, Some(HostEvent::Starting));
         assert!(host.shutdown());
@@ -1770,5 +1947,46 @@ mod tests {
             .await
             .expect("host task should join")
             .expect("host should complete cleanly");
+    }
+
+    #[tokio::test]
+    async fn run_oneshot_completes_with_scripted_provider() {
+        let temp = tempfile::tempdir().expect("temporary workspace");
+        let config_path = temp.path().join("config.toml");
+        fs::write(
+            &config_path,
+            "[terminal]\nenabled = false\n\n[logging]\nenabled = false\n",
+        )
+        .expect("write config");
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(30),
+            run_oneshot(HostConfig {
+                workspace: Some(temp.path().to_path_buf()),
+                config: Some(config_path),
+                sandbox: Some(temp.path().to_path_buf()),
+                model: None,
+                fallback_model: None,
+                permission: Some(HostPermissionMode::Plan),
+                no_color: true,
+                theme: HostThemeMode::NoColor,
+                resume: None,
+                files: Vec::new(),
+                line_mode: false,
+                compact_auto: None,
+                compact_threshold_tokens: None,
+                compact_tail_turns: None,
+                oneshot_prompt: Some("reply with oneshot-ok".to_string()),
+                observe_tx: None,
+                scripted_responses: Some(vec!["oneshot-ok".to_string()]),
+            }),
+        )
+        .await
+        .expect("oneshot should finish promptly")
+        .expect("oneshot should succeed");
+
+        assert_eq!(result.outcome, OneshotOutcome::Completed);
+        assert_eq!(result.final_text.as_deref(), Some("oneshot-ok"));
+        assert!(!result.chat_id.is_empty());
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -92,9 +92,17 @@ impl Log for ActorRuntimeLogger {
 
 pub fn init_runtime_logger(sender: LoggerHandle) -> Result<(), SetLoggerError> {
     let _ = LOGGER_SENDER.set(sender);
-    log::set_logger(&ACTOR_RUNTIME_LOGGER)?;
-    log::set_max_level(LevelFilter::Trace);
-    Ok(())
+    match log::set_logger(&ACTOR_RUNTIME_LOGGER) {
+        Ok(()) => {
+            log::set_max_level(LevelFilter::Trace);
+            Ok(())
+        }
+        // A prior host/test in this process may have already installed the logger.
+        Err(_) => {
+            log::set_max_level(LevelFilter::Trace);
+            Ok(())
+        }
+    }
 }
 
 fn should_capture(target: &str, level: Level) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -881,7 +881,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                 all_providers
             },
             color_enabled: !matches!(std::env::var_os("NO_COLOR"), Some(value) if !value.is_empty()),
-            theme: isanagent::channels::terminal_ui::HostThemeMode::Auto,
+            theme: isanagent::host::HostThemeMode::Auto,
             resume_session: false,
             initial_files: Vec::new(),
             mode: TerminalMode::Tui,

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,14 +199,7 @@ async fn start_embedded_host(
     isanagent::host::start_host(isanagent::host::HostConfig {
         workspace: workspace_arg.map(std::path::PathBuf::from),
         config: config_arg.map(std::path::PathBuf::from),
-        sandbox: None,
-        model: None,
-        fallback_model: None,
-        permission: None,
-        no_color: false,
-        resume: None,
-        files: Vec::new(),
-        line_mode: false,
+        ..Default::default()
     })
     .await
     .map_err(std::io::Error::other)?;
@@ -876,6 +869,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             workspace_dir: workspace.dir.clone(),
             sandbox_dir: workspace.sandbox_dir.clone(),
             status_model: model_name.clone(),
+            status_permission: "default".into(),
             memory_node: memory_node.clone(),
             providers: {
                 // Merge default [provider] + expanded [providers.*] into one map for /model selector
@@ -887,6 +881,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                 all_providers
             },
             color_enabled: !matches!(std::env::var_os("NO_COLOR"), Some(value) if !value.is_empty()),
+            theme: isanagent::channels::terminal_ui::HostThemeMode::Auto,
             resume_session: false,
             initial_files: Vec::new(),
             mode: TerminalMode::Tui,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -77,6 +77,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use log::debug;
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Placeholder provider used when no API key is configured at startup.
@@ -95,6 +96,55 @@ impl Provider for NoKeyProvider {
             "No API key configured. Use /model to select a provider, or add api_key to config.toml."
                 .to_string(),
         ))
+    }
+}
+
+/// Deterministic in-process provider for host/CLI smoke tests.
+#[derive(Clone)]
+pub struct ScriptedProvider {
+    responses: Arc<std::sync::Mutex<std::collections::VecDeque<String>>>,
+    fallback: String,
+}
+
+impl ScriptedProvider {
+    pub fn new(responses: Vec<String>) -> Self {
+        let fallback = responses
+            .last()
+            .cloned()
+            .unwrap_or_else(|| "scripted-ok".to_string());
+        Self {
+            responses: Arc::new(std::sync::Mutex::new(responses.into())),
+            fallback,
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for ScriptedProvider {
+    async fn chat(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: Option<Value>,
+    ) -> Result<LLMResponse, LLMError> {
+        let content = {
+            let mut queue = self
+                .responses
+                .lock()
+                .map_err(|_| LLMError::ApiError("scripted provider lock poisoned".into()))?;
+            queue.pop_front().unwrap_or_else(|| self.fallback.clone())
+        };
+        Ok(LLMResponse {
+            content,
+            tool_calls: None,
+            reasoning_content: None,
+            usage: Some(crate::utils::TokenUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+            }),
+        })
     }
 }
 


### PR DESCRIPTION
## Summary
- Public host additions for ALTAI CLI: `run_oneshot`, `oneshot_prompt`, `observe_tx`, `scripted_responses`
- `HostThemeMode` (auto/dark/light/no-color) wired into TUI/line mode
- Four-way approvals (approve/deny/always/abort) + edit-diff metadata; plan-mode shell/edit policy
- Real `--file` / `@path` attachments (text/image/PDF) with fuzzy basename resolve
- `compact_auto` / `compact_threshold_tokens` / `compact_tail_turns` host overrides
- Line-mode `/context` + `/compact`

Consumed today via a temporary path pin in `altaidevorg/altai-app` (`tools/isanagent-oneshot`). After merge, ALTAI will switch back to a git revision.

## Test plan
- [ ] `cargo test --lib host::`
- [ ] `cargo test --lib channels::terminal_ui::attachments`
- [ ] `cargo test --lib channels::terminal_ui::approval`
- [ ] `cargo check --bin isanagent`
- [ ] Smoke: scripted oneshot completes; interactive approval hotkeys y/n/a/x


Made with [Cursor](https://cursor.com)