### PR TITLE
feat(host): oneshot, theme, approvals, attachments, compaction

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -42,7 +42,7 @@ fn collect_files(dir: &Path, files: &mut Vec<PathBuf>) {
     });
 
     for entry in entries {
-        let entry = entry.unwrap_or_else(|error| panic!("Failed to read UI dist entry: {}", error));
+        let entry = entry.unwrap_or_else(|error| panic!("Failed to read UI dist entry: {error}"));
         let path = entry.path();
         if path.is_dir() {
             collect_files(&path, files);
@@ -60,7 +60,7 @@ fn build_embedded_assets_module(ui_dist_dir: &Path, files: &[PathBuf]) -> String
     for file in files {
         let relative = file
             .strip_prefix(ui_dist_dir)
-            .unwrap_or_else(|error| panic!("Failed to strip UI dist prefix: {}", error))
+            .unwrap_or_else(|error| panic!("Failed to strip UI dist prefix: {error}"))
             .to_string_lossy()
             .replace('\\', "/");
         let absolute = escape_rust_string(&file.to_string_lossy());
@@ -68,8 +68,7 @@ fn build_embedded_assets_module(ui_dist_dir: &Path, files: &[PathBuf]) -> String
         let content_type = mime_type_for_path(file);
 
         generated.push_str(&format!(
-            "    EmbeddedUiAsset {{ path: \"{}\", bytes: include_bytes!(\"{}\"), content_type: \"{}\" }},\n",
-            path, absolute, content_type
+            "    EmbeddedUiAsset {{ path: \"{path}\", bytes: include_bytes!(\"{absolute}\"), content_type: \"{content_type}\" }},\n"
         ));
     }
 

--- a/src/agent/budget.rs
+++ b/src/agent/budget.rs
@@ -198,10 +198,7 @@ impl BudgetController {
         } else {
             // A different typed key means the previous repeated-root-cause warning is stale
             // (e.g. intent-scoped NonZeroExit for `pnpm test` then `pnpm lint`).
-            if self
-                .emitted_warnings
-                .remove(&WarningKey::RepeatedRootCause)
-            {
+            if self.emitted_warnings.remove(&WarningKey::RepeatedRootCause) {
                 self.warning_cleared = true;
             }
             self.last_root_cause = Some(root_cause);
@@ -221,10 +218,7 @@ impl BudgetController {
         if matches!(kind, ProgressKind::NewEvidence) {
             self.last_root_cause = None;
             self.repeated_root_cause_failures = 0;
-            if self
-                .emitted_warnings
-                .remove(&WarningKey::RepeatedRootCause)
-            {
+            if self.emitted_warnings.remove(&WarningKey::RepeatedRootCause) {
                 self.warning_cleared = true;
             }
         }
@@ -379,11 +373,7 @@ fn duration_millis(duration: Duration) -> u64 {
 ///
 /// Exit / not-found / execution failures are **intent-scoped** (`tool:code:intent`): a failing
 /// `pnpm test` then a failing `pnpm lint` must not count as the same repeated root cause.
-pub(crate) fn typed_failure_key(
-    tool_name: &str,
-    code: ToolErrorCode,
-    intent_sig: &str,
-) -> String {
+pub(crate) fn typed_failure_key(tool_name: &str, code: ToolErrorCode, intent_sig: &str) -> String {
     let tool = tool_name.to_ascii_lowercase();
     let code_label = match code {
         ToolErrorCode::InvalidToolArguments => "invalid_tool_arguments",
@@ -789,7 +779,8 @@ mod tests {
         let mut controller = BudgetController::new(test_limits(50));
         let _ = controller.start_turn(Duration::ZERO);
         for step in 0..3 {
-            let intent = tool_intent_signature("exec", &format!(r#"{{"command":"write artifact-{step}"}}"#));
+            let intent =
+                tool_intent_signature("exec", &format!(r#"{{"command":"write artifact-{step}"}}"#));
             let key = typed_failure_key("exec", ToolErrorCode::PolicyDenied, &intent);
             let decision = controller.record_tool_failure(key);
             if step < 1 {

--- a/src/agent/compaction.rs
+++ b/src/agent/compaction.rs
@@ -330,8 +330,7 @@ pub fn build_compact_placeholder(
         head.push('…');
     }
     format!(
-        "[Tool result archived. Recall: recall_tool_result(tool_call_id=\"{}\"). Original: tool={} bytes={} head=\"{}\"]",
-        tool_call_id, tool_name, bytes, head
+        "[Tool result archived. Recall: recall_tool_result(tool_call_id=\"{tool_call_id}\"). Original: tool={tool_name} bytes={bytes} head=\"{head}\"]"
     )
 }
 
@@ -657,7 +656,7 @@ pub async fn do_compaction(args: DoCompactionArgs<'_>) -> CompactionOutcome {
                 .outbound_tx
                 .send(BusMessage::Telemetry(TelemetryEvent::CompactionFailed {
                     chat_id: args.chat_id.to_string(),
-                    reason: format!("provider error: {}", e),
+                    reason: format!("provider error: {e}"),
                     tokens_at_failure: args.tokens_before,
                 }))
                 .await;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -511,7 +511,9 @@ fn classify_approval_reply(reply: &str) -> ApprovalReply {
         .collect();
 
     if tokens.iter().any(|t| ABORT.contains(t))
-        && !tokens.iter().any(|t| AFFIRM.contains(t) || ALWAYS.contains(t))
+        && !tokens
+            .iter()
+            .any(|t| AFFIRM.contains(t) || ALWAYS.contains(t))
     {
         return ApprovalReply::Abort;
     }
@@ -4404,9 +4406,7 @@ impl AgentLogic {
                             let code = tool_result
                                 .error_code()
                                 .unwrap_or(ToolErrorCode::ExecutionFailed);
-                            budget.record_tool_failure(typed_failure_key(
-                                &tool_name, code, &intent,
-                            ))
+                            budget.record_tool_failure(typed_failure_key(&tool_name, code, &intent))
                         } else {
                             budget.record_tool_success(intent)
                         };
@@ -4527,15 +4527,12 @@ impl AgentLogic {
                         };
 
                         let is_error = tool_result.is_error();
-                        let intent =
-                            tool_intent_signature(tool_name, &tc.function.arguments);
+                        let intent = tool_intent_signature(tool_name, &tc.function.arguments);
                         let budget_decision = if is_error {
                             let code = tool_result
                                 .error_code()
                                 .unwrap_or(ToolErrorCode::ExecutionFailed);
-                            budget.record_tool_failure(typed_failure_key(
-                                tool_name, code, &intent,
-                            ))
+                            budget.record_tool_failure(typed_failure_key(tool_name, code, &intent))
                         } else {
                             budget.record_tool_success(intent)
                         };

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -455,7 +455,24 @@ fn should_require_shell_approval(command: &str, patterns: &[String]) -> bool {
 /// negative sentence ("never approve", "i can't approve", "approve? actually nope"). The prompt
 /// constrains the choices to approve/deny with `allow_empty = false`, so the strictness is
 /// UX-compatible; an unrecognized reply simply skips execution and the user can re-confirm.
+#[cfg(test)]
 fn shell_approval_reply_is_grant(reply: &str) -> bool {
+    matches!(
+        classify_approval_reply(reply),
+        ApprovalReply::Grant | ApprovalReply::AlwaysThisRun
+    )
+}
+
+/// Four-way approval reply classification for ALTAI CLI / TUI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApprovalReply {
+    Grant,
+    AlwaysThisRun,
+    Deny,
+    Abort,
+}
+
+fn classify_approval_reply(reply: &str) -> ApprovalReply {
     const AFFIRM: &[&str] = &[
         "approve",
         "approved",
@@ -477,25 +494,65 @@ fn shell_approval_reply_is_grant(reply: &str) -> bool {
         "go",
         "sure",
     ];
-    const FILLER: &[&str] = &["please", "it", "this", "that", "ahead", "now", "run", "do"];
+    const FILLER: &[&str] = &[
+        "please", "it", "this", "that", "ahead", "now", "run", "do", "for",
+    ];
+    const ALWAYS: &[&str] = &["always"];
+    const ABORT: &[&str] = &["abort", "cancel", "quit", "stop"];
 
     let r = reply.trim().to_ascii_lowercase();
     if r.is_empty() {
-        return false;
+        return ApprovalReply::Deny;
     }
-    let mut saw_affirmative = false;
-    for tok in r
+
+    let tokens: Vec<&str> = r
         .split(|c: char| !c.is_alphanumeric())
         .filter(|t| !t.is_empty())
+        .collect();
+
+    if tokens.iter().any(|t| ABORT.contains(t))
+        && !tokens.iter().any(|t| AFFIRM.contains(t) || ALWAYS.contains(t))
     {
-        if AFFIRM.contains(&tok) {
+        return ApprovalReply::Abort;
+    }
+
+    // "always" / "always for this run" — allow only known filler around always.
+    if tokens.iter().any(|t| ALWAYS.contains(t)) {
+        let ok = tokens
+            .iter()
+            .all(|t| ALWAYS.contains(t) || FILLER.contains(t) || AFFIRM.contains(t));
+        if ok {
+            return ApprovalReply::AlwaysThisRun;
+        }
+        return ApprovalReply::Deny;
+    }
+
+    let mut saw_affirmative = false;
+    for tok in &tokens {
+        if AFFIRM.contains(tok) {
             saw_affirmative = true;
-        } else if !FILLER.contains(&tok) {
-            // Negation, caveat, or unmodeled prose -> deny.
-            return false;
+        } else if !FILLER.contains(tok) {
+            return ApprovalReply::Deny;
         }
     }
-    saw_affirmative
+    if saw_affirmative {
+        ApprovalReply::Grant
+    } else {
+        ApprovalReply::Deny
+    }
+}
+
+fn command_preview_with_flag(command: &str) -> (String, bool) {
+    const MAX_PREVIEW: usize = 160;
+    if command.len() <= MAX_PREVIEW {
+        (command.to_string(), false)
+    } else {
+        (format!("{}…", &command[..MAX_PREVIEW]), true)
+    }
+}
+
+fn command_preview(command: &str) -> String {
+    command_preview_with_flag(command).0
 }
 
 fn shell_policy_mode_for_session(
@@ -528,15 +585,6 @@ fn edit_policy_block_reason(unattended_session: bool) -> &'static str {
         "File edit blocked by policy: unattended edit mode is active."
     } else {
         "File edit blocked by policy: plan mode active — finalize or apply the plan first."
-    }
-}
-
-fn command_preview(command: &str) -> String {
-    const MAX_PREVIEW: usize = 160;
-    if command.len() <= MAX_PREVIEW {
-        command.to_string()
-    } else {
-        format!("{}...", &command[..MAX_PREVIEW])
     }
 }
 
@@ -738,6 +786,23 @@ mod code_exec_gate_tests {
         assert!(shell_approval_reply_is_grant("yes do it"));
         assert!(shell_approval_reply_is_grant("yes, please do"));
         assert!(!shell_approval_reply_is_grant("do it"));
+    }
+
+    #[test]
+    fn approval_reply_classifies_always_and_abort() {
+        assert_eq!(
+            classify_approval_reply("always"),
+            ApprovalReply::AlwaysThisRun
+        );
+        assert_eq!(
+            classify_approval_reply("always for this run"),
+            ApprovalReply::AlwaysThisRun
+        );
+        assert_eq!(classify_approval_reply("abort"), ApprovalReply::Abort);
+        assert_eq!(classify_approval_reply("cancel"), ApprovalReply::Abort);
+        assert_eq!(classify_approval_reply("deny"), ApprovalReply::Deny);
+        assert!(shell_approval_reply_is_grant("always"));
+        assert!(!shell_approval_reply_is_grant("abort"));
     }
 
     #[test]
@@ -951,6 +1016,21 @@ struct ToolCallRuntime {
     inbound_metadata: Arc<HashMap<String, serde_json::Value>>,
 }
 
+/// Process-scoped "always for this run" grants (`shell:…` / `edit:…`).
+fn process_approval_grants() -> &'static tokio::sync::Mutex<HashSet<String>> {
+    static GRANTS: std::sync::OnceLock<tokio::sync::Mutex<HashSet<String>>> =
+        std::sync::OnceLock::new();
+    GRANTS.get_or_init(|| tokio::sync::Mutex::new(HashSet::new()))
+}
+
+async fn approval_already_granted(key: &str) -> bool {
+    process_approval_grants().lock().await.contains(key)
+}
+
+async fn remember_approval_grant(key: String) {
+    process_approval_grants().lock().await.insert(key);
+}
+
 /// Runs a tool with optional per-call activity heartbeats and optional cooperative cancellation.
 #[allow(clippy::too_many_arguments)] // Central tool-dispatch path; grouping would obscure call sites.
 async fn execute_tool_call_with_activity(
@@ -1030,21 +1110,30 @@ async fn execute_tool_call_with_activity(
                     }
                     ShellPolicyMode::Ask => {
                         if requires_approval {
+                            let grant_key = format!("shell:{tool_name}:{command}");
+                            if !approval_already_granted(&grant_key).await {
+                            let (preview, preview_truncated) = command_preview_with_flag(&command);
                             let _ = outbound_tx
                                 .send(BusMessage::Telemetry(TelemetryEvent::ShellPolicyDecision {
                                     chat_id: chat_id.clone(),
                                     channel: channel.clone(),
                                     mode: "ask".to_string(),
                                     decision: "approval_requested".to_string(),
-                                    command_preview: preview.clone(),
+                                    command_preview: if preview_truncated {
+                                        format!("{preview} [truncated]")
+                                    } else {
+                                        preview.clone()
+                                    },
                                 }))
                                 .await;
                             let ask_payload = serde_json::json!({
                                 "prompt": format!(
-                                    "Approve running `{}`?\n\n```\n{}\n```\n\nReply with approve or deny.",
-                                    tool_name, command
+                                    "Approve running `{}`?\n\n```\n{}\n```\n\nReply with approve, deny, always (this run), or abort.{}",
+                                    tool_name,
+                                    command,
+                                    if preview_truncated { "\n[command preview truncated in telemetry]" } else { "" }
                                 ),
-                                "choices": ["approve", "deny"],
+                                "choices": ["approve", "deny", "always", "abort"],
                                 "timeout_secs": 1800,
                                 "allow_empty": false
                             });
@@ -1061,37 +1150,62 @@ async fn execute_tool_call_with_activity(
                                 .await;
                             match ask_result {
                                 Ok(reply) => {
-                                    // Deny-default parse: an explicit grant runs; anything else
-                                    // (incl. "do not approve") skips execution.
-                                    let approved = shell_approval_reply_is_grant(&reply);
-                                    if !approved {
-                                        let _ = outbound_tx
-                                            .send(BusMessage::Telemetry(
-                                                TelemetryEvent::ShellPolicyDecision {
-                                                    chat_id: chat_id.clone(),
-                                                    channel: channel.clone(),
-                                                    mode: "ask".to_string(),
-                                                    decision: "approval_denied".to_string(),
-                                                    command_preview: preview,
-                                                },
-                                            ))
-                                            .await;
-                                        return ToolExecutionFinished::error(
-                                            ToolErrorCode::PolicyDenied,
-                                            "Command not approved by user; execution skipped.",
-                                        );
+                                    let classified = classify_approval_reply(&reply);
+                                    match classified {
+                                        ApprovalReply::Grant | ApprovalReply::AlwaysThisRun => {
+                                            if matches!(classified, ApprovalReply::AlwaysThisRun) {
+                                                remember_approval_grant(grant_key).await;
+                                            }
+                                            let _ = outbound_tx
+                                                .send(BusMessage::Telemetry(
+                                                    TelemetryEvent::ShellPolicyDecision {
+                                                        chat_id: chat_id.clone(),
+                                                        channel: channel.clone(),
+                                                        mode: "ask".to_string(),
+                                                        decision: "approval_granted".to_string(),
+                                                        command_preview: preview,
+                                                    },
+                                                ))
+                                                .await;
+                                        }
+                                        ApprovalReply::Abort => {
+                                            let _ = outbound_tx
+                                                .send(BusMessage::Telemetry(
+                                                    TelemetryEvent::ShellPolicyDecision {
+                                                        chat_id: chat_id.clone(),
+                                                        channel: channel.clone(),
+                                                        mode: "ask".to_string(),
+                                                        decision: "approval_denied".to_string(),
+                                                        command_preview: preview,
+                                                    },
+                                                ))
+                                                .await;
+                                            if let Some(token) = cancel_owned.as_ref() {
+                                                token.cancel();
+                                            }
+                                            return ToolExecutionFinished::error(
+                                                ToolErrorCode::PolicyDenied,
+                                                "Command approval aborted by user; execution skipped.",
+                                            );
+                                        }
+                                        ApprovalReply::Deny => {
+                                            let _ = outbound_tx
+                                                .send(BusMessage::Telemetry(
+                                                    TelemetryEvent::ShellPolicyDecision {
+                                                        chat_id: chat_id.clone(),
+                                                        channel: channel.clone(),
+                                                        mode: "ask".to_string(),
+                                                        decision: "approval_denied".to_string(),
+                                                        command_preview: preview,
+                                                    },
+                                                ))
+                                                .await;
+                                            return ToolExecutionFinished::error(
+                                                ToolErrorCode::PolicyDenied,
+                                                "Command not approved by user; execution skipped.",
+                                            );
+                                        }
                                     }
-                                    let _ = outbound_tx
-                                        .send(BusMessage::Telemetry(
-                                            TelemetryEvent::ShellPolicyDecision {
-                                                chat_id: chat_id.clone(),
-                                                channel: channel.clone(),
-                                                mode: "ask".to_string(),
-                                                decision: "approval_granted".to_string(),
-                                                command_preview: preview,
-                                            },
-                                        ))
-                                        .await;
                                 }
                                 Err(e) => {
                                     return ToolExecutionFinished::error(
@@ -1100,6 +1214,7 @@ async fn execute_tool_call_with_activity(
                                     );
                                 }
                             }
+                            } // end if !already_granted
                         }
                     }
                 }
@@ -1161,12 +1276,14 @@ async fn execute_tool_call_with_activity(
                         }
                     };
                     if let Some(preview) = preview {
+                        let grant_key = format!("edit:{}", preview.path);
+                        if !approval_already_granted(&grant_key).await {
                         let ask_payload = serde_json::json!({
                             "prompt": format!(
-                                "Approve edit to `{}`? Review the attached diff, then reply with approve or deny.",
+                                "Approve edit to `{}`? Review the attached diff, then reply with approve, deny, always (this run), or abort.",
                                 preview.path
                             ),
-                            "choices": ["approve", "deny"],
+                            "choices": ["approve", "deny", "always", "abort"],
                             "timeout_secs": 1800,
                             "allow_empty": false,
                             "metadata": {
@@ -1197,12 +1314,28 @@ async fn execute_tool_call_with_activity(
                                 );
                             }
                         };
-                        if !shell_approval_reply_is_grant(&reply) {
-                            return ToolExecutionFinished::error(
-                                ToolErrorCode::PolicyDenied,
-                                "Edit not approved by user; mutation skipped.",
-                            );
+                        match classify_approval_reply(&reply) {
+                            ApprovalReply::Grant => {}
+                            ApprovalReply::AlwaysThisRun => {
+                                remember_approval_grant(grant_key).await;
+                            }
+                            ApprovalReply::Abort => {
+                                if let Some(token) = cancel_owned.as_ref() {
+                                    token.cancel();
+                                }
+                                return ToolExecutionFinished::error(
+                                    ToolErrorCode::PolicyDenied,
+                                    "Edit approval aborted by user; mutation skipped.",
+                                );
+                            }
+                            ApprovalReply::Deny => {
+                                return ToolExecutionFinished::error(
+                                    ToolErrorCode::PolicyDenied,
+                                    "Edit not approved by user; mutation skipped.",
+                                );
+                            }
                         }
+                        } // end if !already_granted
                         approved_mutation_preview = Some(preview);
                     }
                 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -87,7 +87,7 @@ async fn persist_terminal_assistant_message(
         let _ = logger_tx.send(BusMessage::Log(
             LogEvent::warn(
                 name,
-                &format!("Failed to persist terminal assistant message: {}", e),
+                &format!("Failed to persist terminal assistant message: {e}"),
             )
             .with_chat_id(chat_id),
         ));
@@ -440,7 +440,7 @@ fn should_require_shell_approval(command: &str, patterns: &[String]) -> bool {
         if np.is_empty() {
             return false;
         }
-        normalized.contains(&format!(" {} ", np))
+        normalized.contains(&format!(" {np} "))
     })
 }
 
@@ -956,7 +956,7 @@ async fn log_tool_invocation_start(
     let tool_name = &tc.function.name;
     let args_str = &tc.function.arguments;
     let _ = logger_tx.send(BusMessage::Log(
-        LogEvent::info(agent_name, &format!("Invoking tool: {}", tool_name))
+        LogEvent::info(agent_name, &format!("Invoking tool: {tool_name}"))
             .with_chat_id(&inbound.chat_id),
     ));
     let _ = outbound_tx
@@ -1104,8 +1104,7 @@ async fn execute_tool_call_with_activity(
                             return ToolExecutionFinished::error(
                                 ToolErrorCode::PolicyDenied,
                                 format!(
-                                    "Command blocked by shell policy (mode=deny): {}",
-                                    command
+                                    "Command blocked by shell policy (mode=deny): {command}"
                                 ),
                             );
                         }
@@ -1212,7 +1211,7 @@ async fn execute_tool_call_with_activity(
                                 Err(e) => {
                                     return ToolExecutionFinished::error(
                                         ToolErrorCode::ExecutionFailed,
-                                        format!("Shell policy approval failed: {}", e),
+                                        format!("Shell policy approval failed: {e}"),
                                     );
                                 }
                             }
@@ -1747,7 +1746,7 @@ fn spawn_main_chat_reasoning_turn(
         let _ = logger_tx.send(BusMessage::Log(
             LogEvent::debug(
                 &agent_name,
-                &format!("Spawning reasoning task for chat_id: {}", task_chat_id),
+                &format!("Spawning reasoning task for chat_id: {task_chat_id}"),
             )
             .with_chat_id(&task_chat_id),
         ));
@@ -1839,8 +1838,7 @@ fn spawn_main_chat_reasoning_turn(
                     LogEvent::info(
                         &agent_name,
                         &format!(
-                            "Reasoning task for chat_id {} finished via cancellation.",
-                            task_chat_id
+                            "Reasoning task for chat_id {task_chat_id} finished via cancellation."
                         ),
                     )
                     .with_chat_id(&task_chat_id),
@@ -1851,8 +1849,7 @@ fn spawn_main_chat_reasoning_turn(
                     LogEvent::debug(
                         &agent_name,
                         &format!(
-                            "Reasoning task for chat_id {} finished successfully.",
-                            task_chat_id
+                            "Reasoning task for chat_id {task_chat_id} finished successfully."
                         ),
                     )
                     .with_chat_id(&task_chat_id),
@@ -1863,7 +1860,7 @@ fn spawn_main_chat_reasoning_turn(
                 let _ = logger_tx.send(BusMessage::Log(
                     LogEvent::error(
                         "AgentLogic",
-                        &format!("Reasoning loop panicked for chat_id {}", task_chat_id),
+                        &format!("Reasoning loop panicked for chat_id {task_chat_id}"),
                     )
                     .with_chat_id(&task_chat_id),
                 ));
@@ -2008,7 +2005,7 @@ fn spawn_main_chat_reasoning_turn(
                     let _ = logger_tx.send(BusMessage::Log(
                         LogEvent::error(
                             "AgentLogic",
-                            &format!("Dropping queued inbound without valid run ID: {}", error),
+                            &format!("Dropping queued inbound without valid run ID: {error}"),
                         )
                         .with_chat_id(&task_chat_id),
                     ));
@@ -2409,8 +2406,7 @@ impl AgentLogic {
                 LogEvent::warn(
                     &self.name,
                     &format!(
-                        "Ignored cancellation for chat_id {} because run_id did not match the active run.",
-                        chat_id
+                        "Ignored cancellation for chat_id {chat_id} because run_id did not match the active run."
                     ),
                 )
                 .with_chat_id(chat_id),
@@ -2427,7 +2423,7 @@ impl AgentLogic {
         let _ = self.logger_tx.send(BusMessage::Log(
             LogEvent::info(
                 &self.name,
-                &format!("Cancelled reasoning loop for chat_id: {}", chat_id),
+                &format!("Cancelled reasoning loop for chat_id: {chat_id}"),
             )
             .with_chat_id(chat_id),
         ));
@@ -2500,8 +2496,7 @@ impl ActorLogic<BusMessage> for AgentLogic {
                 let _ = self.logger_tx.send(BusMessage::Log(LogEvent::info(
                     &self.name,
                     &format!(
-                        "Switched to provider={} model={}",
-                        provider_name, model_name
+                        "Switched to provider={provider_name} model={model_name}"
                     ),
                 )));
                 return Ok(None);
@@ -2531,7 +2526,7 @@ impl ActorLogic<BusMessage> for AgentLogic {
                         Err(e) => {
                             let _ = logger_tx.send(BusMessage::Log(LogEvent::error(
                                 &name,
-                                &format!("Failed to install skills from {}: {}", repo_url, e),
+                                &format!("Failed to install skills from {repo_url}: {e}"),
                             )));
                         }
                     }
@@ -2545,7 +2540,7 @@ impl ActorLogic<BusMessage> for AgentLogic {
                         let _ = self.logger_tx.send(BusMessage::Log(
                             LogEvent::error(
                                 &self.name,
-                                &format!("Rejecting inbound message: {}", error),
+                                &format!("Rejecting inbound message: {error}"),
                             )
                             .with_chat_id(&inbound.chat_id),
                         ));
@@ -2637,8 +2632,7 @@ impl ActorLogic<BusMessage> for AgentLogic {
                         LogEvent::debug(
                             &self.name,
                             &format!(
-                                "Queued inbound for chat_id {} (FIFO) — reasoning already active.",
-                                chat_id
+                                "Queued inbound for chat_id {chat_id} (FIFO) — reasoning already active."
                             ),
                         )
                         .with_chat_id(&chat_id),
@@ -2681,8 +2675,7 @@ impl ActorLogic<BusMessage> for AgentLogic {
                     let _ = self.logger_tx.send(BusMessage::Log(LogEvent::warn(
                         &self.name,
                         &format!(
-                            "TriggerCompaction dropped for session_key={}: {}",
-                            session_key, e
+                            "TriggerCompaction dropped for session_key={session_key}: {e}"
                         ),
                     )));
                 }
@@ -2744,16 +2737,14 @@ impl AgentLogic {
             .nth(1)
             .ok_or_else(|| {
                 format!(
-                    "Malformed session_key (expected `channel:chat_id:thread`): {}",
-                    session_key
+                    "Malformed session_key (expected `channel:chat_id:thread`): {session_key}"
                 )
             })?
             .to_string();
 
         if self.cancellation_tokens.contains_key(&chat_id) {
             return Err(format!(
-                "Refusing manual compaction: reasoning turn in flight for chat_id={}",
-                chat_id
+                "Refusing manual compaction: reasoning turn in flight for chat_id={chat_id}"
             ));
         }
 
@@ -2761,11 +2752,11 @@ impl AgentLogic {
             .session_manager
             .get_session(&session_key)
             .await
-            .map_err(|e| format!("get_session({}): {}", session_key, e))?;
+            .map_err(|e| format!("get_session({session_key}): {e}"))?;
         let current_context = mem
             .get_context_since_reflection()
             .await
-            .map_err(|e| format!("get_context_since_reflection({}): {}", session_key, e))?;
+            .map_err(|e| format!("get_context_since_reflection({session_key}): {e}"))?;
         let user_turns = current_context.iter().filter(|m| m.role == "user").count();
         let approx_tokens: usize = estimate_context_tokens(&current_context);
 
@@ -2774,7 +2765,7 @@ impl AgentLogic {
         let prefix = {
             let mut parts = session_key.splitn(3, ':');
             let channel = parts.next().unwrap_or("");
-            format!("{}:{}", channel, chat_id)
+            format!("{channel}:{chat_id}")
         };
         let recent = self
             .session_manager
@@ -2986,11 +2977,11 @@ impl AgentLogic {
                 reply: SharedReply::new(tx),
             })
             .await
-            .map_err(|e| format!("Memory actor error: {}", e))?;
+            .map_err(|e| format!("Memory actor error: {e}"))?;
 
         rx.await
             .map_err(|_| "Memory actor channel closed".to_string())?
-            .map_err(|e| format!("Memory node failed to resolve ticket fully: {}", e))?;
+            .map_err(|e| format!("Memory node failed to resolve ticket fully: {e}"))?;
 
         // 2. Inject tool response into memory
         if let Some(id) = tool_call_id {
@@ -3016,9 +3007,9 @@ impl AgentLogic {
                     tool_name_for_resume.as_deref(),
                 ))
                 .await
-                .map_err(|e| format!("Failed to inject tool response into memory: {}", e))?;
+                .map_err(|e| format!("Failed to inject tool response into memory: {e}"))?;
             } else {
-                return Err(format!("Failed to get session {}", session_key));
+                return Err(format!("Failed to get session {session_key}"));
             }
         }
 
@@ -3628,7 +3619,7 @@ impl AgentLogic {
         let thread_info = inbound
             .thread_id
             .as_deref()
-            .map(|t| format!(", thread: '{}'", t))
+            .map(|t| format!(", thread: '{t}'"))
             .unwrap_or_default();
         let now = chrono::Local::now().to_rfc3339();
         let os_family = std::env::consts::OS;
@@ -3670,7 +3661,7 @@ impl AgentLogic {
         if let Some(v) = inbound.metadata.get("isanagent_autonomous_until") {
             if let Some(s) = v.as_str() {
                 runtime_context
-                    .push_str(&format!(" Autonomous session deadline (RFC3339): '{}'.", s));
+                    .push_str(&format!(" Autonomous session deadline (RFC3339): '{s}'."));
             }
         }
         if forbid_final_effective {
@@ -3701,7 +3692,7 @@ impl AgentLogic {
                         return Err(ReasoningLoopError::protocol(msg));
                     }
                     UserPromptHookOutcome::InjectPrefix(prefix) => {
-                        contextualized_content = format!("{}\n{}", prefix, contextualized_content);
+                        contextualized_content = format!("{prefix}\n{contextualized_content}");
                     }
                     UserPromptHookOutcome::Proceed => {}
                 }
@@ -3787,7 +3778,7 @@ impl AgentLogic {
             let _ = logger_tx.send(BusMessage::Log(
                 LogEvent::debug(
                     &name,
-                    &format!("Iteration {}/{}", iterations, max_iterations),
+                    &format!("Iteration {iterations}/{max_iterations}"),
                 )
                 .with_chat_id(&inbound.chat_id),
             ));
@@ -3921,8 +3912,7 @@ impl AgentLogic {
                 String::new()
             };
             let iteration_line = format!(
-                "\n--- Reasoning budget ---\nYou are on tool/LLM step {} of {} for this user turn.\n",
-                iterations, max_iterations
+                "\n--- Reasoning budget ---\nYou are on tool/LLM step {iterations} of {max_iterations} for this user turn.\n"
             );
             let autonomy_line = if forbid_final_effective {
                 "\n--- Autonomy ---\nDo not finish this step with assistant text only — call tools (or `ask_user` if blocked). If you believe you are done, still run a verification tool (e.g. read_file or execution_env_info) when appropriate.\n"
@@ -3959,8 +3949,7 @@ impl AgentLogic {
                                 LogEvent::warn(
                                     &name,
                                     &format!(
-                                        "Doom loop still active after {} consecutive detections — stopping the run.",
-                                        consecutive_doom_detections
+                                        "Doom loop still active after {consecutive_doom_detections} consecutive detections — stopping the run."
                                     ),
                                 )
                                 .with_chat_id(&inbound.chat_id),

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -100,7 +100,7 @@ impl AgentRegistry {
                 }
             };
             let iter_hint = match m.max_iterations {
-                Some(n) => format!(", max {} iterations", n),
+                Some(n) => format!(", max {n} iterations"),
                 None => String::new(),
             };
             s.push_str(&format!(

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -144,7 +144,7 @@ async fn persist_subagent_start(
             reply: SharedReply::new(tx),
         })
         .await
-        .map_err(|e| format!("memory: {}", e))?;
+        .map_err(|e| format!("memory: {e}"))?;
     rx.await.map_err(|_| "memory actor closed".to_string())?
 }
 
@@ -364,8 +364,7 @@ impl SubagentHarness {
                 let maybe = registry.get(agent).cloned();
                 if maybe.is_none() {
                     return Err(format!(
-                        "Named agent '{}' not found in registry. Use `agent_list` to see available agents.",
-                        agent
+                        "Named agent '{agent}' not found in registry. Use `agent_list` to see available agents."
                     ));
                 }
                 maybe
@@ -554,7 +553,7 @@ impl SubagentHarness {
             sender_id: parent_chat_id.clone(),
             chat_id: child_chat_id.clone(),
             thread_id: parent_thread_id.clone(),
-            content: format!("[Sub-agent: {}]\n\n{}", label, prompt),
+            content: format!("[Sub-agent: {label}]\n\n{prompt}"),
             attachments: vec![],
             metadata: HashMap::new(),
         };
@@ -799,7 +798,7 @@ impl SubagentHarness {
                 .await
                 .map_err(|_| {
                     record.cancel.cancel();
-                    format!("subagent_spawn timed out after {}s (wait=true)", max_wait)
+                    format!("subagent_spawn timed out after {max_wait}s (wait=true)")
                 })?;
         }
 
@@ -833,7 +832,7 @@ impl SubagentHarness {
             .inner
             .tasks
             .get(task_id)
-            .ok_or_else(|| format!("Task '{}' not found", task_id))?;
+            .ok_or_else(|| format!("Task '{task_id}' not found"))?;
         if t.parent_chat_id != parent_chat_id {
             return Err("Task is not owned by the current chat".to_string());
         }
@@ -848,7 +847,7 @@ impl SubagentHarness {
     pub fn cancel_task(&self, task_id: &str, parent_chat_id: &str) -> Result<String, String> {
         let t = self.find_task(task_id, parent_chat_id)?;
         t.cancel.cancel();
-        Ok(format!("Cancellation requested for task {}", task_id))
+        Ok(format!("Cancellation requested for task {task_id}"))
     }
 }
 
@@ -1078,7 +1077,7 @@ impl Tool for SubagentPlanTool {
             .and_then(|v| v.as_str())
             .ok_or("Missing plan (JSON string)")?;
         let plan: PlanInput =
-            serde_json::from_str(plan_str).map_err(|e| format!("Invalid plan JSON: {}", e))?;
+            serde_json::from_str(plan_str).map_err(|e| format!("Invalid plan JSON: {e}"))?;
         if plan.steps.is_empty() {
             return Err("plan.steps is empty".to_string());
         }
@@ -1118,12 +1117,12 @@ impl Tool for SubagentPlanTool {
                 let mut body = String::new();
                 for d in &deps[&step_id] {
                     if let Some(r) = results.get(d) {
-                        body.push_str(&format!("## Prior step {} result:\n{}\n\n", d, r));
+                        body.push_str(&format!("## Prior step {d} result:\n{r}\n\n"));
                     }
                 }
                 body.push_str(&prompts[&step_id]);
                 let p = current_parent_ids()?;
-                let label = format!("plan-{}", step_id);
+                let label = format!("plan-{step_id}");
                 let spawn_json = self
                     .harness
                     .spawn(SubagentSpawnSpec {
@@ -1147,7 +1146,7 @@ impl Tool for SubagentPlanTool {
                     })
                     .unwrap_or(spawn_json.clone());
                 results.insert(step_id.clone(), step_output.clone());
-                out.push_str(&format!("## Step {}\n{}\n\n", step_id, step_output));
+                out.push_str(&format!("## Step {step_id}\n{step_output}\n\n"));
                 done.insert(step_id);
             }
         }
@@ -1194,7 +1193,7 @@ impl Tool for TaskHistoryListTool {
                 reply: SharedReply::new(tx),
             })
             .await
-            .map_err(|e| format!("memory: {}", e))?;
+            .map_err(|e| format!("memory: {e}"))?;
         let rows = rx.await.map_err(|_| "memory actor closed".to_string())??;
         if rows.is_empty() {
             return Ok("No persisted sub-agent tasks for this chat yet.".to_string());
@@ -1240,7 +1239,7 @@ impl Tool for AgentListTool {
             let model = m.model.as_deref().unwrap_or("(parent model)");
             let temp = m
                 .temperature
-                .map(|t| format!("{:.2}", t))
+                .map(|t| format!("{t:.2}"))
                 .unwrap_or_else(|| "default".to_string());
             let iter = m
                 .max_iterations
@@ -1304,7 +1303,7 @@ impl Tool for TaskDashboardTool {
                 reply: SharedReply::new(tx),
             })
             .await
-            .map_err(|e| format!("memory: {}", e))?;
+            .map_err(|e| format!("memory: {e}"))?;
         let rows = rx.await.map_err(|_| "memory actor closed".to_string())??;
         if rows.is_empty() {
             out.push_str("(no history)\n");

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -57,7 +57,7 @@ pub fn get_background_job_id(
 /// using an empty thread segment when `thread_id` is missing.
 pub fn clarification_session_key(channel: &str, chat_id: &str, thread_id: Option<&str>) -> String {
     let thread_part = thread_id.unwrap_or("");
-    format!("{}:{}:{}", channel, chat_id, thread_part)
+    format!("{channel}:{chat_id}:{thread_part}")
 }
 
 impl InboundMessage {
@@ -508,17 +508,17 @@ impl LogEvent {
         let target_part = self
             .target
             .as_deref()
-            .map(|target| format!(" [target:{}]", target))
+            .map(|target| format!(" [target:{target}]"))
             .unwrap_or_default();
         let location_part = match (self.file.as_deref(), self.line) {
-            (Some(file), Some(line)) => format!(" [{}:{}]", file, line),
-            (Some(file), None) => format!(" [{}]", file),
+            (Some(file), Some(line)) => format!(" [{file}:{line}]"),
+            (Some(file), None) => format!(" [{file}]"),
             _ => String::new(),
         };
         let meta_part = self
             .metadata
             .as_ref()
-            .map(|m| format!(" {}", m))
+            .map(|m| format!(" {m}"))
             .unwrap_or_default();
         format!(
             "{} [{}] [{}]{}{}{} {}",
@@ -536,7 +536,7 @@ impl LogEvent {
 fn redact_chat_id(chat_id: &str) -> String {
     if let Some((local, domain)) = chat_id.split_once('@') {
         let first = local.chars().next().unwrap_or('*');
-        return format!("{}***@{}", first, domain);
+        return format!("{first}***@{domain}");
     }
     chat_id.to_string()
 }

--- a/src/channels/api.rs
+++ b/src/channels/api.rs
@@ -490,13 +490,13 @@ impl Channel for ApiChannel {
             "ApiChannel",
             "Starting API channel...",
         )));
-        let addr = format!("{}:{}", resolved_bind, port);
+        let addr = format!("{resolved_bind}:{port}");
         let listener = tokio::net::TcpListener::bind(&addr)
             .await
-            .map_err(|e| format!("Failed to bind API port on {}: {}", addr, e))?;
+            .map_err(|e| format!("Failed to bind API port on {addr}: {e}"))?;
         let _ = logger_tx.send(BusMessage::Log(LogEvent::info(
             "ApiChannel",
-            &format!("API channel listening on http://{}", addr),
+            &format!("API channel listening on http://{addr}"),
         )));
 
         let handle = tokio::spawn(async move {
@@ -509,7 +509,7 @@ impl Channel for ApiChannel {
                 }
             });
             if let Err(e) = server.await {
-                error!("API server crashed: {}", e);
+                error!("API server crashed: {e}");
             }
         });
         *self
@@ -566,8 +566,7 @@ impl Channel for ApiChannel {
                                 LogEvent::error(
                                     "ApiChannel",
                                     &format!(
-                                        "Failed to persist streaming response {}: {}",
-                                        response_id, e
+                                        "Failed to persist streaming response {response_id}: {e}"
                                     ),
                                 )
                                 .with_chat_id(&thread_id),
@@ -576,8 +575,7 @@ impl Channel for ApiChannel {
                                 message: "Failed to persist response state.".to_string(),
                             }) {
                                 error!(
-                                    "Failed to send stream error after persist failure: {}",
-                                    send_err
+                                    "Failed to send stream error after persist failure: {send_err}"
                                 );
                             }
                             return Ok(());
@@ -589,8 +587,7 @@ impl Channel for ApiChannel {
                         LogEvent::info(
                             "ApiChannel",
                             &format!(
-                                "Streaming responses request completed with response_id {}",
-                                response_id
+                                "Streaming responses request completed with response_id {response_id}"
                             ),
                         )
                         .with_chat_id(&thread_id),
@@ -600,14 +597,13 @@ impl Channel for ApiChannel {
                         thread_id,
                         response_id,
                     }) {
-                        error!("Failed to send completion to stream: {}", e);
+                        error!("Failed to send completion to stream: {e}");
                     }
                 }
             }
         } else {
             error!(
-                "ApiChannel: No pending request found for chat_id: {}",
-                chat_id
+                "ApiChannel: No pending request found for chat_id: {chat_id}"
             );
         }
         Ok(())
@@ -635,7 +631,7 @@ impl ApiChannel {
                             args,
                             tool_call_id,
                         }) {
-                            error!("Failed to send tool_call_started to stream: {}", e);
+                            error!("Failed to send tool_call_started to stream: {e}");
                         }
                     }
                 }
@@ -654,7 +650,7 @@ impl ApiChannel {
                             message,
                             tool_call_id,
                         }) {
-                            error!("Failed to send tool_progress to stream: {}", e);
+                            error!("Failed to send tool_progress to stream: {e}");
                         }
                     }
                 }
@@ -675,7 +671,7 @@ impl ApiChannel {
                             is_error,
                             tool_call_id,
                         }) {
-                            error!("Failed to send tool_call_finished to stream: {}", e);
+                            error!("Failed to send tool_call_finished to stream: {e}");
                         }
                     }
                 }
@@ -689,7 +685,7 @@ impl ApiChannel {
                             .stream_tx
                             .try_send(StreamEvent::AgentThought { thought })
                         {
-                            error!("Failed to send agent_thought to stream: {}", e);
+                            error!("Failed to send agent_thought to stream: {e}");
                         }
                     }
                 }
@@ -812,7 +808,7 @@ async fn handle_ui_index() -> Response {
 }
 
 async fn handle_ui_asset(AxumPath(asset_path): AxumPath<String>) -> Response {
-    let asset_key = format!("assets/{}", asset_path);
+    let asset_key = format!("assets/{asset_path}");
     match find_ui_asset(&asset_key) {
         Some(asset) => ui_asset_response(asset),
         None => StatusCode::NOT_FOUND.into_response(),
@@ -879,8 +875,7 @@ async fn handle_mte_cron_webhook(
                 LogEvent::error(
                     "ApiChannel",
                     &format!(
-                        "Failed to process multi-tenant-edge cron webhook for job {}: {}",
-                        job_id, error
+                        "Failed to process multi-tenant-edge cron webhook for job {job_id}: {error}"
                     ),
                 ),
             );
@@ -1040,8 +1035,7 @@ async fn handle_responses(
                                 LogEvent::debug(
                                     "ApiChannel",
                                     &format!(
-                                        "Loaded response state from DB for previous_response_id {}",
-                                        previous_response_id
+                                        "Loaded response state from DB for previous_response_id {previous_response_id}"
                                     ),
                                 ),
                             );
@@ -1053,15 +1047,14 @@ async fn handle_responses(
                                 LogEvent::warn(
                                     "ApiChannel",
                                     &format!(
-                                    "Responses request referenced unknown previous_response_id {}",
-                                    previous_response_id
+                                    "Responses request referenced unknown previous_response_id {previous_response_id}"
                                 ),
                                 ),
                             );
                             return ApiError::new(
                                 StatusCode::NOT_FOUND,
                                 "previous_response_not_found",
-                                format!("Unknown previous_response_id: {}", previous_response_id),
+                                format!("Unknown previous_response_id: {previous_response_id}"),
                             )
                             .into_response();
                         }
@@ -1071,8 +1064,7 @@ async fn handle_responses(
                                 LogEvent::error(
                                     "ApiChannel",
                                     &format!(
-                                        "Failed to load response state for {}: {}",
-                                        previous_response_id, e
+                                        "Failed to load response state for {previous_response_id}: {e}"
                                     ),
                                 ),
                             );
@@ -1173,7 +1165,7 @@ async fn handle_responses(
             return ApiError::new(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "agent_queue_unavailable",
-                format!("Failed to enqueue request: {}", e),
+                format!("Failed to enqueue request: {e}"),
             )
             .into_response();
         }
@@ -1183,7 +1175,7 @@ async fn handle_responses(
                 match serde_json::to_string(&event) {
                     Ok(json) => yield Ok::<Event, std::convert::Infallible>(Event::default().data(json)),
                     Err(e) => {
-                        error!("Failed to serialize stream event: {}", e);
+                        error!("Failed to serialize stream event: {e}");
                     }
                 }
             }
@@ -1222,7 +1214,7 @@ async fn handle_responses(
                 &state.logger_tx,
                 LogEvent::error(
                     "ApiChannel",
-                    &format!("Failed to persist response {}: {}", response_id, e),
+                    &format!("Failed to persist response {response_id}: {e}"),
                 )
                 .with_chat_id(&conv_thread_id),
             );
@@ -1241,8 +1233,7 @@ async fn handle_responses(
         LogEvent::info(
             "ApiChannel",
             &format!(
-                "Responses request completed with response_id {}",
-                response_id
+                "Responses request completed with response_id {response_id}"
             ),
         )
         .with_chat_id(&conv_thread_id),
@@ -1306,7 +1297,7 @@ async fn dispatch_agent_turn(
             &state.logger_tx,
             LogEvent::error(
                 "ApiChannel",
-                &format!("API handler failed to send inbound message: {}", e),
+                &format!("API handler failed to send inbound message: {e}"),
             )
             .with_chat_id(&chat_id),
         );
@@ -1467,7 +1458,7 @@ fn collect_input_parts(
             // Handle explicit content part objects (type: "text" / "image_url")
             if let Some(kind) = map.get("type").and_then(Value::as_str) {
                 return collect_content_parts(value, text_segments, attachments)
-                    .map_err(|_| format!("Unsupported content part type: {}", kind));
+                    .map_err(|_| format!("Unsupported content part type: {kind}"));
             }
 
             // Convenience: objects with a top-level `text` field
@@ -1531,7 +1522,7 @@ fn truncate_chat_preview(text: &str) -> String {
     let mut iter = line.chars();
     let chunk: String = iter.by_ref().take(56).collect();
     if iter.next().is_some() {
-        format!("{}…", chunk)
+        format!("{chunk}…")
     } else {
         chunk
     }
@@ -1608,7 +1599,7 @@ fn resolve_memory_thread_id<'a>(state: &ApiState, raw: &'a str) -> Cow<'a, str> 
         if s.ends_with(':') {
             Cow::Borrowed(s)
         } else {
-            Cow::Owned(format!("{}:", s))
+            Cow::Owned(format!("{s}:"))
         }
     } else {
         // Extract the bare ID by taking the last non-empty colon-delimited segment.
@@ -1616,7 +1607,7 @@ fn resolve_memory_thread_id<'a>(state: &ApiState, raw: &'a str) -> Cow<'a, str> 
         // and re-qualifies it with the current channel, preventing cross-channel
         // history access.
         let id = s.rsplit(':').find(|seg| !seg.is_empty()).unwrap_or(s);
-        Cow::Owned(format!("{}{}:", prefix, id))
+        Cow::Owned(format!("{prefix}{id}:"))
     }
 }
 
@@ -1712,7 +1703,7 @@ async fn handle_list_threads(
                         vec![None; rows.len()]
                     }
                     Err(e) => {
-                        error!("thread list preview batch failed: {}", e);
+                        error!("thread list preview batch failed: {e}");
                         vec![None; rows.len()]
                     }
                 };
@@ -2178,7 +2169,7 @@ async fn handle_workspace_file(
         return ApiError::new(
             StatusCode::PAYLOAD_TOO_LARGE,
             "file_too_large",
-            format!("File is {len} bytes (max {}).", WORKSPACE_FILE_MAX_BYTES),
+            format!("File is {len} bytes (max {WORKSPACE_FILE_MAX_BYTES})."),
         )
         .into_response();
     }
@@ -2548,7 +2539,7 @@ async fn handle_clarification_ticket_reply(
         return ApiError::new(
             StatusCode::INTERNAL_SERVER_ERROR,
             "agent_queue_unavailable",
-            format!("Failed to enqueue ticket response: {}", e),
+            format!("Failed to enqueue ticket response: {e}"),
         )
         .into_response();
     }

--- a/src/channels/api_store.rs
+++ b/src/channels/api_store.rs
@@ -56,13 +56,13 @@ struct SqliteApiResponseStoreActor {
 impl SqliteApiResponseStoreActor {
     fn new(db_path: impl AsRef<Path>) -> Result<Self, String> {
         let conn = Connection::open(db_path)
-            .map_err(|e| format!("Failed to open API response store: {}", e))?;
+            .map_err(|e| format!("Failed to open API response store: {e}"))?;
         conn.busy_timeout(Duration::from_secs(5))
-            .map_err(|e| format!("Failed to configure API response store busy timeout: {}", e))?;
+            .map_err(|e| format!("Failed to configure API response store busy timeout: {e}"))?;
         conn.pragma_update(None, "journal_mode", "WAL")
-            .map_err(|e| format!("Failed to enable WAL mode for API response store: {}", e))?;
+            .map_err(|e| format!("Failed to enable WAL mode for API response store: {e}"))?;
         conn.pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|e| format!("Failed to tune API response store synchronous mode: {}", e))?;
+            .map_err(|e| format!("Failed to tune API response store synchronous mode: {e}"))?;
         conn.execute(
             "CREATE TABLE IF NOT EXISTS api_responses (
                 response_id TEXT PRIMARY KEY,
@@ -74,7 +74,7 @@ impl SqliteApiResponseStoreActor {
             )",
             [],
         )
-        .map_err(|e| format!("Failed to initialize api_responses table: {}", e))?;
+        .map_err(|e| format!("Failed to initialize api_responses table: {e}"))?;
 
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_api_responses_previous_response_id
@@ -83,8 +83,7 @@ impl SqliteApiResponseStoreActor {
         )
         .map_err(|e| {
             format!(
-                "Failed to initialize api_responses previous_response_id index: {}",
-                e
+                "Failed to initialize api_responses previous_response_id index: {e}"
             )
         })?;
         conn.execute(
@@ -92,7 +91,7 @@ impl SqliteApiResponseStoreActor {
              ON api_responses(created_at)",
             [],
         )
-        .map_err(|e| format!("Failed to initialize api_responses created_at index: {}", e))?;
+        .map_err(|e| format!("Failed to initialize api_responses created_at index: {e}"))?;
 
         Ok(Self { conn })
     }
@@ -131,7 +130,7 @@ impl ActorLogic<ApiStoreMessage> for SqliteApiResponseStoreActor {
                             created_at
                         ],
                     )
-                    .map_err(|e| format!("Failed to persist response state: {}", e))
+                    .map_err(|e| format!("Failed to persist response state: {e}"))
                     .map(|_| ());
                 let _ = reply.send(result);
             }
@@ -152,7 +151,7 @@ impl ActorLogic<ApiStoreMessage> for SqliteApiResponseStoreActor {
                         },
                     )
                     .optional()
-                    .map_err(|e| format!("Failed to load response state: {}", e));
+                    .map_err(|e| format!("Failed to load response state: {e}"));
                 let _ = reply.send(result);
             }
             ApiStoreMessage::ListThreadsBySender {
@@ -185,7 +184,7 @@ impl ActorLogic<ApiStoreMessage> for SqliteApiResponseStoreActor {
                             ORDER BY updated_at DESC
                             LIMIT ?2",
                         )
-                        .map_err(|e| format!("Failed to list threads: {}", e))?;
+                        .map_err(|e| format!("Failed to list threads: {e}"))?;
                     let rows = stmt
                         .query_map(params![sender_id, limit_i64], |row| {
                             Ok(ThreadListRow {
@@ -194,10 +193,10 @@ impl ActorLogic<ApiStoreMessage> for SqliteApiResponseStoreActor {
                                 latest_response_id: row.get(2)?,
                             })
                         })
-                        .map_err(|e| format!("Failed to list threads: {}", e))?;
+                        .map_err(|e| format!("Failed to list threads: {e}"))?;
                     let mut out = Vec::new();
                     for r in rows {
-                        out.push(r.map_err(|e| format!("Failed to read thread row: {}", e))?);
+                        out.push(r.map_err(|e| format!("Failed to read thread row: {e}"))?);
                     }
                     Ok(out)
                 })();
@@ -215,7 +214,7 @@ impl ActorLogic<ApiStoreMessage> for SqliteApiResponseStoreActor {
                          WHERE thread_id = ?1 AND sender_id = ?2",
                         params![thread_id, sender_id],
                     )
-                    .map_err(|e| format!("Failed to delete thread responses: {}", e));
+                    .map_err(|e| format!("Failed to delete thread responses: {e}"));
                 let _ = reply.send(result);
             }
         }
@@ -253,7 +252,7 @@ impl ResponseStore {
         self.node
             .send_packet(msg)
             .await
-            .map_err(|e| format!("Failed to send response store insert request: {}", e))?;
+            .map_err(|e| format!("Failed to send response store insert request: {e}"))?;
         rx.await
             .map_err(|_| "API response store actor channel closed".to_string())?
     }
@@ -267,7 +266,7 @@ impl ResponseStore {
         self.node
             .send_packet(msg)
             .await
-            .map_err(|e| format!("Failed to send response store get request: {}", e))?;
+            .map_err(|e| format!("Failed to send response store get request: {e}"))?;
         rx.await
             .map_err(|_| "API response store actor channel closed".to_string())?
     }
@@ -286,7 +285,7 @@ impl ResponseStore {
         self.node
             .send_packet(msg)
             .await
-            .map_err(|e| format!("Failed to send list threads request: {}", e))?;
+            .map_err(|e| format!("Failed to send list threads request: {e}"))?;
         rx.await
             .map_err(|_| "API response store actor channel closed".to_string())?
     }
@@ -306,7 +305,7 @@ impl ResponseStore {
         self.node
             .send_packet(msg)
             .await
-            .map_err(|e| format!("Failed to send delete thread request: {}", e))?;
+            .map_err(|e| format!("Failed to send delete thread request: {e}"))?;
         rx.await
             .map_err(|_| "API response store actor channel closed".to_string())?
     }

--- a/src/channels/email.rs
+++ b/src/channels/email.rs
@@ -62,9 +62,9 @@ impl Channel for EmailChannel {
                 let res = tokio::task::spawn_blocking(move || poll_inbox_once(cfg, tx)).await;
 
                 if let Err(e) = res {
-                    error!("IMAP panic: {}", e);
+                    error!("IMAP panic: {e}");
                 } else if let Ok(Err(e)) = res {
-                    error!("IMAP Error: {}. Reconnecting in 15 seconds.", e);
+                    error!("IMAP Error: {e}. Reconnecting in 15 seconds.");
                 }
 
                 tokio::select! {
@@ -111,15 +111,15 @@ impl Channel for EmailChannel {
                     config
                         .email_address
                         .parse()
-                        .map_err(|e| format!("Invalid from address: {}", e))?,
+                        .map_err(|e| format!("Invalid from address: {e}"))?,
                 )
                 .to(to_address
                     .parse()
-                    .map_err(|e| format!("Invalid to address: {}", e))?)
+                    .map_err(|e| format!("Invalid to address: {e}"))?)
                 .subject(if subject.starts_with("Re:") {
                     subject.clone()
                 } else {
-                    format!("Re: {}", subject)
+                    format!("Re: {subject}")
                 })
                 .body(msg.content.clone())
                 .map_err(|e| e.to_string())?;
@@ -128,18 +128,18 @@ impl Channel for EmailChannel {
                 Credentials::new(config.imap_username.clone(), config.imap_password.clone());
 
             let mailer = SmtpTransport::relay(&config.smtp_host)
-                .map_err(|e| format!("Invalid SMTP host: {}", e))?
+                .map_err(|e| format!("Invalid SMTP host: {e}"))?
                 .port(config.smtp_port)
                 .credentials(creds)
                 .build();
 
             mailer.send(&email).map_err(|e| e.to_string())?;
 
-            info!("Successfully sent reply email to {}", to_address);
+            info!("Successfully sent reply email to {to_address}");
             Ok(())
         })
         .await
-        .map_err(|e| format!("SMTP task panicked: {}", e))?
+        .map_err(|e| format!("SMTP task panicked: {e}"))?
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -162,7 +162,7 @@ fn poll_inbox_once(config: EmailConfig, bus_tx: Sender<BusMessage>) -> Result<()
     info!("Found {} UNSEEN messages", messages.len());
 
     for seq in messages {
-        info!("Fetching message {}", seq);
+        info!("Fetching message {seq}");
         if let Ok(fetches) = session.fetch(seq.to_string(), "(ENVELOPE BODY[TEXT])") {
             for m in fetches.iter() {
                 let mut sender = String::from("unknown@example.com");
@@ -201,11 +201,11 @@ fn poll_inbox_once(config: EmailConfig, bus_tx: Sender<BusMessage>) -> Result<()
                 };
 
                 if let Err(e) = bus_tx.blocking_send(BusMessage::Inbound(inbound)) {
-                    error!("Failed to route email to agent bus: {}", e);
+                    error!("Failed to route email to agent bus: {e}");
                 }
             }
         }
-        let _ = session.store(format!("{}", seq), "+FLAGS (\\Seen)");
+        let _ = session.store(format!("{seq}"), "+FLAGS (\\Seen)");
     }
 
     let _ = session.logout();

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -27,7 +27,9 @@ pub trait Channel: Send + Sync {
 pub mod api;
 pub(crate) mod api_store;
 pub mod email;
+pub mod oneshot;
 pub mod slack;
 pub(crate) mod slack_store;
 pub mod terminal;
 pub(crate) mod terminal_ui;
+pub mod tty_prompt;

--- a/src/channels/oneshot.rs
+++ b/src/channels/oneshot.rs
@@ -1,0 +1,380 @@
+//! Headless one-shot channel used by embedding hosts such as ALTAI CLI.
+//!
+//! The channel injects a single inbound prompt, captures the final outbound
+//! assistant message, and either resumes approvals on the controlling TTY
+//! (`/dev/tty`) or rejects them so non-TTY callers never hang or silently
+//! approve.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use tokio::sync::{mpsc, oneshot, watch};
+
+use crate::bus::{BusMessage, InboundMessage, OutboundMessage, RunLifecycleEvent, RunOutcome};
+use crate::channels::tty_prompt::{prompt_on_tty, tty_available};
+use crate::channels::Channel;
+use crate::utils::ContentPart;
+
+pub const ONESHOT_CHANNEL_NAME: &str = "altai-cli";
+
+/// Terminal result of a one-shot host run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OneshotResult {
+    pub chat_id: String,
+    pub run_id: Option<String>,
+    pub outcome: OneshotOutcome,
+    pub final_text: Option<String>,
+}
+
+/// Why a one-shot run stopped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OneshotOutcome {
+    Completed,
+    Failed(String),
+    Cancelled,
+    TimedOut,
+    ApprovalRequired { detail: String },
+    ClarificationRequired { detail: String },
+}
+
+impl OneshotOutcome {
+    pub fn from_run_outcome(outcome: &RunOutcome) -> Self {
+        match outcome {
+            RunOutcome::Completed => Self::Completed,
+            RunOutcome::Cancelled => Self::Cancelled,
+            RunOutcome::Failed { failure, .. } => Self::Failed(format!("{failure:?}")),
+            RunOutcome::Stuck { reason } => Self::Failed(format!("stuck:{reason:?}")),
+            RunOutcome::BudgetExhausted { budget } => {
+                Self::Failed(format!("budget_exhausted:{budget:?}"))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct OneshotState {
+    final_text: Option<String>,
+    run_id: Option<String>,
+    finished: bool,
+}
+
+/// Captures one-shot progress and completes when the run terminates.
+///
+/// Interactive approvals/clarifications resume via `/dev/tty` when available;
+/// otherwise the run exits with an approval/clarification outcome.
+pub struct OneshotChannel {
+    chat_id: String,
+    prompt: String,
+    attachments: Vec<ContentPart>,
+    files: Vec<PathBuf>,
+    state: Arc<Mutex<OneshotState>>,
+    result_tx: Mutex<Option<oneshot::Sender<OneshotResult>>>,
+    shutdown_tx: mpsc::UnboundedSender<()>,
+    observe_tx: Option<mpsc::UnboundedSender<BusMessage>>,
+    bus_tx: Mutex<Option<mpsc::Sender<BusMessage>>>,
+    started: watch::Sender<bool>,
+}
+
+impl OneshotChannel {
+    pub fn new(
+        chat_id: String,
+        prompt: String,
+        files: Vec<PathBuf>,
+        attachments: Vec<ContentPart>,
+        result_tx: oneshot::Sender<OneshotResult>,
+        shutdown_tx: mpsc::UnboundedSender<()>,
+        observe_tx: Option<mpsc::UnboundedSender<BusMessage>>,
+    ) -> Self {
+        let (started, _) = watch::channel(false);
+        Self {
+            chat_id,
+            prompt,
+            attachments,
+            files,
+            state: Arc::new(Mutex::new(OneshotState::default())),
+            result_tx: Mutex::new(Some(result_tx)),
+            shutdown_tx,
+            observe_tx,
+            bus_tx: Mutex::new(None),
+            started,
+        }
+    }
+
+    fn observe(&self, msg: BusMessage) {
+        if let Some(tx) = &self.observe_tx {
+            let _ = tx.send(msg);
+        }
+    }
+
+    fn complete(&self, outcome: OneshotOutcome) {
+        let mut state = self.state.lock().expect("oneshot state");
+        if state.finished {
+            return;
+        }
+        state.finished = true;
+        let result = OneshotResult {
+            chat_id: self.chat_id.clone(),
+            run_id: state.run_id.clone(),
+            outcome,
+            final_text: state.final_text.clone(),
+        };
+        drop(state);
+        if let Some(tx) = self.result_tx.lock().expect("oneshot result").take() {
+            let _ = tx.send(result);
+        }
+        let _ = self.shutdown_tx.send(());
+    }
+
+    fn normalize_tty_reply(raw: &str) -> String {
+        let trimmed = raw.trim();
+        if trimmed.chars().count() == 1 {
+            if let Some(mapped) =
+                crate::channels::terminal_ui::approval_hotkey_reply(trimmed.chars().next().unwrap())
+            {
+                return mapped.to_string();
+            }
+        }
+        trimmed.to_string()
+    }
+
+    async fn resume_approval_on_tty(&self, detail: &str) -> Result<bool, String> {
+        let bus_tx = self
+            .bus_tx
+            .lock()
+            .expect("oneshot bus")
+            .clone()
+            .ok_or_else(|| "oneshot bus is not ready for approval resume".to_string())?;
+
+        let prompt = format!(
+            "\n[altai] Approval required\n{detail}\nChoices: approve / deny / always / abort  (y/n/a/x)\n> "
+        );
+        let reply = tokio::task::spawn_blocking(move || prompt_on_tty(&prompt))
+            .await
+            .map_err(|error| format!("tty prompt join failed: {error}"))?
+            .map_err(|error| format!("tty prompt failed: {error}"))?;
+        let reply = Self::normalize_tty_reply(&reply);
+        if reply.eq_ignore_ascii_case("abort")
+            || reply.eq_ignore_ascii_case("cancel")
+            || reply.eq_ignore_ascii_case("quit")
+        {
+            self.complete(OneshotOutcome::Cancelled);
+            return Ok(true);
+        }
+
+        let inbound = InboundMessage {
+            channel: ONESHOT_CHANNEL_NAME.to_string(),
+            sender_id: "altai-cli".to_string(),
+            chat_id: self.chat_id.clone(),
+            thread_id: None,
+            content: reply,
+            attachments: Vec::new(),
+            metadata: HashMap::new(),
+        };
+        self.observe(BusMessage::Inbound(inbound.clone()));
+        bus_tx
+            .send(BusMessage::Inbound(inbound))
+            .await
+            .map_err(|error| format!("failed to enqueue tty approval reply: {error}"))?;
+        Ok(true)
+    }
+
+    /// Observe host bus traffic that is not delivered through [`Channel::send`].
+    pub fn observe_bus_message(&self, msg: &BusMessage) {
+        self.observe(msg.clone());
+        match msg {
+            BusMessage::RunLifecycle(RunLifecycleEvent::Started { run_id, chat_id })
+                if chat_id == &self.chat_id =>
+            {
+                let mut state = self.state.lock().expect("oneshot state");
+                state.run_id = Some(run_id.clone());
+            }
+            BusMessage::RunLifecycle(RunLifecycleEvent::Terminated {
+                chat_id,
+                run_id,
+                outcome,
+            }) if chat_id == &self.chat_id =>
+            {
+                {
+                    let mut state = self.state.lock().expect("oneshot state");
+                    state.run_id = Some(run_id.clone());
+                }
+                self.complete(OneshotOutcome::from_run_outcome(outcome));
+            }
+            BusMessage::Telemetry(crate::bus::TelemetryEvent::ShellPolicyDecision {
+                chat_id,
+                decision,
+                command_preview,
+                ..
+            }) if chat_id == &self.chat_id && decision == "approval_requested" =>
+            {
+                // When a controlling TTY is available, wait for the clarification
+                // outbound (handled in `send`) so the user can approve interactively.
+                if tty_available() {
+                    return;
+                }
+                self.complete(OneshotOutcome::ApprovalRequired {
+                    detail: command_preview.clone(),
+                });
+            }
+            BusMessage::Outbound(out)
+                if out.channel == ONESHOT_CHANNEL_NAME && out.chat_id == self.chat_id =>
+            {
+                // Captured via Channel::send as well; keep observe path consistent.
+            }
+            _ => {}
+        }
+    }
+
+    fn attachment_note(files: &[PathBuf]) -> String {
+        if files.is_empty() {
+            return String::new();
+        }
+        let list = files
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("\n\n[Attached files: {list}]")
+    }
+}
+
+#[async_trait]
+impl Channel for OneshotChannel {
+    fn name(&self) -> &str {
+        ONESHOT_CHANNEL_NAME
+    }
+
+    async fn start(&self, bus_tx: mpsc::Sender<BusMessage>) -> Result<(), String> {
+        *self.bus_tx.lock().expect("oneshot bus") = Some(bus_tx.clone());
+        let mut content = self.prompt.clone();
+        // Prefer real multimodal attachments; only keep a path note when loading failed.
+        if self.attachments.is_empty() {
+            content.push_str(&Self::attachment_note(&self.files));
+        }
+
+        let inbound = InboundMessage {
+            channel: ONESHOT_CHANNEL_NAME.to_string(),
+            sender_id: "altai-cli".to_string(),
+            chat_id: self.chat_id.clone(),
+            thread_id: None,
+            content,
+            attachments: self.attachments.clone(),
+            metadata: HashMap::new(),
+        };
+        self.observe(BusMessage::Inbound(inbound.clone()));
+        bus_tx
+            .send(BusMessage::Inbound(inbound))
+            .await
+            .map_err(|error| format!("failed to enqueue oneshot prompt: {error}"))?;
+        let _ = self.started.send(true);
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn send(&self, msg: OutboundMessage) -> Result<(), String> {
+        self.observe(BusMessage::Outbound(msg.clone()));
+
+        if msg
+            .metadata
+            .get(crate::clarification::METADATA_CLARIFICATION)
+            .and_then(|value| value.as_bool())
+            == Some(true)
+            || msg
+                .metadata
+                .get(crate::bus::METADATA_CLARIFICATION_TICKET_ID)
+                .is_some()
+        {
+            let detail = if let Some(edit) = msg.metadata.get("edit_diff") {
+                let file = edit
+                    .get("file")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("(unknown)");
+                let truncated = edit
+                    .get("truncated")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let diff = edit.get("diff").and_then(|v| v.as_str()).unwrap_or("");
+                let mut detail = format!("edit approval required for {file}");
+                if truncated {
+                    detail.push_str(" [diff truncated]");
+                }
+                if !diff.is_empty() {
+                    detail.push('\n');
+                    detail.push_str(diff);
+                } else if !msg.content.is_empty() {
+                    detail.push('\n');
+                    detail.push_str(&msg.content);
+                }
+                detail
+            } else {
+                msg.content.clone()
+            };
+
+            if tty_available() {
+                match self.resume_approval_on_tty(&detail).await {
+                    Ok(true) => return Ok(()),
+                    Ok(false) => {}
+                    Err(error) => {
+                        eprintln!("altai-cli: tty approval resume failed: {error}");
+                    }
+                }
+            }
+
+            if msg.metadata.get("edit_diff").is_some() {
+                self.complete(OneshotOutcome::ApprovalRequired { detail });
+            } else {
+                self.complete(OneshotOutcome::ClarificationRequired { detail });
+            }
+            return Ok(());
+        }
+
+        if msg
+            .metadata
+            .get("isanagent_notification")
+            .and_then(|value| value.as_bool())
+            == Some(true)
+        {
+            return Ok(());
+        }
+
+        {
+            let mut state = self.state.lock().expect("oneshot state");
+            state.final_text = Some(msg.content);
+        }
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_completed_run_outcome() {
+        assert_eq!(
+            OneshotOutcome::from_run_outcome(&RunOutcome::Completed),
+            OneshotOutcome::Completed
+        );
+        assert_eq!(
+            OneshotOutcome::from_run_outcome(&RunOutcome::Cancelled),
+            OneshotOutcome::Cancelled
+        );
+    }
+
+    #[test]
+    fn normalizes_hotkey_replies() {
+        assert_eq!(OneshotChannel::normalize_tty_reply("y\n"), "approve");
+        assert_eq!(OneshotChannel::normalize_tty_reply("3"), "always");
+        assert_eq!(OneshotChannel::normalize_tty_reply("deny"), "deny");
+    }
+}

--- a/src/channels/oneshot.rs
+++ b/src/channels/oneshot.rs
@@ -195,8 +195,7 @@ impl OneshotChannel {
                 chat_id,
                 run_id,
                 outcome,
-            }) if chat_id == &self.chat_id =>
-            {
+            }) if chat_id == &self.chat_id => {
                 {
                     let mut state = self.state.lock().expect("oneshot state");
                     state.run_id = Some(run_id.clone());
@@ -208,8 +207,7 @@ impl OneshotChannel {
                 decision,
                 command_preview,
                 ..
-            }) if chat_id == &self.chat_id && decision == "approval_requested" =>
-            {
+            }) if chat_id == &self.chat_id && decision == "approval_requested" => {
                 // When a controlling TTY is available, wait for the clarification
                 // outbound (handled in `send`) so the user can approve interactively.
                 if tty_available() {

--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -157,7 +157,7 @@ impl SlackRuntimeState {
         let auth_res = self
             .client
             .post(self.api_url("auth.test"))
-            .header("Authorization", format!("Bearer {}", bot_token))
+            .header("Authorization", format!("Bearer {bot_token}"))
             .send()
             .await;
 
@@ -171,7 +171,7 @@ impl SlackRuntimeState {
                             &self.logger_tx,
                             LogEvent::info(
                                 "SlackChannel",
-                                &format!("Slack bot connected as {}", uid),
+                                &format!("Slack bot connected as {uid}"),
                             ),
                         );
                         return Some(uid);
@@ -182,7 +182,7 @@ impl SlackRuntimeState {
                         &self.logger_tx,
                         LogEvent::warn(
                             "SlackChannel",
-                            &format!("Slack auth.test failed: {:?}", json),
+                            &format!("Slack auth.test failed: {json:?}"),
                         ),
                     );
                 }
@@ -191,7 +191,7 @@ impl SlackRuntimeState {
                         &self.logger_tx,
                         LogEvent::warn(
                             "SlackChannel",
-                            &format!("Failed to decode Slack auth.test response: {}", e),
+                            &format!("Failed to decode Slack auth.test response: {e}"),
                         ),
                     );
                 }
@@ -201,7 +201,7 @@ impl SlackRuntimeState {
                     &self.logger_tx,
                     LogEvent::warn(
                         "SlackChannel",
-                        &format!("Failed to request Slack auth.test: {}", e),
+                        &format!("Failed to request Slack auth.test: {e}"),
                     ),
                 );
             }
@@ -269,8 +269,7 @@ impl SlackRuntimeState {
             }
             Ok(None) => {}
             Err(e) => warn!(
-                "Failed to load cached Slack user profile for {}: {}",
-                user, e
+                "Failed to load cached Slack user profile for {user}: {e}"
             ),
         }
 
@@ -288,11 +287,11 @@ impl SlackRuntimeState {
     }
 
     async fn fetch_display_name_from_slack(&self, user: &str, bot_token: &str) -> Option<String> {
-        let info_url = self.api_url(&format!("users.info?user={}", user));
+        let info_url = self.api_url(&format!("users.info?user={user}"));
         let info_res = self
             .client
             .get(info_url)
-            .header("Authorization", format!("Bearer {}", bot_token))
+            .header("Authorization", format!("Bearer {bot_token}"))
             .send()
             .await;
 
@@ -302,9 +301,9 @@ impl SlackRuntimeState {
                     return slack_profile_display_name(&json);
                 }
                 Ok(_) => {}
-                Err(e) => warn!("Failed to decode Slack users.info response: {}", e),
+                Err(e) => warn!("Failed to decode Slack users.info response: {e}"),
             },
-            Err(e) => warn!("Failed to fetch Slack user profile for {}: {}", user, e),
+            Err(e) => warn!("Failed to fetch Slack user profile for {user}: {e}"),
         }
 
         None
@@ -325,7 +324,7 @@ impl SlackRuntimeState {
             )
             .await
         {
-            warn!("Failed to persist Slack user profile for {}: {}", user, e);
+            warn!("Failed to persist Slack user profile for {user}: {e}");
         }
     }
 
@@ -348,12 +347,12 @@ impl SlackRuntimeState {
         match self
             .client
             .get(url)
-            .header("Authorization", format!("Bearer {}", bot_token))
+            .header("Authorization", format!("Bearer {bot_token}"))
             .send()
             .await
         {
             Err(e) => {
-                warn!("Failed to download Slack file {}: {}", url, e);
+                warn!("Failed to download Slack file {url}: {e}");
                 None
             }
             Ok(response) => {
@@ -367,12 +366,12 @@ impl SlackRuntimeState {
                 }
                 match response.bytes().await {
                     Err(e) => {
-                        warn!("Failed to read Slack file bytes from {}: {}", url, e);
+                        warn!("Failed to read Slack file bytes from {url}: {e}");
                         None
                     }
                     Ok(bytes) => {
                         let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
-                        let data_uri = format!("data:{};base64,{}", mime, encoded);
+                        let data_uri = format!("data:{mime};base64,{encoded}");
                         Some(ContentPart::ImageUrl {
                             image_url: ImageUrl {
                                 url: data_uri,
@@ -431,7 +430,7 @@ impl SlackRuntimeState {
         let reaction = dispatch.reaction.clone();
         let chat_id = dispatch.inbound.chat_id.clone();
         if let Err(e) = bus_tx.send(BusMessage::Inbound(dispatch.inbound)).await {
-            warn!("Failed to route InboundMessage from Slack: {}", e);
+            warn!("Failed to route InboundMessage from Slack: {e}");
             return;
         }
 
@@ -458,7 +457,7 @@ impl SlackRuntimeState {
 
             match client
                 .post(api_url)
-                .header("Authorization", format!("Bearer {}", bot_token))
+                .header("Authorization", format!("Bearer {bot_token}"))
                 .json(&body)
                 .send()
                 .await
@@ -469,10 +468,10 @@ impl SlackRuntimeState {
                     if let Err(err) =
                         validate_simple_slack_api_response("Slack reaction", status, &body)
                     {
-                        warn!("{}", err);
+                        warn!("{err}");
                     }
                 }
-                Err(e) => warn!("Network error adding Slack emoji reaction: {}", e),
+                Err(e) => warn!("Network error adding Slack emoji reaction: {e}"),
             }
         });
     }
@@ -594,15 +593,15 @@ impl Channel for SlackChannel {
                 port,
                 path,
             } => {
-                let addr = format!("0.0.0.0:{}", port);
+                let addr = format!("0.0.0.0:{port}");
                 let listener = tokio::net::TcpListener::bind(&addr)
                     .await
-                    .map_err(|e| format!("Failed to bind Slack webhook port on {}: {}", addr, e))?;
+                    .map_err(|e| format!("Failed to bind Slack webhook port on {addr}: {e}"))?;
                 log_slack(
                     &self.shared.logger_tx,
                     LogEvent::info(
                         "SlackChannel",
-                        &format!("Slack webhook listening on http://{}{}", addr, path),
+                        &format!("Slack webhook listening on http://{addr}{path}"),
                     ),
                 );
 
@@ -624,7 +623,7 @@ impl Channel for SlackChannel {
                         }
                     });
                     if let Err(e) = server.await {
-                        error!("Slack webhook server crashed: {}", e);
+                        error!("Slack webhook server crashed: {e}");
                     }
                 });
                 self.store_task_handle(handle).await?;
@@ -662,7 +661,7 @@ impl Channel for SlackChannel {
             async move {
                 let response = client
                     .post(api_url)
-                    .header("Authorization", format!("Bearer {}", bot_token))
+                    .header("Authorization", format!("Bearer {bot_token}"))
                     .json(&body)
                     .send()
                     .await
@@ -735,8 +734,7 @@ where
             },
             Err(e) => {
                 error!(
-                    "Slack postMessage network error (attempt {}): {}",
-                    attempt, e
+                    "Slack postMessage network error (attempt {attempt}): {e}"
                 );
                 if attempt < max_retries {
                     tokio::time::sleep(backoff).await;
@@ -747,7 +745,7 @@ where
         }
     }
 
-    error!("Slack send failed after {} attempts.", max_retries);
+    error!("Slack send failed after {max_retries} attempts.");
     Err("Slack send max retries exceeded".to_string())
 }
 
@@ -783,12 +781,11 @@ fn classify_post_message_response(response: SlackHttpResponse) -> SlackSendDecis
             let err = api_response
                 .error
                 .unwrap_or_else(|| "unknown_error".to_string());
-            error!("Slack postMessage failed with ok=false: {}", err);
-            SlackSendDecision::Fatal(format!("Slack API returned ok=false: {}", err))
+            error!("Slack postMessage failed with ok=false: {err}");
+            SlackSendDecision::Fatal(format!("Slack API returned ok=false: {err}"))
         }
         Err(e) => SlackSendDecision::Fatal(format!(
-            "Failed to decode Slack postMessage response: {}",
-            e
+            "Failed to decode Slack postMessage response: {e}"
         )),
     }
 }
@@ -800,13 +797,12 @@ fn validate_simple_slack_api_response(
 ) -> Result<(), String> {
     if !status.is_success() {
         return Err(format!(
-            "{} failed with status {}: {}",
-            action, status, body
+            "{action} failed with status {status}: {body}"
         ));
     }
 
     let api_response = serde_json::from_str::<SlackApiResponse>(body)
-        .map_err(|e| format!("Failed to decode {} response: {}", action, e))?;
+        .map_err(|e| format!("Failed to decode {action} response: {e}"))?;
     if api_response.ok {
         return Ok(());
     }
@@ -839,14 +835,14 @@ async fn handle_slack_webhook(
         now,
         state.timestamp_tolerance_secs,
     ) {
-        warn!("Slack webhook signature verification failed: {}", err);
+        warn!("Slack webhook signature verification failed: {err}");
         return StatusCode::UNAUTHORIZED.into_response();
     }
 
     let payload: Value = match serde_json::from_slice(body.as_ref()) {
         Ok(payload) => payload,
         Err(e) => {
-            warn!("Failed to parse Slack webhook payload: {}", e);
+            warn!("Failed to parse Slack webhook payload: {e}");
             return StatusCode::BAD_REQUEST.into_response();
         }
     };
@@ -908,7 +904,7 @@ async fn run_socket_mode(
         let res = shared
             .client
             .post(shared.api_url("apps.connections.open"))
-            .header("Authorization", format!("Bearer {}", app_token))
+            .header("Authorization", format!("Bearer {app_token}"))
             .header("Content-type", "application/x-www-form-urlencoded")
             .send()
             .await;
@@ -923,7 +919,7 @@ async fn run_socket_mode(
                         &shared.logger_tx,
                         LogEvent::error(
                             "SlackChannel",
-                            &format!("Slack apps.connections.open failed: {:?}", json),
+                            &format!("Slack apps.connections.open failed: {json:?}"),
                         ),
                     );
                     if wait_for_shutdown_or_timeout(shutdown_rx, Duration::from_secs(backoff_secs))
@@ -939,7 +935,7 @@ async fn run_socket_mode(
                         &shared.logger_tx,
                         LogEvent::error(
                             "SlackChannel",
-                            &format!("Failed to parse Slack response: {}", e),
+                            &format!("Failed to parse Slack response: {e}"),
                         ),
                     );
                     if wait_for_shutdown_or_timeout(shutdown_rx, Duration::from_secs(backoff_secs))
@@ -956,7 +952,7 @@ async fn run_socket_mode(
                     &shared.logger_tx,
                     LogEvent::error(
                         "SlackChannel",
-                        &format!("Failed to request Slack websockets URL: {}", e),
+                        &format!("Failed to request Slack websockets URL: {e}"),
                     ),
                 );
                 if wait_for_shutdown_or_timeout(shutdown_rx, Duration::from_secs(backoff_secs))
@@ -983,7 +979,7 @@ async fn run_socket_mode(
                     &shared.logger_tx,
                     LogEvent::error(
                         "SlackChannel",
-                        &format!("WebSocket connection failed: {}", e),
+                        &format!("WebSocket connection failed: {e}"),
                     ),
                 );
                 if wait_for_shutdown_or_timeout(shutdown_rx, Duration::from_secs(backoff_secs))
@@ -1020,7 +1016,7 @@ async fn run_socket_mode(
             let msg = match msg {
                 Ok(m) => m,
                 Err(e) => {
-                    error!("Slack websocket read error: {}", e);
+                    error!("Slack websocket read error: {e}");
                     break;
                 }
             };
@@ -1033,7 +1029,7 @@ async fn run_socket_mode(
                 if let Some(envelope_id) = payload.get("envelope_id").and_then(Value::as_str) {
                     let ack = json!({ "envelope_id": envelope_id });
                     if let Err(e) = write.send(Message::Text(ack.to_string().into())).await {
-                        error!("Failed to ack Slack envelope: {}", e);
+                        error!("Failed to ack Slack envelope: {e}");
                     }
                 }
 
@@ -1054,8 +1050,7 @@ async fn run_socket_mode(
         }
 
         warn!(
-            "Slack Socket Mode disconnected. Reconnecting in {} seconds...",
-            backoff_secs
+            "Slack Socket Mode disconnected. Reconnecting in {backoff_secs} seconds..."
         );
         if wait_for_shutdown_or_timeout(shutdown_rx, Duration::from_secs(backoff_secs)).await {
             break;
@@ -1120,7 +1115,7 @@ fn normalize_slack_event(
     }
 
     let stripped_text = strip_bot_mention(&text, bot_user_id);
-    let payload_text = format!("(Slack User: {}) {}", display_name, stripped_text)
+    let payload_text = format!("(Slack User: {display_name}) {stripped_text}")
         .trim()
         .to_string();
 
@@ -1202,7 +1197,7 @@ fn strip_bot_mention(text: &str, bot_user_id: Option<&str>) -> String {
 fn normalize_webhook_path(path: Option<&str>) -> String {
     match path.map(str::trim).filter(|value| !value.is_empty()) {
         Some(path) if path.starts_with('/') => path.to_string(),
-        Some(path) => format!("/{}", path),
+        Some(path) => format!("/{path}"),
         None => DEFAULT_WEBHOOK_PATH.to_string(),
     }
 }
@@ -1244,7 +1239,7 @@ fn verify_slack_signature(
 
     let mut mac = HmacSha256::new_from_slice(signing_secret.as_bytes())
         .map_err(|_| "invalid_signing_secret")?;
-    mac.update(format!("v0:{}:", timestamp).as_bytes());
+    mac.update(format!("v0:{timestamp}:").as_bytes());
     mac.update(body);
     mac.verify_slice(&provided).map_err(|_| "invalid_signature")
 }

--- a/src/channels/slack_store.rs
+++ b/src/channels/slack_store.rs
@@ -34,25 +34,22 @@ struct SqliteSlackUserProfileStoreActor {
 impl SqliteSlackUserProfileStoreActor {
     fn new(db_path: impl AsRef<Path>) -> Result<Self, String> {
         let conn = Connection::open(db_path)
-            .map_err(|e| format!("Failed to open Slack user profile store: {}", e))?;
+            .map_err(|e| format!("Failed to open Slack user profile store: {e}"))?;
         conn.busy_timeout(Duration::from_secs(5)).map_err(|e| {
             format!(
-                "Failed to configure Slack user profile store busy timeout: {}",
-                e
+                "Failed to configure Slack user profile store busy timeout: {e}"
             )
         })?;
         conn.pragma_update(None, "journal_mode", "WAL")
             .map_err(|e| {
                 format!(
-                    "Failed to enable WAL mode for Slack user profile store: {}",
-                    e
+                    "Failed to enable WAL mode for Slack user profile store: {e}"
                 )
             })?;
         conn.pragma_update(None, "synchronous", "NORMAL")
             .map_err(|e| {
                 format!(
-                    "Failed to tune Slack user profile store synchronous mode: {}",
-                    e
+                    "Failed to tune Slack user profile store synchronous mode: {e}"
                 )
             })?;
         conn.execute(
@@ -63,7 +60,7 @@ impl SqliteSlackUserProfileStoreActor {
             )",
             [],
         )
-        .map_err(|e| format!("Failed to initialize slack_user_profiles table: {}", e))?;
+        .map_err(|e| format!("Failed to initialize slack_user_profiles table: {e}"))?;
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_slack_user_profiles_fetched_at
              ON slack_user_profiles(fetched_at_unix_secs)",
@@ -71,8 +68,7 @@ impl SqliteSlackUserProfileStoreActor {
         )
         .map_err(|e| {
             format!(
-                "Failed to initialize slack_user_profiles fetched_at index: {}",
-                e
+                "Failed to initialize slack_user_profiles fetched_at index: {e}"
             )
         })?;
 
@@ -106,7 +102,7 @@ impl ActorLogic<SlackUserStoreMessage> for SqliteSlackUserProfileStoreActor {
                             fetched_at_unix_secs = excluded.fetched_at_unix_secs",
                         params![user_id, stored.display_name, stored.fetched_at_unix_secs],
                     )
-                    .map_err(|e| format!("Failed to persist Slack user profile: {}", e))
+                    .map_err(|e| format!("Failed to persist Slack user profile: {e}"))
                     .map(|_| ());
                 let _ = reply.send(result);
             }
@@ -126,7 +122,7 @@ impl ActorLogic<SlackUserStoreMessage> for SqliteSlackUserProfileStoreActor {
                         },
                     )
                     .optional()
-                    .map_err(|e| format!("Failed to load Slack user profile: {}", e));
+                    .map_err(|e| format!("Failed to load Slack user profile: {e}"));
                 let _ = reply.send(result);
             }
         }
@@ -160,7 +156,7 @@ impl SlackUserProfileStore {
         self.node
             .send_packet(msg)
             .await
-            .map_err(|e| format!("Failed to send Slack user profile upsert request: {}", e))?;
+            .map_err(|e| format!("Failed to send Slack user profile upsert request: {e}"))?;
         rx.await
             .map_err(|_| "Slack user profile store actor channel closed".to_string())?
     }
@@ -177,7 +173,7 @@ impl SlackUserProfileStore {
         self.node
             .send_packet(msg)
             .await
-            .map_err(|e| format!("Failed to send Slack user profile get request: {}", e))?;
+            .map_err(|e| format!("Failed to send Slack user profile get request: {e}"))?;
         rx.await
             .map_err(|_| "Slack user profile store actor channel closed".to_string())?
     }

--- a/src/channels/terminal.rs
+++ b/src/channels/terminal.rs
@@ -679,16 +679,23 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
                 }
             });
             let sandbox_dir = self.sandbox_dir.clone();
+            let workspace_dir = self.workspace_dir.clone();
+            let mut providers = self.providers.clone();
             let memory_node = self.memory_node.clone();
             let channel_name_for_line = channel_name.clone();
             let mut pending_host_files = self.initial_files.clone();
             std::thread::spawn(move || {
                 use std::io::BufRead;
+                let mut active_provider_key =
+                    crate::channels::terminal_ui::resolve_initial_active_provider_key(
+                        &workspace_dir,
+                        &providers,
+                    );
                 println!(
                     "ALTAI line mode · {sandbox_label} · {status_model} · {status_permission} · session {session_short}"
                 );
                 println!(
-                    "Commands: /exit · /context · /compact [focus] · @file attachments. Color: {}",
+                    "Commands: /exit · /context · /compact [focus] · /key <api_key> · @file attachments. Color: {}",
                     if crate::channels::terminal_ui::uses_ansi_color() {
                         "on"
                     } else {
@@ -790,9 +797,118 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
                         if focus.is_empty() {
                             println!("[system] Compaction requested. It will run between turns.");
                         } else {
+                            println!("[system] Compaction requested with focus: \"{focus}\".");
+                        }
+                        print!("> ");
+                        let _ = std::io::Write::flush(&mut std::io::stdout());
+                        continue;
+                    }
+                    if trimmed.eq_ignore_ascii_case("/key")
+                        || trimmed.to_ascii_lowercase().starts_with("/key ")
+                    {
+                        let arg = trimmed.strip_prefix("/key").unwrap_or("").trim();
+                        if arg.is_empty() {
                             println!(
-                                "[system] Compaction requested with focus: \"{focus}\"."
+                                "[system] Usage: /key <api_key>  (or /key <provider_config_key> <api_key>)"
                             );
+                            print!("> ");
+                            let _ = std::io::Write::flush(&mut std::io::stdout());
+                            continue;
+                        }
+                        let mut parts = arg.splitn(2, char::is_whitespace);
+                        let first = parts.next().unwrap_or("").trim();
+                        let rest = parts.next().unwrap_or("").trim();
+                        let (config_key_arg, secret): (Option<&str>, &str) =
+                            if !rest.is_empty() && providers.contains_key(first) {
+                                (Some(first), rest)
+                            } else {
+                                (None, arg)
+                            };
+                        let resolved_config_key = config_key_arg
+                            .map(|s| s.to_string())
+                            .or_else(|| active_provider_key.clone())
+                            .or_else(|| {
+                                if providers.len() == 1 {
+                                    providers.keys().next().cloned()
+                                } else {
+                                    None
+                                }
+                            });
+                        let Some(resolved_config_key) = resolved_config_key else {
+                            let mut available: Vec<&str> =
+                                providers.keys().map(|s| s.as_str()).collect();
+                            available.sort_unstable();
+                            println!(
+                                "[system] Multiple providers configured; specify one: /key <provider_config_key> <api_key>. Available: {}. Or run /model first, then /key.",
+                                available.join(", ")
+                            );
+                            print!("> ");
+                            let _ = std::io::Write::flush(&mut std::io::stdout());
+                            continue;
+                        };
+                        if crate::channels::terminal_ui::key_looks_like_placeholder(secret) {
+                            println!(
+                                "[system] That doesn't look like a real API key. Usage: /key <api_key>"
+                            );
+                            print!("> ");
+                            let _ = std::io::Write::flush(&mut std::io::stdout());
+                            continue;
+                        }
+                        match providers.get_mut(&resolved_config_key) {
+                            None => {
+                                let mut available: Vec<&str> =
+                                    providers.keys().map(|s| s.as_str()).collect();
+                                available.sort_unstable();
+                                println!(
+                                    "[system] Unknown provider '{resolved_config_key}'. Available: {}.",
+                                    available.join(", ")
+                                );
+                            }
+                            Some(cfg) => {
+                                cfg.api_key = Some(secret.to_string());
+                                let provider_name = cfg.provider_name.clone();
+                                let model_name = cfg.model_name.clone();
+                                let resolved_url = cfg.resolved_base_url().unwrap_or_default();
+                                match cfg.resolve_api_key() {
+                                    Ok(resolved_key) => {
+                                        let masked =
+                                            crate::channels::terminal_ui::mask_api_key_suffix(
+                                                &resolved_key,
+                                            );
+                                        match crate::channels::terminal_ui::persist_provider_api_key(
+                                            &workspace_dir,
+                                            &resolved_config_key,
+                                            secret,
+                                        ) {
+                                            Ok(()) => println!(
+                                                "[system] API key updated for '{resolved_config_key}' (ends in {masked}) and saved to config.toml."
+                                            ),
+                                            Err(e) => println!(
+                                                "[system] API key updated for '{resolved_config_key}' (ends in {masked}) for this session, but could not persist to config.toml: {e}"
+                                            ),
+                                        }
+                                        if bus_tx
+                                            .blocking_send(BusMessage::SwitchModel {
+                                                provider_name,
+                                                model_name,
+                                                base_url: resolved_url,
+                                                api_key: resolved_key,
+                                            })
+                                            .is_err()
+                                        {
+                                            println!("[system] Bus closed; exiting.");
+                                            let _ = shutdown.send(());
+                                            break;
+                                        }
+                                        active_provider_key = Some(resolved_config_key);
+                                    }
+                                    Err(e) => {
+                                        println!(
+                                            "[system] Key was set, but could not resolve it for switching: {e}"
+                                        );
+                                    }
+                                }
+                            }
                         }
                         print!("> ");
                         let _ = std::io::Write::flush(&mut std::io::stdout());

--- a/src/channels/terminal.rs
+++ b/src/channels/terminal.rs
@@ -531,10 +531,14 @@ pub struct TerminalChannelConfig {
     pub workspace_dir: PathBuf,
     pub sandbox_dir: PathBuf,
     pub status_model: String,
+    /// Short permission label for the status bar (`ask`, `plan`, …).
+    pub status_permission: String,
     pub memory_node: NodeHandle<MemoryMessage>,
     pub providers: std::collections::HashMap<String, crate::config::ProviderConfig>,
     /// Whether the TUI should render ANSI foreground colors.
     pub color_enabled: bool,
+    /// Host-selected ALTAI theme (resolved with `color_enabled` / NO_COLOR).
+    pub theme: crate::channels::terminal_ui::HostThemeMode,
     /// Load the configured chat's persisted transcript before accepting input.
     pub resume_session: bool,
     /// File references composed into the first user message.
@@ -560,6 +564,7 @@ pub struct TerminalChannel {
     sandbox_dir: PathBuf,
     /// Provider model id for the status line (e.g. from config).
     status_model: String,
+    status_permission: String,
     /// Workspace memory actor (for past-session list + transcript load in the TUI thread).
     memory_node: NodeHandle<MemoryMessage>,
     /// Outbound messages for the Ratatui thread (set when `start` succeeds).
@@ -567,6 +572,7 @@ pub struct TerminalChannel {
     /// Named alternative providers for `/model` switching.
     providers: std::collections::HashMap<String, crate::config::ProviderConfig>,
     color_enabled: bool,
+    theme: crate::channels::terminal_ui::HostThemeMode,
     resume_session: bool,
     initial_files: Vec<PathBuf>,
     mode: TerminalMode,
@@ -581,10 +587,12 @@ impl TerminalChannel {
             workspace_dir: config.workspace_dir,
             sandbox_dir: config.sandbox_dir,
             status_model: config.status_model,
+            status_permission: config.status_permission,
             memory_node: config.memory_node,
             outbound_ui_tx: Arc::new(Mutex::new(None)),
             providers: config.providers,
             color_enabled: config.color_enabled,
+            theme: config.theme,
             resume_session: config.resume_session,
             initial_files: config.initial_files,
             mode: config.mode,
@@ -611,6 +619,7 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
 
         let channel_name = self.name().to_string();
         if self.mode == TerminalMode::Line {
+            crate::channels::terminal_ui::init_from_host(self.theme, !self.color_enabled);
             let (tx, rx) = std::sync::mpsc::channel::<OutboundMessage>();
             *self
                 .outbound_ui_tx
@@ -618,21 +627,198 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
                 .map_err(|_| "terminal outbound bridge poisoned".to_string())? = Some(tx);
             let chat_id = self.chat_id.clone();
             let shutdown = self.shutdown_tx.clone();
+            let status_model = self.status_model.clone();
+            let status_permission = self.status_permission.clone();
+            let sandbox_label = self
+                .sandbox_dir
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("workspace")
+                .to_string();
+            let session_short = truncate_leading_ellipsis(&chat_id, 13);
             std::thread::spawn(move || {
                 for message in rx {
-                    println!("{}", message.content);
+                    let is_clarification = message
+                        .metadata
+                        .get(crate::clarification::METADATA_CLARIFICATION)
+                        .and_then(|v| v.as_bool())
+                        == Some(true);
+                    let prefix = if is_clarification {
+                        "approval"
+                    } else if message
+                        .metadata
+                        .get(ISANAGENT_TOOL_NOTIFY)
+                        .and_then(|v| v.as_bool())
+                        == Some(true)
+                    {
+                        "tool"
+                    } else {
+                        "assistant"
+                    };
+                    println!("[{prefix}] {}", message.content);
+                    if let Some(edit) = message.metadata.get("edit_diff") {
+                        let file = edit
+                            .get("file")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("(unknown)");
+                        let truncated = edit
+                            .get("truncated")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        let badge = if truncated { " [truncated]" } else { "" };
+                        println!("[edit_diff] {file}{badge}");
+                        if let Some(diff) = edit.get("diff").and_then(|v| v.as_str()) {
+                            println!("{diff}");
+                        }
+                    }
+                    if is_clarification {
+                        println!(
+                            "[choices] 1=approve 2=deny 3=always 4=abort  (type the word or number)"
+                        );
+                    }
                 }
             });
+            let sandbox_dir = self.sandbox_dir.clone();
+            let memory_node = self.memory_node.clone();
+            let channel_name_for_line = channel_name.clone();
+            let mut pending_host_files = self.initial_files.clone();
             std::thread::spawn(move || {
                 use std::io::BufRead;
-                println!("ALTAI line mode. Type /exit to quit.");
+                println!(
+                    "ALTAI line mode · {sandbox_label} · {status_model} · {status_permission} · session {session_short}"
+                );
+                println!(
+                    "Commands: /exit · /context · /compact [focus] · @file attachments. Color: {}",
+                    if crate::channels::terminal_ui::uses_ansi_color() {
+                        "on"
+                    } else {
+                        "off (plain)"
+                    }
+                );
+                if !pending_host_files.is_empty() {
+                    let refs = pending_host_files
+                        .iter()
+                        .map(|path| format!("@{}", path.display()))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    println!(
+                        "Pending --file attachments ({refs}) will load with your first message."
+                    );
+                }
+                print!("> ");
+                let _ = std::io::Write::flush(&mut std::io::stdout());
+                let rt = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(error) => {
+                        eprintln!("line mode runtime failed: {error}");
+                        return;
+                    }
+                };
                 for line in std::io::stdin().lock().lines() {
                     let Ok(content) = line else { break };
-                    if matches!(content.trim(), "/exit" | "/quit") {
+                    let trimmed = content.trim();
+                    if matches!(trimmed, "/exit" | "/quit") {
                         let _ = shutdown.send(());
                         break;
                     }
-                    if content.trim().is_empty() {
+                    if trimmed.is_empty() {
+                        print!("> ");
+                        let _ = std::io::Write::flush(&mut std::io::stdout());
+                        continue;
+                    }
+                    if trimmed.eq_ignore_ascii_case("/context") {
+                        let session_key = crate::bus::clarification_session_key(
+                            &channel_name_for_line,
+                            &chat_id,
+                            None,
+                        );
+                        let messages = rt.block_on(async {
+                            let (tx, rx) = tokio::sync::oneshot::channel();
+                            let _ = memory_node
+                                .send_packet(crate::memory::MemoryMessage::GetContext {
+                                    thread_id: session_key.clone(),
+                                    reply: crate::memory::SharedReply::new(tx),
+                                })
+                                .await;
+                            rx.await.ok().and_then(|r| r.ok()).unwrap_or_default()
+                        });
+                        let user_turns = messages.iter().filter(|m| m.role == "user").count();
+                        let approx_tokens: usize = messages
+                            .iter()
+                            .map(|m| m.content.as_ref().map_or(0, |c| c.text_content().len()) / 4)
+                            .sum();
+                        println!(
+                            "[context] {} message(s) · {} user turn(s) · ~{} tokens (rough estimate). Use /compact to force compaction.",
+                            messages.len(),
+                            user_turns,
+                            approx_tokens
+                        );
+                        print!("> ");
+                        let _ = std::io::Write::flush(&mut std::io::stdout());
+                        continue;
+                    }
+                    if trimmed.eq_ignore_ascii_case("/compact")
+                        || trimmed.to_ascii_lowercase().starts_with("/compact ")
+                    {
+                        let focus = trimmed
+                            .strip_prefix("/compact")
+                            .or_else(|| trimmed.strip_prefix("/COMPACT"))
+                            .unwrap_or("")
+                            .trim()
+                            .to_string();
+                        let session_key = crate::bus::clarification_session_key(
+                            &channel_name_for_line,
+                            &chat_id,
+                            None,
+                        );
+                        let msg = BusMessage::TriggerCompaction {
+                            session_key,
+                            focus_instructions: if focus.is_empty() {
+                                None
+                            } else {
+                                Some(focus.clone())
+                            },
+                            trigger: Some(crate::bus::CompactionTrigger::Manual),
+                        };
+                        if bus_tx.blocking_send(msg).is_err() {
+                            println!("[system] Bus closed; cannot trigger compaction.");
+                            break;
+                        }
+                        if focus.is_empty() {
+                            println!("[system] Compaction requested. It will run between turns.");
+                        } else {
+                            println!(
+                                "[system] Compaction requested with focus: \"{focus}\"."
+                            );
+                        }
+                        print!("> ");
+                        let _ = std::io::Write::flush(&mut std::io::stdout());
+                        continue;
+                    }
+
+                    let (clean_text, mut attachments) =
+                        crate::channels::terminal_ui::parse_terminal_attachments(
+                            &content,
+                            &sandbox_dir,
+                        );
+                    if !pending_host_files.is_empty() {
+                        let (host_parts, warnings) =
+                            crate::channels::terminal_ui::load_host_file_attachments(
+                                &sandbox_dir,
+                                &pending_host_files,
+                            );
+                        for warning in warnings {
+                            eprintln!("Warning: {warning}");
+                        }
+                        attachments.extend(host_parts);
+                        pending_host_files.clear();
+                    }
+                    if clean_text.trim().is_empty() && attachments.is_empty() {
+                        print!("> ");
+                        let _ = std::io::Write::flush(&mut std::io::stdout());
                         continue;
                     }
                     if bus_tx
@@ -641,14 +827,20 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
                             sender_id: "local_user".into(),
                             chat_id: chat_id.clone(),
                             thread_id: None,
-                            content,
-                            attachments: Vec::new(),
+                            content: if clean_text.is_empty() {
+                                "(attached files)".into()
+                            } else {
+                                clean_text
+                            },
+                            attachments,
                             metadata: Default::default(),
                         }))
                         .is_err()
                     {
                         break;
                     }
+                    print!("> ");
+                    let _ = std::io::Write::flush(&mut std::io::stdout());
                 }
             });
             return Ok(());
@@ -681,12 +873,14 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
         let log_clone = logger_tx.clone();
         let memory_node_clone = self.memory_node.clone();
         let color_enabled = self.color_enabled;
+        let theme = self.theme;
         let resume_session = self.resume_session;
         let initial_files = self.initial_files.clone();
+        let status_permission = self.status_permission.clone();
 
         let opening_banner = format!(
             "ALTAI isanagent v{} — thread {}\n\
-             Commands: /exit, /new  ·  Images: @path/to/file inside the workspace.",
+             Commands: /exit, /new, /context, /compact  ·  Attachments: @path (text/image/PDF) inside the workspace.",
             env!("CARGO_PKG_VERSION"),
             truncate_leading_ellipsis(&chat_id_clone, 13)
         );
@@ -705,9 +899,11 @@ For headless or piped runs, set [terminal] enabled = false in config.toml (requi
                         channel_name,
                         opening_banner,
                         status_model,
+                        status_permission,
                         memory_node: memory_node_clone,
                         providers: providers_clone,
                         color_enabled,
+                        theme,
                         resume_session,
                         initial_files,
                     },

--- a/src/channels/terminal_ui/app.rs
+++ b/src/channels/terminal_ui/app.rs
@@ -238,6 +238,8 @@ pub enum Cell {
         text: String,
         /// From `ask_user` when provided; shown as a numbered list in the terminal.
         choices: Vec<String>,
+        /// Optional unified-diff payload for file-edit approvals.
+        edit_diff: Option<crate::channels::terminal_ui::EditDiffPayload>,
     },
     System {
         message: String,
@@ -387,6 +389,14 @@ pub struct App {
     pub model_selector: Option<ModelSelector>,
     /// Active model name displayed in the status bar (updated on `/model` switch).
     pub status_model: String,
+    /// Workspace label (usually sandbox basename) for the dense status header.
+    pub status_workspace: String,
+    /// Permission mode label (`ask`, `plan`, …).
+    pub status_permission: String,
+    /// Short session / chat id for the status header.
+    pub status_session: String,
+    /// Blocking approval overlay (shell / edit) awaiting a four-way reply.
+    pub pending_approval: bool,
 }
 
 impl Default for App {
@@ -485,6 +495,10 @@ impl App {
             crons_count: 0,
             model_selector: None,
             status_model: String::new(),
+            status_workspace: String::new(),
+            status_permission: String::new(),
+            status_session: String::new(),
+            pending_approval: false,
         }
     }
 
@@ -519,7 +533,17 @@ impl App {
         self.scroll_offset == 0
     }
 
+    fn reduce_motion_enabled() -> bool {
+        matches!(
+            std::env::var("ALTAI_TUI_REDUCE_MOTION").as_deref(),
+            Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes") | Ok("on")
+        )
+    }
+
     pub fn get_spinner_frame(&self) -> char {
+        if Self::reduce_motion_enabled() {
+            return '●';
+        }
         const FRAMES: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
         FRAMES[self.spinner_tick % FRAMES.len()]
     }

--- a/src/channels/terminal_ui/approval.rs
+++ b/src/channels/terminal_ui/approval.rs
@@ -1,0 +1,116 @@
+//! Approval / edit-diff helpers for the Ratatui terminal UI.
+
+use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
+
+use super::theme::Theme;
+
+/// Workspace-relative edit preview carried on clarification metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditDiffPayload {
+    pub file: String,
+    pub diff: String,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffLineKind {
+    Add,
+    Del,
+    Hunk,
+    Meta,
+    Context,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffLine {
+    pub kind: DiffLineKind,
+    pub gutter: &'static str,
+    pub text: String,
+}
+
+/// Parse unified-diff text into styled line descriptors (mirrors desktop EditApprovalCard).
+pub fn parse_diff_lines(diff: &str) -> Vec<DiffLine> {
+    diff.lines()
+        .map(|raw| {
+            let (kind, gutter, text) = if raw.starts_with("+++") || raw.starts_with("---") {
+                (DiffLineKind::Meta, " ", raw.to_string())
+            } else if raw.starts_with("@@") {
+                (DiffLineKind::Hunk, " ", raw.to_string())
+            } else if let Some(rest) = raw.strip_prefix('+') {
+                (DiffLineKind::Add, "+", rest.to_string())
+            } else if let Some(rest) = raw.strip_prefix('-') {
+                (DiffLineKind::Del, "-", rest.to_string())
+            } else if let Some(rest) = raw.strip_prefix(' ') {
+                (DiffLineKind::Context, " ", rest.to_string())
+            } else {
+                (DiffLineKind::Context, " ", raw.to_string())
+            };
+            DiffLine { kind, gutter, text }
+        })
+        .collect()
+}
+
+pub fn diff_lines_to_spans(diff: &str, max_lines: usize) -> Vec<Line<'static>> {
+    let parsed = parse_diff_lines(diff);
+    let truncated_input = parsed.len() > max_lines;
+    let mut out = Vec::new();
+    for line in parsed.into_iter().take(max_lines) {
+        let style = match line.kind {
+            DiffLineKind::Add => Theme::tool_done(),
+            DiffLineKind::Del => Theme::error(),
+            DiffLineKind::Hunk => Theme::clarification(),
+            DiffLineKind::Meta => Theme::dim(),
+            DiffLineKind::Context => Theme::text(),
+        };
+        out.push(Line::from(vec![
+            Span::styled(line.gutter.to_string(), Theme::dim()),
+            Span::styled(line.text, style),
+        ]));
+    }
+    if truncated_input {
+        out.push(Line::from(Span::styled(
+            "… [diff truncated for display]",
+            Theme::dim().add_modifier(Modifier::ITALIC),
+        )));
+    }
+    out
+}
+
+/// Four canonical approval choices shown in overlays / line mode.
+pub const APPROVAL_CHOICES: &[&str] = &["approve", "deny", "always", "abort"];
+
+/// Map a hotkey / digit to a canonical approval reply.
+pub fn approval_hotkey_reply(ch: char) -> Option<&'static str> {
+    match ch {
+        'y' | 'Y' | '1' => Some("approve"),
+        'n' | 'N' | '2' => Some("deny"),
+        'a' | 'A' | '3' => Some("always"),
+        'x' | 'X' | '4' | '\u{1b}' => Some("abort"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_unified_diff_kinds() {
+        let lines = parse_diff_lines(
+            "--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new\n context\n",
+        );
+        assert_eq!(lines[0].kind, DiffLineKind::Meta);
+        assert_eq!(lines[2].kind, DiffLineKind::Hunk);
+        assert_eq!(lines[3].kind, DiffLineKind::Del);
+        assert_eq!(lines[4].kind, DiffLineKind::Add);
+        assert_eq!(lines[5].kind, DiffLineKind::Context);
+    }
+
+    #[test]
+    fn hotkeys_map_four_way_choices() {
+        assert_eq!(approval_hotkey_reply('y'), Some("approve"));
+        assert_eq!(approval_hotkey_reply('3'), Some("always"));
+        assert_eq!(approval_hotkey_reply('x'), Some("abort"));
+    }
+}

--- a/src/channels/terminal_ui/approval.rs
+++ b/src/channels/terminal_ui/approval.rs
@@ -97,9 +97,7 @@ mod tests {
 
     #[test]
     fn parses_unified_diff_kinds() {
-        let lines = parse_diff_lines(
-            "--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new\n context\n",
-        );
+        let lines = parse_diff_lines("--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new\n context\n");
         assert_eq!(lines[0].kind, DiffLineKind::Meta);
         assert_eq!(lines[2].kind, DiffLineKind::Hunk);
         assert_eq!(lines[3].kind, DiffLineKind::Del);

--- a/src/channels/terminal_ui/attachments.rs
+++ b/src/channels/terminal_ui/attachments.rs
@@ -1,7 +1,8 @@
-//! `@path` image attachment parsing for terminal input (Ratatui compose line).
+//! `@path` attachment parsing for terminal input (Ratatui compose + line mode).
 
-use crate::utils::{resolve_path, ContentPart, ImageUrl};
+use crate::utils::{resolve_path, ContentPart, Document, ImageUrl};
 use base64::Engine as _;
+use std::path::{Path, PathBuf};
 
 /// Detects the MIME type of an image file from its extension.
 pub(crate) fn image_mime_from_extension(path: &std::path::Path) -> Option<&'static str> {
@@ -19,21 +20,187 @@ pub(crate) fn image_mime_from_extension(path: &std::path::Path) -> Option<&'stat
     }
 }
 
+fn is_probably_text_extension(path: &Path) -> bool {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_lowercase())
+        .as_deref()
+    {
+        None => true, // extensionless (Dockerfile, Makefile, LICENSE, …)
+        Some(ext) => matches!(
+            ext,
+            "rs" | "ts" | "tsx" | "js" | "jsx" | "json" | "toml" | "yaml" | "yml"
+                | "md" | "txt" | "css" | "html" | "py" | "go" | "java" | "kt"
+                | "swift" | "c" | "h" | "cpp" | "hpp" | "cs" | "rb" | "php"
+                | "sh" | "bash" | "zsh" | "sql" | "graphql" | "xml" | "svg"
+                | "env" | "ini" | "cfg" | "conf" | "lock" | "gitignore"
+                | "dockerfile" | "makefile" | "cmake" | "gradle" | "properties"
+        ),
+    }
+}
+
+fn is_pdf(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("pdf"))
+}
+
+const MAX_TEXT_ATTACH_CHARS: usize = 200_000;
+
+/// Load a sandbox-scoped file into a multimodal content part.
+pub fn load_sandbox_file_attachment(
+    sandbox_dir: &Path,
+    path: &Path,
+) -> Result<ContentPart, String> {
+    let expanded = shellexpand::tilde(&path.display().to_string()).into_owned();
+    let resolved = resolve_path(sandbox_dir, &expanded)
+        .or_else(|| fuzzy_resolve_in_sandbox(sandbox_dir, &expanded))
+        .ok_or_else(|| {
+            format!(
+                "could not resolve attachment path inside workspace: {}",
+                path.display()
+            )
+        })?;
+
+    if let Some(mime) = image_mime_from_extension(&resolved) {
+        let bytes = std::fs::read(&resolved)
+            .map_err(|error| format!("could not read {}: {error}", resolved.display()))?;
+        let engine = base64::engine::general_purpose::STANDARD;
+        let data_uri = format!("data:{mime};base64,{}", engine.encode(&bytes));
+        return Ok(ContentPart::ImageUrl {
+            image_url: ImageUrl {
+                url: data_uri,
+                detail: None,
+            },
+        });
+    }
+
+    if is_pdf(&resolved) {
+        let bytes = std::fs::read(&resolved)
+            .map_err(|error| format!("could not read {}: {error}", resolved.display()))?;
+        let engine = base64::engine::general_purpose::STANDARD;
+        let name = resolved
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(str::to_string);
+        return Ok(ContentPart::Document {
+            document: Document {
+                data: engine.encode(&bytes),
+                media_type: "application/pdf".into(),
+                name,
+            },
+        });
+    }
+
+    if !is_probably_text_extension(&resolved) {
+        return Err(format!(
+            "unsupported attachment type for {}: use text, image, or PDF",
+            resolved.display()
+        ));
+    }
+
+    let mut text = std::fs::read_to_string(&resolved)
+        .map_err(|error| format!("could not read {}: {error}", resolved.display()))?;
+    let truncated = text.chars().count() > MAX_TEXT_ATTACH_CHARS;
+    if truncated {
+        text = text.chars().take(MAX_TEXT_ATTACH_CHARS).collect();
+        text.push_str("\n… [truncated]");
+    }
+    let sandbox_canon = std::fs::canonicalize(sandbox_dir).unwrap_or_else(|_| sandbox_dir.to_path_buf());
+    let resolved_canon = std::fs::canonicalize(&resolved).unwrap_or(resolved.clone());
+    let rel = resolved_canon
+        .strip_prefix(&sandbox_canon)
+        .unwrap_or(resolved_canon.as_path());
+    let label = rel.display();
+    let body = format!("<context-file path=\"{label}\">\n{text}\n</context-file>");
+    Ok(ContentPart::Text { text: body })
+}
+
+/// Load many host `--file` paths into attachments; returns warnings for failures.
+pub fn load_host_file_attachments(
+    sandbox_dir: &Path,
+    files: &[PathBuf],
+) -> (Vec<ContentPart>, Vec<String>) {
+    let mut attachments = Vec::new();
+    let mut warnings = Vec::new();
+    for path in files {
+        match load_sandbox_file_attachment(sandbox_dir, path) {
+            Ok(part) => attachments.push(part),
+            Err(error) => warnings.push(error),
+        }
+    }
+    (attachments, warnings)
+}
+
+/// Fuzzy-resolve a partial path / basename under the sandbox (depth-limited walk).
+pub fn fuzzy_resolve_in_sandbox(sandbox_dir: &Path, query: &str) -> Option<PathBuf> {
+    let query = query.trim().trim_start_matches("./");
+    if query.is_empty() {
+        return None;
+    }
+    let query_lower = query.to_ascii_lowercase();
+    let mut matches: Vec<PathBuf> = Vec::new();
+    let mut stack = vec![(sandbox_dir.to_path_buf(), 0u32)];
+    while let Some((dir, depth)) = stack.pop() {
+        if depth > 6 || matches.len() >= 32 {
+            break;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().to_ascii_lowercase();
+            if name == ".git" || name == "node_modules" || name == "target" || name == ".isanagent"
+            {
+                continue;
+            }
+            if path.is_dir() {
+                stack.push((path, depth + 1));
+                continue;
+            }
+            let rel = path
+                .strip_prefix(sandbox_dir)
+                .unwrap_or(path.as_path())
+                .to_string_lossy()
+                .to_ascii_lowercase();
+            if name == query_lower
+                || rel == query_lower
+                || rel.ends_with(&format!("/{query_lower}"))
+                || rel.contains(&query_lower)
+            {
+                matches.push(path);
+            }
+        }
+    }
+    if matches.len() == 1 {
+        return matches.pop();
+    }
+    // Prefer exact basename match when multiple fuzzy hits.
+    let exact: Vec<_> = matches
+        .iter()
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.eq_ignore_ascii_case(query))
+        })
+        .cloned()
+        .collect();
+    if exact.len() == 1 {
+        return exact.into_iter().next();
+    }
+    None
+}
+
 /// Parses a terminal input string for `@<filepath>` references.
 ///
-/// Each `@<path>` token that resolves to a supported image file (png/jpeg/gif/webp)
-/// inside the sandbox is consumed: removed from the returned text, base64-encoded,
-/// and returned as a `ContentPart::ImageUrl` attachment using a data URI.
-///
-/// `@<token>` references that do NOT resolve to an image (missing files, non-image
-/// extensions, outside sandbox) are preserved in the text so they can serve as
-/// agent mentions or other syntax.
-pub(crate) fn parse_terminal_attachments(
+/// Supported attachments: images, PDFs, and common text source files.
+/// Unresolvable `@token`s are preserved as literal text (agent mentions).
+pub fn parse_terminal_attachments(
     input: &str,
     sandbox_dir: &std::path::Path,
 ) -> (String, Vec<ContentPart>) {
-    let engine = base64::engine::general_purpose::STANDARD;
-
     let mut clean_parts: Vec<&str> = Vec::new();
     let mut attachments: Vec<ContentPart> = Vec::new();
     let mut last_end = 0;
@@ -51,41 +218,18 @@ pub(crate) fn parse_terminal_attachments(
             let raw_path = &input[path_start..path_end];
             let expanded = shellexpand::tilde(raw_path).into_owned();
 
-            let expanded_path = std::path::Path::new(&expanded);
-            let path_exists = expanded_path.exists() || sandbox_dir.join(expanded_path).exists();
-
-            // Only strip @token from text when it resolves to a supported image file.
-            // Unresolvable tokens (missing files, non-image types, outside sandbox) are
-            // preserved as regular text so that @agent mentions and similar syntax survive.
             let mut consumed = false;
-            match resolve_path(sandbox_dir, &expanded) {
-                None if path_exists => {
-                    eprintln!("Warning: @<path> is outside the sandbox boundary, skipping.");
+            match load_sandbox_file_attachment(sandbox_dir, Path::new(&expanded)) {
+                Ok(part) => {
+                    attachments.push(part);
+                    consumed = true;
                 }
-                None => {
-                    // File doesn't exist — leave @token as text (may be an agent mention).
-                }
-                Some(file_path) => match image_mime_from_extension(&file_path) {
-                    None => {
-                        // Not a supported image type — leave @token as text.
+                Err(error) => {
+                    // Keep @token when it looks like an agent mention (no slash / no extension).
+                    if expanded.contains('/') || expanded.contains('.') {
+                        eprintln!("Warning: {error}");
                     }
-                    Some(mime) => match std::fs::read(&file_path) {
-                        Err(_) => {
-                            eprintln!("Warning: could not read @<path>, skipping.");
-                        }
-                        Ok(file_bytes) => {
-                            let data_uri =
-                                format!("data:{};base64,{}", mime, engine.encode(&file_bytes));
-                            attachments.push(ContentPart::ImageUrl {
-                                image_url: ImageUrl {
-                                    url: data_uri,
-                                    detail: None,
-                                },
-                            });
-                            consumed = true;
-                        }
-                    },
-                },
+                }
             }
 
             if consumed {
@@ -108,7 +252,8 @@ pub(crate) fn parse_terminal_attachments(
 
 #[cfg(test)]
 mod tests {
-    use super::parse_terminal_attachments;
+    use super::*;
+    use std::fs;
 
     #[test]
     fn no_at_references_returns_text_unchanged() {
@@ -119,94 +264,37 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_extension_is_skipped() {
-        let sandbox = std::env::temp_dir();
-        let path = sandbox.join("isanagent_test_skip.txt");
-        std::fs::write(&path, b"hello").ok();
-        let input = format!("show @{} please", path.display());
-        let (text, attachments) = parse_terminal_attachments(&input, &sandbox);
-        assert!(
-            text.contains('@'),
-            "non-image @reference must stay in text (may be an agent mention)"
-        );
-        assert!(attachments.is_empty(), "non-image files must be skipped");
-        let _ = std::fs::remove_file(&path);
-    }
-
-    #[test]
-    fn missing_file_is_skipped() {
-        let sandbox = std::env::temp_dir();
-        let path = sandbox.join("isanagent_nonexistent_image.png");
-        let _ = std::fs::remove_file(&path);
-        let input = format!("see @{} thanks", path.display());
-        let (text, attachments) = parse_terminal_attachments(&input, &sandbox);
-        assert!(
-            text.contains('@'),
-            "unresolved @reference must stay in text (may be an agent mention)"
-        );
-        assert!(
-            attachments.is_empty(),
-            "missing file must be skipped gracefully"
-        );
-    }
-
-    #[test]
-    fn path_outside_sandbox_is_rejected() {
-        use std::io::Write as _;
-        let tmp = std::env::temp_dir();
-        let sandbox = tmp.join("isanagent_sandbox_test");
-        std::fs::create_dir_all(&sandbox).expect("create sandbox");
-
-        let outside = tmp.join("isanagent_outside_test.png");
-        let png_bytes: &[u8] = &[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
-        let mut f = std::fs::File::create(&outside).expect("create outside png");
-        f.write_all(png_bytes).expect("write png");
-        drop(f);
-
-        let input = format!("describe @{} please", outside.display());
-        let (_text, attachments) = parse_terminal_attachments(&input, &sandbox);
-        assert!(
-            attachments.is_empty(),
-            "file outside sandbox must be rejected"
-        );
-
-        let _ = std::fs::remove_file(&outside);
-        let _ = std::fs::remove_dir_all(&sandbox);
-    }
-
-    #[test]
-    fn existing_image_is_attached_as_data_uri() {
-        use std::io::Write;
-        let sandbox = std::env::temp_dir().join("isanagent_sandbox_image_test");
-        std::fs::create_dir_all(&sandbox).expect("create sandbox");
-        let tmp = sandbox.join("isanagent_terminal_test.png");
-        let png_bytes: &[u8] = &[
-            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48,
-            0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00,
-            0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08,
-            0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21, 0xbc,
-            0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
-        ];
-        let mut f = std::fs::File::create(&tmp).expect("create temp png");
-        f.write_all(png_bytes).expect("write png");
-        drop(f);
-
-        let input = format!("describe this image @{} please", tmp.display());
-        let (text, attachments) = parse_terminal_attachments(&input, &sandbox);
-
-        assert!(!text.contains('@'));
-        assert_eq!(attachments.len(), 1, "should have one image attachment");
-
-        if let crate::utils::ContentPart::ImageUrl { image_url } = &attachments[0] {
-            assert!(
-                image_url.url.starts_with("data:image/png;base64,"),
-                "expected a PNG data URI, got: {}",
-                &image_url.url[..40.min(image_url.url.len())]
-            );
-        } else {
-            panic!("expected ContentPart::ImageUrl");
+    fn loads_text_file_as_context_part() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("note.md");
+        fs::write(&path, "# hello\n").expect("write");
+        let part = load_sandbox_file_attachment(dir.path(), Path::new("note.md")).expect("load");
+        match part {
+            ContentPart::Text { text } => {
+                assert!(text.contains("path=\"note.md\""));
+                assert!(text.contains("# hello"));
+            }
+            other => panic!("expected text part, got {other:?}"),
         }
+    }
 
-        let _ = std::fs::remove_dir_all(&sandbox);
+    #[test]
+    fn fuzzy_resolves_unique_basename() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let nested = dir.path().join("src");
+        fs::create_dir_all(&nested).expect("mkdir");
+        fs::write(nested.join("unique_m4_file.rs"), "fn main() {}\n").expect("write");
+        let found = fuzzy_resolve_in_sandbox(dir.path(), "unique_m4_file.rs").expect("fuzzy");
+        assert!(found.ends_with("unique_m4_file.rs"));
+    }
+
+    #[test]
+    fn at_text_reference_is_consumed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("README.md"), "docs\n").expect("write");
+        let (text, attachments) =
+            parse_terminal_attachments("summarize @README.md please", dir.path());
+        assert_eq!(text, "summarize  please");
+        assert_eq!(attachments.len(), 1);
     }
 }

--- a/src/channels/terminal_ui/attachments.rs
+++ b/src/channels/terminal_ui/attachments.rs
@@ -30,12 +30,48 @@ fn is_probably_text_extension(path: &Path) -> bool {
         None => true, // extensionless (Dockerfile, Makefile, LICENSE, …)
         Some(ext) => matches!(
             ext,
-            "rs" | "ts" | "tsx" | "js" | "jsx" | "json" | "toml" | "yaml" | "yml"
-                | "md" | "txt" | "css" | "html" | "py" | "go" | "java" | "kt"
-                | "swift" | "c" | "h" | "cpp" | "hpp" | "cs" | "rb" | "php"
-                | "sh" | "bash" | "zsh" | "sql" | "graphql" | "xml" | "svg"
-                | "env" | "ini" | "cfg" | "conf" | "lock" | "gitignore"
-                | "dockerfile" | "makefile" | "cmake" | "gradle" | "properties"
+            "rs" | "ts"
+                | "tsx"
+                | "js"
+                | "jsx"
+                | "json"
+                | "toml"
+                | "yaml"
+                | "yml"
+                | "md"
+                | "txt"
+                | "css"
+                | "html"
+                | "py"
+                | "go"
+                | "java"
+                | "kt"
+                | "swift"
+                | "c"
+                | "h"
+                | "cpp"
+                | "hpp"
+                | "cs"
+                | "rb"
+                | "php"
+                | "sh"
+                | "bash"
+                | "zsh"
+                | "sql"
+                | "graphql"
+                | "xml"
+                | "svg"
+                | "env"
+                | "ini"
+                | "cfg"
+                | "conf"
+                | "lock"
+                | "gitignore"
+                | "dockerfile"
+                | "makefile"
+                | "cmake"
+                | "gradle"
+                | "properties"
         ),
     }
 }
@@ -107,7 +143,8 @@ pub fn load_sandbox_file_attachment(
         text = text.chars().take(MAX_TEXT_ATTACH_CHARS).collect();
         text.push_str("\n… [truncated]");
     }
-    let sandbox_canon = std::fs::canonicalize(sandbox_dir).unwrap_or_else(|_| sandbox_dir.to_path_buf());
+    let sandbox_canon =
+        std::fs::canonicalize(sandbox_dir).unwrap_or_else(|_| sandbox_dir.to_path_buf());
     let resolved_canon = std::fs::canonicalize(&resolved).unwrap_or(resolved.clone());
     let rel = resolved_canon
         .strip_prefix(&sandbox_canon)

--- a/src/channels/terminal_ui/markdown.rs
+++ b/src/channels/terminal_ui/markdown.rs
@@ -108,11 +108,11 @@ pub fn assistant_markdown_lines(markdown: &str, width: usize) -> Vec<Line<'stati
             }
             Event::End(TagEnd::Link) => {
                 if let Some(url) = link_dest.take() {
-                    push_run(&mut runs, Theme::dim(), &format!(" ({})", url));
+                    push_run(&mut runs, Theme::dim(), &format!(" ({url})"));
                 }
             }
             Event::Start(Tag::Image { dest_url, .. }) => {
-                push_run(&mut runs, Theme::dim(), &format!(" [image: {}] ", dest_url));
+                push_run(&mut runs, Theme::dim(), &format!(" [image: {dest_url}] "));
             }
             Event::End(TagEnd::Image) => {}
             Event::Text(t) => {
@@ -174,7 +174,7 @@ pub fn assistant_markdown_lines(markdown: &str, width: usize) -> Vec<Line<'stati
                 push_run(&mut runs, Theme::assistant_bullet(), mark);
             }
             Event::FootnoteReference(l) => {
-                push_run(&mut runs, Theme::dim(), &format!(" [^{}] ", l));
+                push_run(&mut runs, Theme::dim(), &format!(" [^{l}] "));
             }
             Event::Start(Tag::Table(_) | Tag::TableHead | Tag::TableRow | Tag::TableCell) => {}
             Event::End(TagEnd::TableCell) => {
@@ -260,7 +260,7 @@ fn wrap_runs_to_lines(
                     first_word = false;
                     word.to_string()
                 } else {
-                    format!(" {}", word)
+                    format!(" {word}")
                 };
                 let tw = token.as_str().width();
                 if col + tw > width {

--- a/src/channels/terminal_ui/mod.rs
+++ b/src/channels/terminal_ui/mod.rs
@@ -30,7 +30,10 @@ pub use theme::{
     resolve_host_appearance, uses_ansi_color, HostThemeMode, Theme, ThemeAppearance,
 };
 
-pub(crate) use run::{run_ratatui_main, RatatuiMainConfig};
+pub(crate) use run::{
+    key_looks_like_placeholder, mask_api_key_suffix, persist_provider_api_key,
+    resolve_initial_active_provider_key, run_ratatui_main, RatatuiMainConfig,
+};
 
 use unicode_width::UnicodeWidthStr;
 

--- a/src/channels/terminal_ui/mod.rs
+++ b/src/channels/terminal_ui/mod.rs
@@ -4,6 +4,7 @@
 #![allow(dead_code, unused_imports)]
 
 mod app;
+pub(crate) mod approval;
 mod attachments;
 mod execution_browser;
 mod history_cells;
@@ -20,9 +21,15 @@ pub use app::{
     TerminalUiFocus, TerminalUiMode, ToastKind, ToolNoticePhase, ToolRailEntry,
     TranscriptSelection,
 };
-pub use theme::{init, init_from_env, uses_ansi_color, Theme};
+pub use approval::{approval_hotkey_reply, EditDiffPayload, APPROVAL_CHOICES};
+pub use attachments::{
+    load_host_file_attachments, load_sandbox_file_attachment, parse_terminal_attachments,
+};
+pub use theme::{
+    current_appearance, init, init_appearance, init_from_env, init_from_host,
+    resolve_host_appearance, uses_ansi_color, HostThemeMode, Theme, ThemeAppearance,
+};
 
-pub(crate) use attachments::parse_terminal_attachments;
 pub(crate) use run::{run_ratatui_main, RatatuiMainConfig};
 
 use unicode_width::UnicodeWidthStr;

--- a/src/channels/terminal_ui/panes/cell_render.rs
+++ b/src/channels/terminal_ui/panes/cell_render.rs
@@ -111,22 +111,55 @@ pub(crate) fn cell_block_lines(cell: &Cell, inner_width: usize) -> Vec<Line<'sta
             v.push(Line::from(""));
             v
         }
-        Cell::Clarification { text, choices } => {
+        Cell::Clarification {
+            text,
+            choices,
+            edit_diff,
+        } => {
             let inner = w.saturating_sub(2).max(8);
+            let title = if edit_diff.is_some() {
+                "edit approval"
+            } else {
+                "approval"
+            };
             let mut v = vec![Line::from(vec![
                 Span::styled(" ? ", Theme::clarification()),
-                Span::styled("question", Theme::clarification()),
+                Span::styled(title, Theme::clarification().add_modifier(Modifier::BOLD)),
             ])];
+            if let Some(diff) = edit_diff {
+                v.push(Line::from(vec![
+                    Span::styled(" file ", Theme::dim()),
+                    Span::styled(diff.file.clone(), Theme::active()),
+                ]));
+                if diff.truncated {
+                    v.push(Line::from(Span::styled(
+                        " [truncated]",
+                        Theme::tool_call(),
+                    )));
+                }
+                v.extend(crate::channels::terminal_ui::approval::diff_lines_to_spans(
+                    &diff.diff,
+                    40,
+                ));
+            }
             for ln in wrap_text(text, inner) {
                 v.push(Line::from(Span::styled(ln, Theme::clarification())));
             }
-            if !choices.is_empty() {
+            let shown_choices = if choices.is_empty() {
+                crate::channels::terminal_ui::APPROVAL_CHOICES
+                    .iter()
+                    .map(|s| (*s).to_string())
+                    .collect::<Vec<_>>()
+            } else {
+                choices.clone()
+            };
+            if !shown_choices.is_empty() {
                 v.push(Line::from(Span::styled(
-                    "Reply with a number (1–n) or the exact option text.",
+                    "1 approve · 2 deny · 3 always · 4 abort  (or type the option)",
                     Theme::dim(),
                 )));
                 let indent = "   ";
-                for (i, choice) in choices.iter().enumerate() {
+                for (i, choice) in shown_choices.iter().enumerate() {
                     let n = i + 1;
                     let head = format!("{n}. ");
                     let first = format!("{head}{choice}");

--- a/src/channels/terminal_ui/panes/cell_render.rs
+++ b/src/channels/terminal_ui/panes/cell_render.rs
@@ -132,14 +132,10 @@ pub(crate) fn cell_block_lines(cell: &Cell, inner_width: usize) -> Vec<Line<'sta
                     Span::styled(diff.file.clone(), Theme::active()),
                 ]));
                 if diff.truncated {
-                    v.push(Line::from(Span::styled(
-                        " [truncated]",
-                        Theme::tool_call(),
-                    )));
+                    v.push(Line::from(Span::styled(" [truncated]", Theme::tool_call())));
                 }
                 v.extend(crate::channels::terminal_ui::approval::diff_lines_to_spans(
-                    &diff.diff,
-                    40,
+                    &diff.diff, 40,
                 ));
             }
             for ln in wrap_text(text, inner) {

--- a/src/channels/terminal_ui/run.rs
+++ b/src/channels/terminal_ui/run.rs
@@ -92,14 +92,164 @@ fn persist_last_model(workspace_dir: &Path, config_key: &str) {
     let _ = std::fs::write(&path, config_key);
 }
 
+/// Resolve the initially "active" provider config key for `/key` when no explicit key is
+/// given: prefer the last model persisted to `.system_generated/last_model` (if it still names
+/// a known provider), else fall back to the sole configured provider when there is exactly one.
+/// Otherwise the caller must ask the user to `/key <provider_config_key> <secret>` or `/model`
+/// first.
+pub(crate) fn resolve_initial_active_provider_key(
+    workspace_dir: &Path,
+    providers: &std::collections::HashMap<String, crate::config::ProviderConfig>,
+) -> Option<String> {
+    let last_model_path = workspace_dir.join(LAST_MODEL_FILE);
+    if let Ok(saved) = std::fs::read_to_string(&last_model_path) {
+        let saved = saved.trim();
+        if !saved.is_empty() && providers.contains_key(saved) {
+            return Some(saved.to_string());
+        }
+    }
+    if providers.len() == 1 {
+        return providers.keys().next().cloned();
+    }
+    None
+}
+
+/// Lightweight placeholder check for interactively entered API keys. Mirrors
+/// `config::api_key_looks_like_placeholder` (kept private there) without depending on config
+/// internals: rejects empty values, angle-bracket templates (`<changethis>`), and common
+/// placeholder tokens.
+pub(crate) fn key_looks_like_placeholder(s: &str) -> bool {
+    let t = s.trim();
+    if t.is_empty() || t.starts_with('<') {
+        return true;
+    }
+    if !t.is_ascii() {
+        return true;
+    }
+    let lower = t.to_ascii_lowercase();
+    if lower == "changethis" {
+        return true;
+    }
+    [
+        "optional",
+        "placeholder",
+        "replace_me",
+        "replaceme",
+        "your_api_key",
+        "changeme",
+    ]
+    .iter()
+    .any(|pat| lower.contains(pat))
+}
+
+/// Never echo a full API key in toasts/cells: show only the trailing 4 characters, e.g. `…cd34`.
+pub(crate) fn mask_api_key_suffix(key: &str) -> String {
+    let trimmed = key.trim();
+    let n = trimmed.chars().count();
+    if n == 0 {
+        return "****".to_string();
+    }
+    let take = n.min(4);
+    let tail: String = trimmed.chars().skip(n - take).collect();
+    format!("…{tail}")
+}
+
+/// Best-effort merge of a live API key into workspace `config.toml`, preserving comments via
+/// `toml_edit::DocumentMut`. Tries, in order: an exact `[providers.<config_key>]` section
+/// (legacy per-model format), a family table whose `models = [...]` array contains
+/// `config_key` (the common family format, where `config_key` is a model name), the legacy
+/// singular `[provider]` block, and finally creates a fresh `[providers.<config_key>]` section.
+pub(crate) fn persist_provider_api_key(
+    workspace_dir: &Path,
+    config_key: &str,
+    api_key: &str,
+) -> Result<(), String> {
+    let config_path = workspace_dir.join("config.toml");
+    let raw = std::fs::read_to_string(&config_path)
+        .map_err(|e| format!("Could not read {}: {}", config_path.display(), e))?;
+    let mut doc: toml_edit::DocumentMut = raw
+        .parse()
+        .map_err(|e| format!("Could not parse config.toml: {e}"))?;
+
+    let providers_table_ref = doc.get("providers").and_then(toml_edit::Item::as_table);
+    let exact_match = providers_table_ref.is_some_and(|t| t.contains_key(config_key));
+    let family_match = if exact_match {
+        None
+    } else {
+        providers_table_ref.and_then(|providers| {
+            providers.iter().find_map(|(key, item)| {
+                let models = item.as_table()?.get("models")?.as_array()?;
+                models
+                    .iter()
+                    .any(|v| v.as_str() == Some(config_key))
+                    .then(|| key.to_string())
+            })
+        })
+    };
+    let has_legacy_provider = doc
+        .get("provider")
+        .and_then(toml_edit::Item::as_table)
+        .is_some();
+
+    let target_section: Option<String> = if exact_match {
+        Some(config_key.to_string())
+    } else {
+        family_match
+    };
+
+    if let Some(section_key) = target_section {
+        let providers_table = doc["providers"]
+            .as_table_mut()
+            .ok_or_else(|| "config.toml `providers` is not a table".to_string())?;
+        let entry = providers_table
+            .entry(&section_key)
+            .or_insert(toml_edit::Item::Table(toml_edit::Table::new()));
+        let entry_table = entry
+            .as_table_mut()
+            .ok_or_else(|| format!("[providers.{section_key}] is not a table in config.toml"))?;
+        entry_table["api_key"] = toml_edit::value(api_key);
+    } else if has_legacy_provider {
+        let provider_table = doc["provider"]
+            .as_table_mut()
+            .ok_or_else(|| "config.toml `provider` is not a table".to_string())?;
+        provider_table["api_key"] = toml_edit::value(api_key);
+    } else {
+        if doc
+            .get("providers")
+            .and_then(toml_edit::Item::as_table)
+            .is_none()
+        {
+            let mut fresh = toml_edit::Table::new();
+            fresh.set_implicit(true);
+            doc["providers"] = toml_edit::Item::Table(fresh);
+        }
+        let providers_table = doc["providers"]
+            .as_table_mut()
+            .ok_or_else(|| "config.toml `providers` is not a table".to_string())?;
+        let entry = providers_table
+            .entry(config_key)
+            .or_insert(toml_edit::Item::Table(toml_edit::Table::new()));
+        let entry_table = entry
+            .as_table_mut()
+            .ok_or_else(|| format!("[providers.{config_key}] is not a table in config.toml"))?;
+        entry_table["api_key"] = toml_edit::value(api_key);
+    }
+
+    std::fs::write(&config_path, doc.to_string())
+        .map_err(|e| format!("Could not write {}: {}", config_path.display(), e))
+}
+
 /// Shared helper: resolve a provider config by key, send SwitchModel, and update UI.
 /// Used by both the interactive model selector (Enter key) and the `/model <name>` command.
+/// On success, records `config_key` as the active provider so a later bare `/key <secret>`
+/// knows which `[providers.*]` entry to update.
 fn try_switch_model(
     app: &mut App,
     bus_tx: &Sender<BusMessage>,
     providers: &std::collections::HashMap<String, crate::config::ProviderConfig>,
     workspace_dir: &Path,
     config_key: &str,
+    active_provider_key: &mut Option<String>,
 ) {
     if let Some(cfg) = providers.get(config_key) {
         let resolved_url = cfg.resolved_base_url().unwrap_or_default();
@@ -119,6 +269,7 @@ fn try_switch_model(
                 } else {
                     app.status_model = cfg.model_name.clone();
                     persist_last_model(workspace_dir, config_key);
+                    *active_provider_key = Some(config_key.to_string());
                     app.set_toast(
                         ToastKind::Ok,
                         format!("Model: {}", app.status_model),
@@ -129,8 +280,9 @@ fn try_switch_model(
             Err(e) => {
                 let err_msg = format!(
                     "No API key for '{}': {}\n\
-                     Set the env var or add api_key = \"...\" under [providers.{}] in config.toml.",
-                    config_key, e, config_key
+                     Run /key {} <api_key> to set one now, or add api_key = \"...\" under \
+                     [providers.{}] in config.toml (or set the env var).",
+                    config_key, e, config_key, config_key
                 );
                 app.cells.push(Cell::Error { message: err_msg });
                 app.set_toast(
@@ -143,9 +295,97 @@ fn try_switch_model(
     }
 }
 
+/// `/key` command handler: sets (or updates) an API key at runtime, hot-swaps the live
+/// connection via `BusMessage::SwitchModel`, persists it to `config.toml`, and updates the
+/// in-memory `providers` map so a later `/model` picks up the new key. Never echoes the full
+/// key — only the trailing 4 characters are ever shown.
+#[allow(clippy::too_many_arguments)]
+fn try_set_api_key(
+    app: &mut App,
+    bus_tx: &Sender<BusMessage>,
+    providers: &mut std::collections::HashMap<String, crate::config::ProviderConfig>,
+    workspace_dir: &Path,
+    config_key: &str,
+    api_key: &str,
+    active_provider_key: &mut Option<String>,
+) {
+    if key_looks_like_placeholder(api_key) {
+        app.cells.push(Cell::Error {
+            message: "That doesn't look like a real API key. Usage: /key <api_key>  (or /key <provider_config_key> <api_key>)".into(),
+        });
+        return;
+    }
+    let Some(cfg) = providers.get_mut(config_key) else {
+        let mut available: Vec<&str> = providers.keys().map(|s| s.as_str()).collect();
+        available.sort_unstable();
+        app.cells.push(Cell::Error {
+            message: format!(
+                "Unknown provider '{}'. Available: {}. Run /model first to pick one, then /key.",
+                config_key,
+                available.join(", ")
+            ),
+        });
+        return;
+    };
+    cfg.api_key = Some(api_key.to_string());
+    let provider_name = cfg.provider_name.clone();
+    let model_name = cfg.model_name.clone();
+    let resolved_url = cfg.resolved_base_url().unwrap_or_default();
+    let resolved_key = match cfg.resolve_api_key() {
+        Ok(k) => k,
+        Err(e) => {
+            app.cells.push(Cell::Error {
+                message: format!("Key was set, but could not resolve it for switching: {e}"),
+            });
+            return;
+        }
+    };
+    let masked = mask_api_key_suffix(&resolved_key);
+
+    match persist_provider_api_key(workspace_dir, config_key, api_key) {
+        Ok(()) => app.cells.push(Cell::System {
+            message: format!(
+                "API key updated for '{config_key}' (ends in {masked}) and saved to config.toml."
+            ),
+        }),
+        Err(e) => app.cells.push(Cell::System {
+            message: format!(
+                "API key updated for '{config_key}' (ends in {masked}) for this session, but \
+                 could not persist to config.toml: {e}"
+            ),
+        }),
+    }
+
+    let msg = BusMessage::SwitchModel {
+        provider_name,
+        model_name: model_name.clone(),
+        base_url: resolved_url,
+        api_key: resolved_key,
+    };
+    if bus_tx.blocking_send(msg).is_err() {
+        app.cells.push(Cell::System {
+            message: "Bus closed; exiting.".into(),
+        });
+        app.request_quit();
+    } else {
+        app.status_model = model_name;
+        persist_last_model(workspace_dir, config_key);
+        *active_provider_key = Some(config_key.to_string());
+        app.set_toast(
+            ToastKind::Ok,
+            format!("API key set for {config_key} ({masked})"),
+            Duration::from_secs(3),
+        );
+    }
+}
+
 const TERMINAL_HELP: &str = r#"Commands (leading slash):
   /exit, /quit   Quit and restore the terminal
   /new           Start a new thread (new chat id)
+  /model [name]  Switch LLM model (interactive picker, or /model <config_key>)
+  /key [key]     Set/update an API key at runtime; hot-swaps the live model, saves to
+                 config.toml. Usage: /key <api_key>  or  /key <provider_config_key> <api_key>
+                 (only the last 4 characters are ever shown back to you)
   /copy          Copy the last assistant reply to the clipboard
   /install-python Install uv (best effort) in the background; UI stays responsive
   /cancel, /stop Stop the in-flight reply for this chat (drops queued prompts)
@@ -199,6 +439,7 @@ fn env_falsy(var: &str) -> bool {
 /// Slash commands with descriptions for the autocomplete popup.
 const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/model", "Switch LLM model"),
+    ("/key", "Set/update an API key"),
     ("/new", "Start a new thread"),
     ("/exit", "Quit the terminal"),
     ("/copy", "Copy last reply to clipboard"),
@@ -1410,12 +1651,17 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
         status_model,
         status_permission,
         memory_node,
-        providers,
+        mut providers,
         color_enabled,
         theme,
         resume_session,
         initial_files,
     } = config;
+
+    // Which `[providers.*]` entry `/key` (with no explicit target) should update; refreshed by
+    // `try_switch_model` and by `/key` itself whenever a provider is selected.
+    let mut active_provider_key: Option<String> =
+        resolve_initial_active_provider_key(&workspace_dir, &providers);
 
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -2358,46 +2604,14 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                                 .and_then(|s| s.selected_entry().map(|e| e.config_key.clone()));
                             app.model_selector = None;
                             if let Some(config_key) = selection {
-                                if let Some(cfg) = providers.get(&config_key) {
-                                    let resolved_url = cfg.resolved_base_url().unwrap_or_default();
-                                    match cfg.resolve_api_key() {
-                                        Ok(api_key) => {
-                                            let msg = BusMessage::SwitchModel {
-                                                provider_name: cfg.provider_name.clone(),
-                                                model_name: cfg.model_name.clone(),
-                                                base_url: resolved_url,
-                                                api_key,
-                                            };
-                                            if bus_tx.blocking_send(msg).is_err() {
-                                                app.cells.push(Cell::System {
-                                                    message: "Bus closed; exiting.".into(),
-                                                });
-                                                app.request_quit();
-                                            } else {
-                                                app.status_model = cfg.model_name.clone();
-                                                persist_last_model(&workspace_dir, &config_key);
-                                                app.set_toast(
-                                                    ToastKind::Ok,
-                                                    format!("Model: {}", app.status_model),
-                                                    Duration::from_secs(3),
-                                                );
-                                            }
-                                        }
-                                        Err(e) => {
-                                            let err_msg = format!(
-                                                "No API key for '{}': {}\n\
-                                                Set the env var or add api_key = \"...\" under [providers.{}] in config.toml.",
-                                                config_key, e, config_key
-                                            );
-                                            app.cells.push(Cell::Error { message: err_msg });
-                                            app.set_toast(
-                                                ToastKind::Err,
-                                                format!("No API key for {}", config_key),
-                                                Duration::from_secs(5),
-                                            );
-                                        }
-                                    }
-                                }
+                                try_switch_model(
+                                    &mut app,
+                                    &bus_tx,
+                                    &providers,
+                                    &workspace_dir,
+                                    &config_key,
+                                    &mut active_provider_key,
+                                );
                             }
                         }
                         KeyCode::Esc | KeyCode::Char('q') => {
@@ -2826,6 +3040,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                                         &providers,
                                         &workspace_dir,
                                         arg,
+                                        &mut active_provider_key,
                                     );
                                 } else {
                                     let available: Vec<&str> =
@@ -2837,6 +3052,66 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                                             available.join(", ")
                                         ),
                                     });
+                                }
+                                continue;
+                            }
+                            if text.eq_ignore_ascii_case("/key")
+                                || text.to_ascii_lowercase().starts_with("/key ")
+                            {
+                                let arg = text.strip_prefix("/key").unwrap_or("").trim();
+                                if arg.is_empty() {
+                                    app.cells.push(Cell::System {
+                                        message: "Usage: /key <api_key>  (or /key <provider_config_key> <api_key>)".into(),
+                                    });
+                                    continue;
+                                }
+                                // Optional leading token names a provider config key explicitly;
+                                // otherwise the whole arg is the secret and we fall back to the
+                                // currently active provider (or the sole configured one).
+                                let mut parts = arg.splitn(2, char::is_whitespace);
+                                let first = parts.next().unwrap_or("").trim();
+                                let rest = parts.next().unwrap_or("").trim();
+                                let (config_key_arg, secret): (Option<&str>, &str) =
+                                    if !rest.is_empty() && providers.contains_key(first) {
+                                        (Some(first), rest)
+                                    } else {
+                                        (None, arg)
+                                    };
+                                let resolved_config_key = config_key_arg
+                                    .map(|s| s.to_string())
+                                    .or_else(|| active_provider_key.clone())
+                                    .or_else(|| {
+                                        if providers.len() == 1 {
+                                            providers.keys().next().cloned()
+                                        } else {
+                                            None
+                                        }
+                                    });
+                                match resolved_config_key {
+                                    Some(config_key) => {
+                                        try_set_api_key(
+                                            &mut app,
+                                            &bus_tx,
+                                            &mut providers,
+                                            &workspace_dir,
+                                            &config_key,
+                                            secret,
+                                            &mut active_provider_key,
+                                        );
+                                    }
+                                    None => {
+                                        let mut available: Vec<&str> =
+                                            providers.keys().map(|s| s.as_str()).collect();
+                                        available.sort_unstable();
+                                        app.cells.push(Cell::Error {
+                                            message: format!(
+                                                "Multiple providers configured; specify which one: \
+                                                 /key <provider_config_key> <api_key>. Available: {}. \
+                                                 Or run /model first, then /key.",
+                                                available.join(", ")
+                                            ),
+                                        });
+                                    }
                                 }
                                 continue;
                             }
@@ -2877,7 +3152,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                             }
                             app.cells.push(Cell::System {
                             message:
-                                "Unknown command. Try /help, /exit, /new, /chats, /copy, /install-python, /cancel, /background, /retry, /tools, /exec, /agents, /model, /compact, /context, /skills."
+                                "Unknown command. Try /help, /exit, /new, /chats, /copy, /install-python, /cancel, /background, /retry, /tools, /exec, /agents, /model, /key, /compact, /context, /skills."
                                     .into(),
                         });
                             continue;
@@ -3633,5 +3908,195 @@ mod execution_strip_tests {
         let out = execution_strip_subtitle(None, "683c0fdc-a2bd");
         assert!(out.starts_with('…'));
         assert!(out.contains("683c0fdc"));
+    }
+}
+
+#[cfg(test)]
+mod api_key_persist_tests {
+    use super::{
+        key_looks_like_placeholder, mask_api_key_suffix, persist_provider_api_key,
+        resolve_initial_active_provider_key,
+    };
+    use std::collections::HashMap;
+
+    fn write_config(dir: &std::path::Path, contents: &str) {
+        std::fs::write(dir.join("config.toml"), contents).expect("write config.toml");
+    }
+
+    fn read_config(dir: &std::path::Path) -> String {
+        std::fs::read_to_string(dir.join("config.toml")).expect("read config.toml")
+    }
+
+    #[test]
+    fn sets_api_key_under_exact_providers_section() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_config(
+            tmp.path(),
+            "# top-of-file comment\n\
+             [providers.anthropic]\n\
+             # a comment on the model list\n\
+             models = [\"claude-opus-4-7\"]\n\
+             api_key = \"<changethis>\"\n",
+        );
+
+        persist_provider_api_key(tmp.path(), "anthropic", "sk-ant-real-secret-1234")
+            .expect("persist should succeed");
+
+        let out = read_config(tmp.path());
+        assert!(
+            out.contains("api_key = \"sk-ant-real-secret-1234\""),
+            "expected new key written: {out}"
+        );
+        assert!(
+            out.contains("# top-of-file comment"),
+            "top-level comment should be preserved: {out}"
+        );
+        assert!(
+            out.contains("# a comment on the model list"),
+            "in-table comment should be preserved: {out}"
+        );
+        assert!(
+            !out.contains("<changethis>"),
+            "placeholder should be replaced: {out}"
+        );
+    }
+
+    #[test]
+    fn sets_api_key_via_family_model_name_lookup() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_config(
+            tmp.path(),
+            "[providers.gemini]\n\
+             models = [\"gemini-2.5-flash\", \"gemini-2.5-pro\"]\n\
+             api_key = \"<changethis>\"\n",
+        );
+
+        // Family-expanded config keys are model names, not the section key.
+        persist_provider_api_key(tmp.path(), "gemini-2.5-pro", "sk-gem-secret")
+            .expect("persist should succeed");
+
+        let doc: toml_edit::DocumentMut = read_config(tmp.path()).parse().expect("parse");
+        assert_eq!(
+            doc["providers"]["gemini"]["api_key"].as_str(),
+            Some("sk-gem-secret")
+        );
+    }
+
+    #[test]
+    fn sets_api_key_under_legacy_singular_provider_block() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_config(
+            tmp.path(),
+            "[provider]\n\
+             provider_name = \"openai\"\n\
+             model_name = \"gpt-5.5\"\n\
+             api_key = \"<changethis>\"\n",
+        );
+
+        persist_provider_api_key(tmp.path(), "openai/gpt-5.5", "sk-legacy-secret")
+            .expect("persist should succeed");
+
+        let doc: toml_edit::DocumentMut = read_config(tmp.path()).parse().expect("parse");
+        assert_eq!(
+            doc["provider"]["api_key"].as_str(),
+            Some("sk-legacy-secret")
+        );
+    }
+
+    #[test]
+    fn creates_fresh_section_when_nothing_matches() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_config(tmp.path(), "restrict_to_workspace = true\n");
+
+        persist_provider_api_key(tmp.path(), "brand-new", "sk-fresh-secret")
+            .expect("persist should succeed");
+
+        let doc: toml_edit::DocumentMut = read_config(tmp.path()).parse().expect("parse");
+        assert_eq!(
+            doc["providers"]["brand-new"]["api_key"].as_str(),
+            Some("sk-fresh-secret")
+        );
+    }
+
+    #[test]
+    fn missing_config_file_returns_err() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let err = persist_provider_api_key(tmp.path(), "anthropic", "sk-x").unwrap_err();
+        assert!(err.contains("Could not read"), "{err}");
+    }
+
+    #[test]
+    fn placeholder_detection_rejects_common_templates() {
+        for bad in [
+            "",
+            "  ",
+            "<changethis>",
+            "changethis",
+            "YOUR_API_KEY",
+            "replace_me",
+        ] {
+            assert!(
+                key_looks_like_placeholder(bad),
+                "expected placeholder rejection for {bad:?}"
+            );
+        }
+        assert!(!key_looks_like_placeholder("sk-ant-real-secret-1234"));
+    }
+
+    #[test]
+    fn masking_only_reveals_last_four_chars() {
+        assert_eq!(mask_api_key_suffix("sk-ant-real-secret-1234"), "…1234");
+        assert_eq!(mask_api_key_suffix("ab"), "…ab");
+        assert_eq!(mask_api_key_suffix(""), "****");
+    }
+
+    #[test]
+    fn resolves_sole_provider_when_last_model_file_absent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut providers = HashMap::new();
+        providers.insert(
+            "only-one".to_string(),
+            crate::config::ProviderConfig::default(),
+        );
+        assert_eq!(
+            resolve_initial_active_provider_key(tmp.path(), &providers),
+            Some("only-one".to_string())
+        );
+    }
+
+    #[test]
+    fn resolves_last_model_file_when_valid() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join(".system_generated")).expect("mkdir");
+        std::fs::write(
+            tmp.path().join(".system_generated/last_model"),
+            "claude-opus-4-7",
+        )
+        .expect("write last_model");
+        let mut providers = HashMap::new();
+        providers.insert(
+            "claude-opus-4-7".to_string(),
+            crate::config::ProviderConfig::default(),
+        );
+        providers.insert(
+            "gpt-5.5".to_string(),
+            crate::config::ProviderConfig::default(),
+        );
+        assert_eq!(
+            resolve_initial_active_provider_key(tmp.path(), &providers),
+            Some("claude-opus-4-7".to_string())
+        );
+    }
+
+    #[test]
+    fn no_signal_with_multiple_unknown_providers() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut providers = HashMap::new();
+        providers.insert("a".to_string(), crate::config::ProviderConfig::default());
+        providers.insert("b".to_string(), crate::config::ProviderConfig::default());
+        assert_eq!(
+            resolve_initial_active_provider_key(tmp.path(), &providers),
+            None
+        );
     }
 }

--- a/src/channels/terminal_ui/run.rs
+++ b/src/channels/terminal_ui/run.rs
@@ -42,9 +42,8 @@ use crate::channels::terminal_ui::protocol::{
 };
 use crate::channels::terminal_ui::text_format::truncate_chars_display;
 use crate::channels::terminal_ui::{
-    execution_browser, init, uses_ansi_color, AgentTaskStatus, App, Cell, JobStripStatus,
-    ModelSelector, TerminalUiFocus, Theme, ToastKind, ToolNoticePhase, ToolRailEntry,
-    TranscriptSelection,
+    execution_browser, uses_ansi_color, AgentTaskStatus, App, Cell, JobStripStatus, ModelSelector,
+    TerminalUiFocus, Theme, ToastKind, ToolNoticePhase, ToolRailEntry, TranscriptSelection,
 };
 use crate::clarification::{METADATA_CLARIFICATION, METADATA_CLARIFICATION_CHOICES};
 use crate::memory::{chat_id_from_root_thread_id, MemoryMessage, SharedReply};
@@ -391,9 +390,20 @@ fn outbound_to_cell(msg: &OutboundMessage) -> Cell {
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
+        let edit_diff = msg.metadata.get("edit_diff").and_then(|v| {
+            let file = v.get("file")?.as_str()?.to_string();
+            let diff = v.get("diff")?.as_str()?.to_string();
+            let truncated = v.get("truncated").and_then(|t| t.as_bool()).unwrap_or(false);
+            Some(crate::channels::terminal_ui::EditDiffPayload {
+                file,
+                diff,
+                truncated,
+            })
+        });
         Cell::Clarification {
             text: msg.content.clone(),
             choices,
+            edit_diff,
         }
     } else {
         Cell::Assistant {
@@ -423,6 +433,44 @@ fn layout_chunks(area: Rect, exec_panel_h: u16, active_tool_h: u16, input_h: u16
     [
         chunks[0], chunks[1], chunks[2], chunks[3], chunks[4], chunks[5],
     ]
+}
+
+/// ALTAI Task Session density breakpoints (cols).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LayoutDensity {
+    Narrow,
+    Medium,
+    Wide,
+}
+
+impl LayoutDensity {
+    pub(crate) fn from_cols(cols: u16) -> Self {
+        if cols < 80 {
+            Self::Narrow
+        } else if cols < 120 {
+            Self::Medium
+        } else {
+            Self::Wide
+        }
+    }
+}
+
+/// Split the main content region for wide terminals when a secondary pane is focused.
+fn split_main_content(
+    area: Rect,
+    density: LayoutDensity,
+    focus: TerminalUiFocus,
+) -> (Rect, Option<Rect>) {
+    if density == LayoutDensity::Wide && focus != TerminalUiFocus::Transcript {
+        let side = (area.width / 3).clamp(28, 56);
+        let parts = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Min(24), Constraint::Length(side)])
+            .split(area);
+        (parts[0], Some(parts[1]))
+    } else {
+        (area, None)
+    }
 }
 
 fn chunks_line_width(spans: &[Span<'static>]) -> usize {
@@ -677,11 +725,53 @@ fn line_from_chunk_groups(groups: Vec<Vec<Span<'static>>>, max_width: usize) -> 
     }
 }
 
-fn build_title_line(max_width: usize) -> Line<'static> {
-    let groups = vec![vec![Span::styled(
-        " ALTAI isanagent ",
-        Theme::input_prompt(),
-    )]];
+fn build_title_line(max_width: usize, app: &App) -> Line<'static> {
+    let dim = Theme::dim();
+    let workspace = if app.status_workspace.is_empty() {
+        "workspace".to_string()
+    } else {
+        app.status_workspace.clone()
+    };
+    let model = if app.status_model.is_empty() {
+        "model?".to_string()
+    } else {
+        app.status_model.clone()
+    };
+    let permission = if app.status_permission.is_empty() {
+        "default".to_string()
+    } else {
+        app.status_permission.clone()
+    };
+    let session = if app.status_session.is_empty() {
+        "—".to_string()
+    } else {
+        app.status_session.clone()
+    };
+    let mut groups: Vec<Vec<Span<'static>>> = vec![
+        vec![Span::styled(" ALTAI ", Theme::active())],
+        vec![
+            Span::styled("· ", dim),
+            Span::styled(workspace, Theme::text()),
+        ],
+        vec![
+            Span::styled(" · ", dim),
+            Span::styled(model, Theme::active()),
+        ],
+        vec![
+            Span::styled(" · ", dim),
+            Span::styled(permission, dim),
+        ],
+        vec![
+            Span::styled(" · ", dim),
+            Span::styled(format!("session {session}"), dim),
+        ],
+    ];
+    if !uses_ansi_color() {
+        groups.push(vec![
+            Span::styled(" · ", dim),
+            Span::styled("[plain]", dim),
+        ]);
+    }
     line_from_chunk_groups(groups, max_width)
 }
 
@@ -694,12 +784,12 @@ fn build_status_line(
 ) -> Line<'static> {
     let dim = Theme::dim();
     let activity_label = if thinking {
-        format!("🦾 {} thinking", app.get_spinner_frame())
+        format!("running {} thinking", app.get_spinner_frame())
     } else {
-        "🦾 idle".to_string()
+        "idle".to_string()
     };
     let activity_style = if thinking {
-        Theme::tool_call()
+        Theme::active()
     } else {
         Theme::dim()
     };
@@ -711,21 +801,21 @@ fn build_status_line(
         first_row,
         vec![
             Span::styled(" · ", dim),
-            Span::styled(format!("[ 📋 {} Todos ]", app.todos_count), dim),
+            Span::styled(format!("todos {}", app.todos_count), dim),
         ],
         vec![
             Span::styled(" · ", dim),
-            Span::styled(format!("[ 🕒 {} Crons ]", app.crons_count), dim),
+            Span::styled(format!("crons {}", app.crons_count), dim),
         ],
         vec![
             Span::styled(" · ", dim),
-            Span::styled(format!("[ 🛠 {} Jobs ]", app.jobs_strip.len()), dim),
+            Span::styled(format!("jobs {}", app.jobs_strip.len()), dim),
         ],
         vec![
             Span::styled(" · ", dim),
             Span::styled(
                 format!(
-                    "[ 🤖 {} Agents ]",
+                    "agents {}",
                     app.agent_tasks.iter().filter(|e| !e.status.is_terminal()).count()
                 ),
                 dim,
@@ -738,7 +828,7 @@ fn build_status_line(
         vec![
             Span::styled(" · ", dim),
             Span::styled(
-                "Enter send · ^G background · ^Shift+Y copy last · ^Shift+M wheel · ^W word · ^U clear · ^C cancel · ^D exit",
+                "Enter send · ^G jobs · Tab panes · ^C cancel · ^D exit",
                 Theme::status_bar(),
             ),
         ],
@@ -1291,12 +1381,15 @@ pub(crate) struct RatatuiMainConfig {
     pub channel_name: String,
     pub opening_banner: String,
     pub status_model: String,
+    pub status_permission: String,
     /// Workspace memory (same as agent) for past-session list and transcript load.
     pub memory_node: NodeHandle<MemoryMessage>,
     /// Named alternative providers for `/model` switching.
     pub providers: std::collections::HashMap<String, crate::config::ProviderConfig>,
     /// Whether the host permits ANSI foreground colors for this session.
     pub color_enabled: bool,
+    /// Host-selected ALTAI theme mode.
+    pub theme: super::HostThemeMode,
     /// Whether `chat_id` names a persisted chat that should be loaded.
     pub resume_session: bool,
     /// File references composed into the first user message.
@@ -1315,9 +1408,11 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
         channel_name,
         opening_banner,
         status_model,
+        status_permission,
         memory_node,
         providers,
         color_enabled,
+        theme,
         resume_session,
         initial_files,
     } = config;
@@ -1327,7 +1422,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
         .build()
         .map_err(io::Error::other)?;
 
-    init(color_enabled);
+    super::init_from_host(theme, !color_enabled);
 
     let mut stdout = stdout();
     enable_raw_mode()?;
@@ -1352,6 +1447,21 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
 
     let mut app = App::new();
     app.status_model = status_model;
+    app.status_permission = status_permission;
+    app.status_workspace = sandbox_dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("workspace")
+        .to_string();
+    app.status_session = {
+        let n = chat_id.chars().count();
+        if n <= 13 {
+            chat_id.clone()
+        } else {
+            let tail: String = chat_id.chars().skip(n - 12).collect();
+            format!("…{tail}")
+        }
+    };
     app.cells.push(Cell::System {
         message: opening_banner,
     });
@@ -1690,6 +1800,9 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                     app.upsert_tool_notice(tool_call_id, phase, content);
                 }
                 other => {
+                    if matches!(other, Cell::Clarification { .. }) {
+                        app.pending_approval = true;
+                    }
                     append_cell_merging_thought(&mut app.cells, other);
                 }
             }
@@ -1738,11 +1851,122 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
             }
             let input_h = (visual_lines + 2).clamp(3, 12);
             let ch = layout_chunks(area, exec_h, active_strip_h, input_h);
+            let density = LayoutDensity::from_cols(area.width);
 
             let title_w = ch[0].width as usize;
-            let title = Paragraph::new(build_title_line(title_w.max(1)));
+            let title = Paragraph::new(build_title_line(title_w.max(1), &app));
             f.render_widget(title, ch[0]);
 
+            let (main_left, side_opt) = split_main_content(ch[1], density, app.ui_focus);
+            if let Some(side) = side_opt {
+                let (w, max_s, vis_start) = transcript_paragraph(
+                    &app.cells,
+                    main_left,
+                    app.scroll_offset,
+                    app.transcript_selection.as_ref(),
+                );
+                max_transcript_scroll_holder.set(max_s);
+                app.last_transcript_visible_start = vis_start;
+                f.render_widget(w, main_left);
+                app.last_transcript_rect = Some(main_left);
+                // Focused secondary pane occupies the right column.
+                let pane = side;
+                match app.ui_focus {
+                    TerminalUiFocus::Transcript => {}
+                    TerminalUiFocus::Conversations => {
+                        let (w, max_s) = conversations_list_paragraph(&app, pane);
+                        max_conversations_list_scroll_holder.set(max_s);
+                        f.render_widget(w, pane);
+                        app.last_conversations_list_rect = Some(pane);
+                        app.last_tool_history_rect = None;
+                        app.last_executions_list_rect = None;
+                        app.last_executions_code_rect = None;
+                        app.last_executions_output_rect = None;
+                        app.last_agent_tasks_rect = None;
+                    }
+                    TerminalUiFocus::Executions => {
+                        let list_w = (pane.width / 3).clamp(18, 36);
+                        let hareas = Layout::default()
+                            .direction(Direction::Horizontal)
+                            .constraints([Constraint::Length(list_w), Constraint::Min(6)])
+                            .split(pane);
+                        let (pl, max_l) = executions_list_paragraph(&app, hareas[0]);
+                        max_exec_list_scroll_holder.set(max_l);
+                        f.render_widget(pl, hareas[0]);
+                        app.last_executions_list_rect = Some(hareas[0]);
+                        app.last_conversations_list_rect = None;
+                        app.last_tool_history_rect = None;
+                        app.last_agent_tasks_rect = None;
+                        match &app.executions_detail {
+                            Some(d) => {
+                                let vareas = Layout::default()
+                                    .direction(Direction::Vertical)
+                                    .constraints([
+                                        Constraint::Percentage(52),
+                                        Constraint::Percentage(48),
+                                    ])
+                                    .split(hareas[1]);
+                                let (pc, max_c) = executions_code_paragraph(
+                                    d,
+                                    vareas[0],
+                                    app.executions_code_scroll_top,
+                                );
+                                max_exec_code_scroll_holder.set(max_c);
+                                f.render_widget(pc, vareas[0]);
+                                let (po, max_o) = executions_output_paragraph(
+                                    &d.journal,
+                                    vareas[1],
+                                    app.executions_output_scroll_top,
+                                );
+                                max_exec_out_scroll_holder.set(max_o);
+                                f.render_widget(po, vareas[1]);
+                                app.last_executions_code_rect = Some(vareas[0]);
+                                app.last_executions_output_rect = Some(vareas[1]);
+                            }
+                            None => {
+                                max_exec_code_scroll_holder.set(0);
+                                max_exec_out_scroll_holder.set(0);
+                                app.last_executions_code_rect = None;
+                                app.last_executions_output_rect = None;
+                            }
+                        }
+                    }
+                    TerminalUiFocus::ToolHistory => {
+                        let (w, max_s) = tool_history_paragraph(
+                            &app.tool_rail,
+                            pane,
+                            app.tool_history_scroll,
+                        );
+                        max_tool_history_scroll_holder.set(max_s);
+                        f.render_widget(w, pane);
+                        app.last_tool_history_rect = Some(pane);
+                        app.last_conversations_list_rect = None;
+                        app.last_executions_list_rect = None;
+                        app.last_agent_tasks_rect = None;
+                    }
+                    TerminalUiFocus::AgentTasks | TerminalUiFocus::BackgroundJobs => {
+                        let list = background_pane_paragraph(&app);
+                        let title = if app.ui_focus == TerminalUiFocus::BackgroundJobs {
+                            " background "
+                        } else {
+                            " sub-agents "
+                        };
+                        let w = Paragraph::new(Text::from(list))
+                            .block(
+                                Block::default()
+                                    .borders(Borders::ALL)
+                                    .title(Span::styled(title, Theme::tool_call()))
+                                    .border_style(Theme::dim()),
+                            )
+                            .scroll((app.agent_tasks_scroll_top as u16, 0));
+                        f.render_widget(w, pane);
+                        app.last_agent_tasks_rect = Some(pane);
+                        app.last_conversations_list_rect = None;
+                        app.last_tool_history_rect = None;
+                        app.last_executions_list_rect = None;
+                    }
+                }
+            } else {
             match app.ui_focus {
                 TerminalUiFocus::Transcript => {
                     let (w, max_s, vis_start) = transcript_paragraph(
@@ -1875,6 +2099,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                     app.last_conversations_list_rect = None;
                 }
             }
+            } // end single-pane (non-wide) branch
 
             if exec_h > 0 {
                 let exec_block = Block::default()
@@ -2665,6 +2890,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
 
                         app.cells.push(Cell::User { text: raw.clone() });
                         app.thinking = true;
+                        app.pending_approval = false;
                         app.last_inbound_text = Some(text.to_string());
                         app.llm_retry_available = false;
                         let (clean_text, attachments) =
@@ -2967,6 +3193,37 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                             }
                         }
                     }
+                    KeyCode::Char(c) if app.pending_approval && app.input.is_empty() => {
+                        if let Some(reply) =
+                            crate::channels::terminal_ui::approval_hotkey_reply(c)
+                        {
+                            app.cells.push(Cell::User {
+                                text: reply.to_string(),
+                            });
+                            app.thinking = true;
+                            app.pending_approval = false;
+                            app.last_inbound_text = Some(reply.to_string());
+                            let msg = InboundMessage {
+                                channel: channel_name.clone(),
+                                sender_id: "local_user".to_string(),
+                                chat_id: chat_id.clone(),
+                                thread_id: None,
+                                content: reply.to_string(),
+                                attachments: Vec::new(),
+                                metadata: Default::default(),
+                            };
+                            if bus_tx.blocking_send(BusMessage::Inbound(msg)).is_err() {
+                                app.thinking = false;
+                                app.cells.push(Cell::System {
+                                    message: "Bus closed; exiting.".into(),
+                                });
+                                app.request_quit();
+                            }
+                            app.scroll_to_bottom();
+                        } else {
+                            app.insert_char(c);
+                        }
+                    }
                     KeyCode::Char(c) => app.insert_char(c),
                     _ => {}
                 }
@@ -3249,10 +3506,14 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
 
 #[cfg(test)]
 mod width_fit_tests {
-    use super::{build_status_line, build_title_line};
+    use super::{
+        build_status_line, build_title_line, split_main_content, LayoutDensity,
+    };
     use crate::channels::terminal_ui::app::App;
     use crate::channels::terminal_ui::display_width;
     use crate::channels::terminal_ui::text_format::truncate_chars_display;
+    use crate::channels::terminal_ui::TerminalUiFocus;
+    use ratatui::layout::Rect;
     use ratatui::text::Line;
 
     fn flat(line: &Line) -> String {
@@ -3261,6 +3522,15 @@ mod width_fit_tests {
             .map(|s| s.content.as_ref())
             .collect::<Vec<_>>()
             .join("")
+    }
+
+    fn sample_app() -> App {
+        let mut app = App::new();
+        app.status_workspace = "altai-app".into();
+        app.status_model = "anthropic/claude-sonnet".into();
+        app.status_permission = "plan".into();
+        app.status_session = "…abc123".into();
+        app
     }
 
     #[test]
@@ -3276,12 +3546,10 @@ mod width_fit_tests {
 
     #[test]
     fn status_drops_low_priority_when_narrow() {
-        let app = App::new();
+        let app = sample_app();
         let line = build_status_line(26, false, 3, None, &app);
         let t = flat(&line);
-        assert!(t.contains("🦾"), "{t}");
-        assert!(t.contains("idle"));
-        assert!(!t.contains("thread"), "{t}");
+        assert!(t.contains("idle"), "{t}");
         assert!(
             !t.contains("Enter send"),
             "hints should drop first when tight: {t}"
@@ -3289,11 +3557,54 @@ mod width_fit_tests {
     }
 
     #[test]
-    fn title_shows_brand_only() {
-        let line = build_title_line(120);
+    fn title_shows_brand_workspace_model() {
+        let app = sample_app();
+        let line = build_title_line(160, &app);
         let t = flat(&line);
-        assert!(t.contains("ALTAI isanagent"), "{t}");
-        assert!(!t.contains("thread "), "{t}");
+        assert!(t.contains("ALTAI"), "{t}");
+        assert!(t.contains("altai-app"), "{t}");
+        assert!(t.contains("anthropic/claude-sonnet"), "{t}");
+        assert!(t.contains("plan"), "{t}");
+    }
+
+    #[test]
+    fn title_and_status_fit_snapshot_widths() {
+        let app = sample_app();
+        for width in [80usize, 100, 160] {
+            let title = flat(&build_title_line(width, &app));
+            let status = flat(&build_status_line(width, false, 3, None, &app));
+            assert!(
+                display_width(&title) <= width,
+                "title overflow at {width}: {title:?}"
+            );
+            assert!(
+                display_width(&status) <= width,
+                "status overflow at {width}: {status:?}"
+            );
+            assert!(title.contains("ALTAI"), "{title}");
+            assert!(status.contains("idle"), "{status}");
+        }
+    }
+
+    #[test]
+    fn layout_density_breakpoints() {
+        assert_eq!(LayoutDensity::from_cols(79), LayoutDensity::Narrow);
+        assert_eq!(LayoutDensity::from_cols(80), LayoutDensity::Medium);
+        assert_eq!(LayoutDensity::from_cols(119), LayoutDensity::Medium);
+        assert_eq!(LayoutDensity::from_cols(120), LayoutDensity::Wide);
+    }
+
+    #[test]
+    fn wide_layout_splits_secondary_pane() {
+        let area = Rect::new(0, 0, 160, 40);
+        let (left, right) =
+            split_main_content(area, LayoutDensity::Wide, TerminalUiFocus::ToolHistory);
+        assert!(right.is_some());
+        assert!(left.width + right.unwrap().width <= area.width);
+        let (only, none) =
+            split_main_content(area, LayoutDensity::Medium, TerminalUiFocus::ToolHistory);
+        assert!(none.is_none());
+        assert_eq!(only, area);
     }
 }
 

--- a/src/channels/terminal_ui/run.rs
+++ b/src/channels/terminal_ui/run.rs
@@ -279,15 +279,14 @@ fn try_switch_model(
             }
             Err(e) => {
                 let err_msg = format!(
-                    "No API key for '{}': {}\n\
-                     Run /key {} <api_key> to set one now, or add api_key = \"...\" under \
-                     [providers.{}] in config.toml (or set the env var).",
-                    config_key, e, config_key, config_key
+                    "No API key for '{config_key}': {e}\n\
+                     Run /key {config_key} <api_key> to set one now, or add api_key = \"...\" under \
+                     [providers.{config_key}] in config.toml (or set the env var)."
                 );
                 app.cells.push(Cell::Error { message: err_msg });
                 app.set_toast(
                     ToastKind::Err,
-                    format!("No API key for {}", config_key),
+                    format!("No API key for {config_key}"),
                     Duration::from_secs(5),
                 );
             }
@@ -2384,7 +2383,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
             };
             let t = truncate_chars_display(active_text, active_w.max(8).saturating_sub(6));
             let active_row = Line::from(vec![
-                Span::styled(format!(" {} ", icon), Theme::tool_call()),
+                Span::styled(format!(" {icon} "), Theme::tool_call()),
                 Span::styled(t, Theme::dim()),
             ]);
             f.render_widget(Paragraph::new(active_row), ch[4]);
@@ -2540,7 +2539,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                     let mut lines: Vec<Line> = Vec::new();
                     for (cmd, desc) in matching.iter().take(hint_inner.height as usize) {
                         lines.push(Line::from(vec![
-                            Span::styled(format!("{:<16}", cmd), Style::default().fg(Color::Cyan)),
+                            Span::styled(format!("{cmd:<16}"), Style::default().fg(Color::Cyan)),
                             Span::styled(*desc, Style::default().fg(Color::Gray)),
                         ]));
                     }
@@ -2784,7 +2783,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                                 sync_terminal_session_chat(&bus_tx, &chat_id);
                                 app.thinking = false;
                                 app.cells.push(Cell::System {
-                                    message: format!("New thread: {}", chat_id),
+                                    message: format!("New thread: {chat_id}"),
                                 });
                                 rescan_executions_manifest(&workspace_dir, &chat_id, &mut app);
                                 last_exec_poll = Instant::now();
@@ -3009,8 +3008,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                                         "Compaction requested. It will run between turns; next inbound will see a smaller context.".to_string()
                                     } else {
                                         format!(
-                                            "Compaction requested with focus: \"{}\". Next inbound will see a smaller context.",
-                                            focus
+                                            "Compaction requested with focus: \"{focus}\". Next inbound will see a smaller context."
                                         )
                                     };
                                     app.cells.push(Cell::System { message: note });
@@ -3137,7 +3135,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                                             });
                                         } else {
                                             app.cells.push(Cell::System {
-                                                message: format!("Skill installation requested for repository: {}. Check logs for progress.", repo_url),
+                                                message: format!("Skill installation requested for repository: {repo_url}. Check logs for progress."),
                                             });
                                         }
                                     }

--- a/src/channels/terminal_ui/run.rs
+++ b/src/channels/terminal_ui/run.rs
@@ -634,7 +634,10 @@ fn outbound_to_cell(msg: &OutboundMessage) -> Cell {
         let edit_diff = msg.metadata.get("edit_diff").and_then(|v| {
             let file = v.get("file")?.as_str()?.to_string();
             let diff = v.get("diff")?.as_str()?.to_string();
-            let truncated = v.get("truncated").and_then(|t| t.as_bool()).unwrap_or(false);
+            let truncated = v
+                .get("truncated")
+                .and_then(|t| t.as_bool())
+                .unwrap_or(false);
             Some(crate::channels::terminal_ui::EditDiffPayload {
                 file,
                 diff,
@@ -998,20 +1001,14 @@ fn build_title_line(max_width: usize, app: &App) -> Line<'static> {
             Span::styled(" · ", dim),
             Span::styled(model, Theme::active()),
         ],
-        vec![
-            Span::styled(" · ", dim),
-            Span::styled(permission, dim),
-        ],
+        vec![Span::styled(" · ", dim), Span::styled(permission, dim)],
         vec![
             Span::styled(" · ", dim),
             Span::styled(format!("session {session}"), dim),
         ],
     ];
     if !uses_ansi_color() {
-        groups.push(vec![
-            Span::styled(" · ", dim),
-            Span::styled("[plain]", dim),
-        ]);
+        groups.push(vec![Span::styled(" · ", dim), Span::styled("[plain]", dim)]);
     }
     line_from_chunk_groups(groups, max_width)
 }
@@ -1057,7 +1054,10 @@ fn build_status_line(
             Span::styled(
                 format!(
                     "agents {}",
-                    app.agent_tasks.iter().filter(|e| !e.status.is_terminal()).count()
+                    app.agent_tasks
+                        .iter()
+                        .filter(|e| !e.status.is_terminal())
+                        .count()
                 ),
                 dim,
             ),
@@ -2178,11 +2178,8 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                         }
                     }
                     TerminalUiFocus::ToolHistory => {
-                        let (w, max_s) = tool_history_paragraph(
-                            &app.tool_rail,
-                            pane,
-                            app.tool_history_scroll,
-                        );
+                        let (w, max_s) =
+                            tool_history_paragraph(&app.tool_rail, pane, app.tool_history_scroll);
                         max_tool_history_scroll_holder.set(max_s);
                         f.render_widget(w, pane);
                         app.last_tool_history_rect = Some(pane);
@@ -2213,138 +2210,139 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                     }
                 }
             } else {
-            match app.ui_focus {
-                TerminalUiFocus::Transcript => {
-                    let (w, max_s, vis_start) = transcript_paragraph(
-                        &app.cells,
-                        ch[1],
-                        app.scroll_offset,
-                        app.transcript_selection.as_ref(),
-                    );
-                    max_transcript_scroll_holder.set(max_s);
-                    app.last_transcript_visible_start = vis_start;
-                    f.render_widget(w, ch[1]);
-                    app.last_transcript_rect = Some(ch[1]);
-                    app.last_tool_history_rect = None;
-                    app.last_executions_list_rect = None;
-                    app.last_executions_code_rect = None;
-                    app.last_executions_output_rect = None;
-                    app.last_conversations_list_rect = None;
-                    app.last_agent_tasks_rect = None;
-                }
-                TerminalUiFocus::Conversations => {
-                    let (w, max_s) = conversations_list_paragraph(&app, ch[1]);
-                    max_conversations_list_scroll_holder.set(max_s);
-                    f.render_widget(w, ch[1]);
-                    app.last_conversations_list_rect = Some(ch[1]);
-                    app.last_transcript_rect = None;
-                    app.last_tool_history_rect = None;
-                    app.last_executions_list_rect = None;
-                    app.last_executions_code_rect = None;
-                    app.last_executions_output_rect = None;
-                    app.last_agent_tasks_rect = None;
-                }
-                TerminalUiFocus::Executions => {
-                    let list_w = (ch[1].width / 3).clamp(26, 46);
-                    let hareas = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .constraints([Constraint::Length(list_w), Constraint::Min(8)])
-                        .split(ch[1]);
-                    let list_r = hareas[0];
-                    let detail_area = hareas[1];
-                    let vareas = Layout::default()
-                        .direction(Direction::Vertical)
-                        .constraints([Constraint::Percentage(52), Constraint::Percentage(48)])
-                        .split(detail_area);
-                    let code_r = vareas[0];
-                    let out_r = vareas[1];
-
-                    let (pl, max_l) = executions_list_paragraph(&app, list_r);
-                    max_exec_list_scroll_holder.set(max_l);
-                    f.render_widget(pl, list_r);
-
-                    match &app.executions_detail {
-                        Some(d) => {
-                            let (pc, max_c) = executions_code_paragraph(
-                                d,
-                                code_r,
-                                app.executions_code_scroll_top,
-                            );
-                            max_exec_code_scroll_holder.set(max_c);
-                            f.render_widget(pc, code_r);
-                            let (po, max_o) = executions_output_paragraph(
-                                &d.journal,
-                                out_r,
-                                app.executions_output_scroll_top,
-                            );
-                            max_exec_out_scroll_holder.set(max_o);
-                            f.render_widget(po, out_r);
-                            app.last_executions_code_rect = Some(code_r);
-                            app.last_executions_output_rect = Some(out_r);
-                        }
-                        None => {
-                            max_exec_code_scroll_holder.set(0);
-                            max_exec_out_scroll_holder.set(0);
-                            app.last_executions_code_rect = None;
-                            app.last_executions_output_rect = None;
-                            let msg = app
-                                .executions_detail_error
-                                .as_deref()
-                                .unwrap_or("Pick a run from the list (↑↓).");
-                            let empty = Paragraph::new(Line::from(Span::styled(msg, Theme::dim())))
-                                .block(
-                                    Block::default()
-                                        .borders(Borders::ALL)
-                                        .title(Span::styled(" detail ", Theme::dim()))
-                                        .border_style(Theme::dim()),
-                                );
-                            f.render_widget(empty, detail_area);
-                        }
+                match app.ui_focus {
+                    TerminalUiFocus::Transcript => {
+                        let (w, max_s, vis_start) = transcript_paragraph(
+                            &app.cells,
+                            ch[1],
+                            app.scroll_offset,
+                            app.transcript_selection.as_ref(),
+                        );
+                        max_transcript_scroll_holder.set(max_s);
+                        app.last_transcript_visible_start = vis_start;
+                        f.render_widget(w, ch[1]);
+                        app.last_transcript_rect = Some(ch[1]);
+                        app.last_tool_history_rect = None;
+                        app.last_executions_list_rect = None;
+                        app.last_executions_code_rect = None;
+                        app.last_executions_output_rect = None;
+                        app.last_conversations_list_rect = None;
+                        app.last_agent_tasks_rect = None;
                     }
-                    app.last_transcript_rect = None;
-                    app.last_tool_history_rect = None;
-                    app.last_executions_list_rect = Some(list_r);
-                    app.last_conversations_list_rect = None;
-                    app.last_agent_tasks_rect = None;
+                    TerminalUiFocus::Conversations => {
+                        let (w, max_s) = conversations_list_paragraph(&app, ch[1]);
+                        max_conversations_list_scroll_holder.set(max_s);
+                        f.render_widget(w, ch[1]);
+                        app.last_conversations_list_rect = Some(ch[1]);
+                        app.last_transcript_rect = None;
+                        app.last_tool_history_rect = None;
+                        app.last_executions_list_rect = None;
+                        app.last_executions_code_rect = None;
+                        app.last_executions_output_rect = None;
+                        app.last_agent_tasks_rect = None;
+                    }
+                    TerminalUiFocus::Executions => {
+                        let list_w = (ch[1].width / 3).clamp(26, 46);
+                        let hareas = Layout::default()
+                            .direction(Direction::Horizontal)
+                            .constraints([Constraint::Length(list_w), Constraint::Min(8)])
+                            .split(ch[1]);
+                        let list_r = hareas[0];
+                        let detail_area = hareas[1];
+                        let vareas = Layout::default()
+                            .direction(Direction::Vertical)
+                            .constraints([Constraint::Percentage(52), Constraint::Percentage(48)])
+                            .split(detail_area);
+                        let code_r = vareas[0];
+                        let out_r = vareas[1];
+
+                        let (pl, max_l) = executions_list_paragraph(&app, list_r);
+                        max_exec_list_scroll_holder.set(max_l);
+                        f.render_widget(pl, list_r);
+
+                        match &app.executions_detail {
+                            Some(d) => {
+                                let (pc, max_c) = executions_code_paragraph(
+                                    d,
+                                    code_r,
+                                    app.executions_code_scroll_top,
+                                );
+                                max_exec_code_scroll_holder.set(max_c);
+                                f.render_widget(pc, code_r);
+                                let (po, max_o) = executions_output_paragraph(
+                                    &d.journal,
+                                    out_r,
+                                    app.executions_output_scroll_top,
+                                );
+                                max_exec_out_scroll_holder.set(max_o);
+                                f.render_widget(po, out_r);
+                                app.last_executions_code_rect = Some(code_r);
+                                app.last_executions_output_rect = Some(out_r);
+                            }
+                            None => {
+                                max_exec_code_scroll_holder.set(0);
+                                max_exec_out_scroll_holder.set(0);
+                                app.last_executions_code_rect = None;
+                                app.last_executions_output_rect = None;
+                                let msg = app
+                                    .executions_detail_error
+                                    .as_deref()
+                                    .unwrap_or("Pick a run from the list (↑↓).");
+                                let empty =
+                                    Paragraph::new(Line::from(Span::styled(msg, Theme::dim())))
+                                        .block(
+                                            Block::default()
+                                                .borders(Borders::ALL)
+                                                .title(Span::styled(" detail ", Theme::dim()))
+                                                .border_style(Theme::dim()),
+                                        );
+                                f.render_widget(empty, detail_area);
+                            }
+                        }
+                        app.last_transcript_rect = None;
+                        app.last_tool_history_rect = None;
+                        app.last_executions_list_rect = Some(list_r);
+                        app.last_conversations_list_rect = None;
+                        app.last_agent_tasks_rect = None;
+                    }
+                    TerminalUiFocus::ToolHistory => {
+                        let (w, max_s) =
+                            tool_history_paragraph(&app.tool_rail, ch[1], app.tool_history_scroll);
+                        max_tool_history_scroll_holder.set(max_s);
+                        f.render_widget(w, ch[1]);
+                        app.last_tool_history_rect = Some(ch[1]);
+                        app.last_transcript_rect = None;
+                        app.last_executions_list_rect = None;
+                        app.last_executions_code_rect = None;
+                        app.last_executions_output_rect = None;
+                        app.last_conversations_list_rect = None;
+                        app.last_agent_tasks_rect = None;
+                    }
+                    TerminalUiFocus::AgentTasks | TerminalUiFocus::BackgroundJobs => {
+                        let list = background_pane_paragraph(&app);
+                        let title = if app.ui_focus == TerminalUiFocus::BackgroundJobs {
+                            " background "
+                        } else {
+                            " sub-agents "
+                        };
+                        let w = Paragraph::new(Text::from(list))
+                            .block(
+                                Block::default()
+                                    .borders(Borders::ALL)
+                                    .title(Span::styled(title, Theme::tool_call()))
+                                    .border_style(Theme::dim()),
+                            )
+                            .scroll((app.agent_tasks_scroll_top as u16, 0));
+                        f.render_widget(w, ch[1]);
+                        app.last_agent_tasks_rect = Some(ch[1]);
+                        app.last_transcript_rect = None;
+                        app.last_tool_history_rect = None;
+                        app.last_executions_list_rect = None;
+                        app.last_executions_code_rect = None;
+                        app.last_executions_output_rect = None;
+                        app.last_conversations_list_rect = None;
+                    }
                 }
-                TerminalUiFocus::ToolHistory => {
-                    let (w, max_s) =
-                        tool_history_paragraph(&app.tool_rail, ch[1], app.tool_history_scroll);
-                    max_tool_history_scroll_holder.set(max_s);
-                    f.render_widget(w, ch[1]);
-                    app.last_tool_history_rect = Some(ch[1]);
-                    app.last_transcript_rect = None;
-                    app.last_executions_list_rect = None;
-                    app.last_executions_code_rect = None;
-                    app.last_executions_output_rect = None;
-                    app.last_conversations_list_rect = None;
-                    app.last_agent_tasks_rect = None;
-                }
-                TerminalUiFocus::AgentTasks | TerminalUiFocus::BackgroundJobs => {
-                    let list = background_pane_paragraph(&app);
-                    let title = if app.ui_focus == TerminalUiFocus::BackgroundJobs {
-                        " background "
-                    } else {
-                        " sub-agents "
-                    };
-                    let w = Paragraph::new(Text::from(list))
-                        .block(
-                            Block::default()
-                                .borders(Borders::ALL)
-                                .title(Span::styled(title, Theme::tool_call()))
-                                .border_style(Theme::dim()),
-                        )
-                        .scroll((app.agent_tasks_scroll_top as u16, 0));
-                    f.render_widget(w, ch[1]);
-                    app.last_agent_tasks_rect = Some(ch[1]);
-                    app.last_transcript_rect = None;
-                    app.last_tool_history_rect = None;
-                    app.last_executions_list_rect = None;
-                    app.last_executions_code_rect = None;
-                    app.last_executions_output_rect = None;
-                    app.last_conversations_list_rect = None;
-                }
-            }
             } // end single-pane (non-wide) branch
 
             if exec_h > 0 {
@@ -3469,8 +3467,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
                         }
                     }
                     KeyCode::Char(c) if app.pending_approval && app.input.is_empty() => {
-                        if let Some(reply) =
-                            crate::channels::terminal_ui::approval_hotkey_reply(c)
+                        if let Some(reply) = crate::channels::terminal_ui::approval_hotkey_reply(c)
                         {
                             app.cells.push(Cell::User {
                                 text: reply.to_string(),
@@ -3781,9 +3778,7 @@ pub(crate) fn run_ratatui_main(config: RatatuiMainConfig) -> io::Result<()> {
 
 #[cfg(test)]
 mod width_fit_tests {
-    use super::{
-        build_status_line, build_title_line, split_main_content, LayoutDensity,
-    };
+    use super::{build_status_line, build_title_line, split_main_content, LayoutDensity};
     use crate::channels::terminal_ui::app::App;
     use crate::channels::terminal_ui::display_width;
     use crate::channels::terminal_ui::text_format::truncate_chars_display;

--- a/src/channels/terminal_ui/theme.rs
+++ b/src/channels/terminal_ui/theme.rs
@@ -1,10 +1,48 @@
 #![allow(dead_code)]
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
 use ratatui::style::{Color, Modifier, Style};
 
 static USE_ANSI_COLOR: AtomicBool = AtomicBool::new(true);
+/// 0 = dark, 1 = light, 2 = no-color (structure only).
+static APPEARANCE: AtomicU8 = AtomicU8::new(0);
+
+/// Host-selected theme mode before auto / NO_COLOR resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HostThemeMode {
+    #[default]
+    Auto,
+    Dark,
+    Light,
+    NoColor,
+}
+
+/// Effective appearance applied to the TUI for this process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThemeAppearance {
+    Dark,
+    Light,
+    NoColor,
+}
+
+impl ThemeAppearance {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Light,
+            2 => Self::NoColor,
+            _ => Self::Dark,
+        }
+    }
+
+    fn as_u8(self) -> u8 {
+        match self {
+            Self::Dark => 0,
+            Self::Light => 1,
+            Self::NoColor => 2,
+        }
+    }
+}
 
 /// Read [`NO_COLOR`](https://no-color.org/) and store whether to emit ANSI colors. Call once from the Ratatui entry before the first draw.
 pub fn init_from_env() {
@@ -18,6 +56,51 @@ pub fn init_from_env() {
 /// Set the color capability chosen by an embedding host for this TUI session.
 pub fn init(allow: bool) {
     USE_ANSI_COLOR.store(allow, Ordering::Relaxed);
+    if !allow {
+        APPEARANCE.store(ThemeAppearance::NoColor.as_u8(), Ordering::Relaxed);
+    }
+}
+
+/// Apply a resolved ALTAI appearance (dark / light / no-color).
+pub fn init_appearance(appearance: ThemeAppearance) {
+    APPEARANCE.store(appearance.as_u8(), Ordering::Relaxed);
+    USE_ANSI_COLOR.store(appearance != ThemeAppearance::NoColor, Ordering::Relaxed);
+}
+
+/// Resolve host theme + NO_COLOR into an appearance and apply it.
+pub fn init_from_host(theme: HostThemeMode, no_color: bool) {
+    let appearance = resolve_host_appearance(theme, no_color);
+    init_appearance(appearance);
+}
+
+/// Resolve without mutating global theme state (for tests and adapters).
+pub fn resolve_host_appearance(theme: HostThemeMode, no_color: bool) -> ThemeAppearance {
+    if no_color || theme == HostThemeMode::NoColor {
+        return ThemeAppearance::NoColor;
+    }
+    match theme {
+        HostThemeMode::Dark => ThemeAppearance::Dark,
+        HostThemeMode::Light => ThemeAppearance::Light,
+        HostThemeMode::NoColor => ThemeAppearance::NoColor,
+        HostThemeMode::Auto => detect_auto_appearance(),
+    }
+}
+
+fn detect_auto_appearance() -> ThemeAppearance {
+    if let Ok(raw) = std::env::var("COLORFGBG") {
+        if let Some(bg) = raw
+            .split(';')
+            .nth(1)
+            .and_then(|part| part.trim().parse::<u8>().ok())
+        {
+            return if bg >= 8 {
+                ThemeAppearance::Light
+            } else {
+                ThemeAppearance::Dark
+            };
+        }
+    }
+    ThemeAppearance::Dark
 }
 
 #[inline]
@@ -29,6 +112,54 @@ fn ansi_color() -> bool {
 #[inline]
 pub fn uses_ansi_color() -> bool {
     ansi_color()
+}
+
+#[inline]
+pub fn current_appearance() -> ThemeAppearance {
+    ThemeAppearance::from_u8(APPEARANCE.load(Ordering::Relaxed))
+}
+
+/// Truecolor roles derived from ALTAI App `globals.css` OKLCH tokens.
+#[derive(Debug, Clone, Copy)]
+struct Palette {
+    text: Color,
+    muted: Color,
+    active: Color,
+    warning: Color,
+    success: Color,
+    info: Color,
+    error: Color,
+    focus: Color,
+}
+
+const DARK: Palette = Palette {
+    text: Color::Rgb(240, 242, 244),
+    muted: Color::Rgb(137, 140, 146),
+    active: Color::Rgb(181, 234, 38),
+    warning: Color::Rgb(245, 174, 57),
+    success: Color::Rgb(81, 198, 114),
+    info: Color::Rgb(75, 174, 237),
+    error: Color::Rgb(248, 75, 75),
+    focus: Color::Rgb(93, 114, 149),
+};
+
+const LIGHT: Palette = Palette {
+    text: Color::Rgb(19, 22, 28),
+    muted: Color::Rgb(81, 85, 92),
+    active: Color::Rgb(154, 211, 53),
+    warning: Color::Rgb(201, 105, 0),
+    success: Color::Rgb(0, 127, 53),
+    info: Color::Rgb(0, 106, 175),
+    error: Color::Rgb(212, 9, 36),
+    focus: Color::Rgb(79, 100, 134),
+};
+
+fn palette() -> Option<&'static Palette> {
+    match current_appearance() {
+        ThemeAppearance::Dark => Some(&DARK),
+        ThemeAppearance::Light => Some(&LIGHT),
+        ThemeAppearance::NoColor => None,
+    }
 }
 
 #[inline]
@@ -49,63 +180,153 @@ fn fg_mod(c: Color, m: Modifier) -> Style {
     }
 }
 
-/// Default palette for the TUI (tuned for dark terminals). Honors `NO_COLOR` (no foreground colors; modifiers kept for structure).
+/// Default palette for the TUI. Honors host theme + `NO_COLOR`.
 #[derive(Debug, Clone, Copy)]
 pub struct Theme;
 
 impl Theme {
     pub fn text() -> Style {
-        fg(Color::White)
+        match palette() {
+            Some(p) => fg(p.text),
+            None => Style::default(),
+        }
     }
 
     pub fn dim() -> Style {
-        fg(Color::DarkGray)
+        match palette() {
+            Some(p) => fg(p.muted),
+            None => Style::default().add_modifier(Modifier::DIM),
+        }
     }
 
     pub fn user_prefix() -> Style {
-        fg_mod(Color::Cyan, Modifier::BOLD)
+        match palette() {
+            Some(p) => fg_mod(p.info, Modifier::BOLD),
+            None => Style::default().add_modifier(Modifier::BOLD),
+        }
     }
 
     pub fn assistant_bullet() -> Style {
-        fg(Color::DarkGray)
+        Theme::dim()
     }
 
     pub fn thinking() -> Style {
-        fg_mod(Color::DarkGray, Modifier::ITALIC)
+        match palette() {
+            Some(p) => fg_mod(p.muted, Modifier::ITALIC),
+            None => Style::default().add_modifier(Modifier::ITALIC | Modifier::DIM),
+        }
     }
 
     pub fn tool_call() -> Style {
-        fg(Color::Yellow)
+        match palette() {
+            Some(p) => fg(p.warning),
+            None => Style::default().add_modifier(Modifier::BOLD),
+        }
     }
 
     /// Yellow + dim/italic, used for in-flight `Cell::ToolNotice` cells whose result
     /// has not yet arrived. Distinguishes "waiting" from a finished green/red result.
     pub fn tool_pending() -> Style {
-        fg_mod(Color::Yellow, Modifier::DIM | Modifier::ITALIC)
+        match palette() {
+            Some(p) => fg_mod(p.warning, Modifier::DIM | Modifier::ITALIC),
+            None => Style::default().add_modifier(Modifier::DIM | Modifier::ITALIC),
+        }
     }
 
     pub fn tool_done() -> Style {
-        fg(Color::Green)
+        match palette() {
+            Some(p) => fg(p.success),
+            None => Style::default().add_modifier(Modifier::BOLD),
+        }
     }
 
     pub fn clarification() -> Style {
-        fg(Color::Magenta)
+        match palette() {
+            Some(p) => fg(p.focus),
+            None => Style::default().add_modifier(Modifier::BOLD),
+        }
     }
 
     pub fn error() -> Style {
-        fg(Color::Red)
+        match palette() {
+            Some(p) => fg(p.error),
+            None => Style::default().add_modifier(Modifier::BOLD),
+        }
     }
 
     pub fn status_bar() -> Style {
-        fg(Color::Gray)
+        Theme::dim()
+    }
+
+    /// Lime/active accent — focused control, brand mark, progress.
+    pub fn active() -> Style {
+        match palette() {
+            Some(p) => fg_mod(p.active, Modifier::BOLD),
+            None => Style::default().add_modifier(Modifier::BOLD),
+        }
     }
 
     pub fn input_prompt() -> Style {
-        fg_mod(Color::Green, Modifier::BOLD)
+        Theme::active()
     }
 
     /// Highlight style for mouse-selected text in the transcript.
     pub fn selection() -> Style {
         Style::default().add_modifier(Modifier::REVERSED)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_color_disables_ansi() {
+        assert_eq!(
+            resolve_host_appearance(HostThemeMode::Dark, true),
+            ThemeAppearance::NoColor
+        );
+        assert_eq!(
+            resolve_host_appearance(HostThemeMode::NoColor, false),
+            ThemeAppearance::NoColor
+        );
+    }
+
+    #[test]
+    fn light_theme_sets_appearance() {
+        assert_eq!(
+            resolve_host_appearance(HostThemeMode::Light, false),
+            ThemeAppearance::Light
+        );
+        assert_eq!(
+            resolve_host_appearance(HostThemeMode::Dark, false),
+            ThemeAppearance::Dark
+        );
+    }
+
+    #[test]
+    fn resolve_respects_explicit_modes() {
+        assert_eq!(
+            resolve_host_appearance(HostThemeMode::Dark, false),
+            ThemeAppearance::Dark
+        );
+        assert_eq!(
+            resolve_host_appearance(HostThemeMode::Light, false),
+            ThemeAppearance::Light
+        );
+        assert_eq!(
+            resolve_host_appearance(HostThemeMode::Auto, true),
+            ThemeAppearance::NoColor
+        );
+    }
+
+    #[test]
+    fn init_from_host_applies_no_color() {
+        init_from_host(HostThemeMode::Dark, true);
+        assert!(!uses_ansi_color());
+        assert_eq!(current_appearance(), ThemeAppearance::NoColor);
+        // Restore a colored dark default for other single-threaded callers.
+        init_from_host(HostThemeMode::Dark, false);
+        assert!(uses_ansi_color());
     }
 }

--- a/src/channels/tty_prompt.rs
+++ b/src/channels/tty_prompt.rs
@@ -1,0 +1,60 @@
+//! Interactive approval prompts against the controlling terminal (`/dev/tty` / `CONIN$`).
+
+use std::io::{self, BufRead, Write};
+
+/// Open the process-controlling terminal for interactive prompts even when stdin/stdout are pipes.
+pub fn open_tty() -> io::Result<(Box<dyn Write + Send>, Box<dyn BufRead + Send>)> {
+    #[cfg(unix)]
+    {
+        use std::fs::OpenOptions;
+        let writer = OpenOptions::new().write(true).open("/dev/tty")?;
+        let reader = OpenOptions::new().read(true).open("/dev/tty")?;
+        Ok((
+            Box::new(io::BufWriter::new(writer)),
+            Box::new(io::BufReader::new(reader)),
+        ))
+    }
+    #[cfg(windows)]
+    {
+        use std::fs::OpenOptions;
+        let writer = OpenOptions::new().write(true).open("CONOUT$")?;
+        let reader = OpenOptions::new().read(true).open("CONIN$")?;
+        Ok((
+            Box::new(io::BufWriter::new(writer)),
+            Box::new(io::BufReader::new(reader)),
+        ))
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "no controlling TTY API on this platform",
+        ))
+    }
+}
+
+/// Returns true when a controlling TTY can be opened for interactive approval.
+pub fn tty_available() -> bool {
+    open_tty().is_ok()
+}
+
+/// Print `prompt` to the controlling TTY and read one line of reply.
+pub fn prompt_on_tty(prompt: &str) -> io::Result<String> {
+    let (mut writer, mut reader) = open_tty()?;
+    write!(writer, "{prompt}")?;
+    writer.flush()?;
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    Ok(line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tty_probe_does_not_panic() {
+        // In CI / sandboxes /dev/tty may be absent; just ensure the probe is safe.
+        let _ = tty_available();
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -492,11 +492,10 @@ impl AppConfig {
                     };
                     if result.contains_key(model) {
                         warn!(
-                            "Duplicate model name \"{}\" in [providers.{}] -- \
+                            "Duplicate model name \"{model}\" in [providers.{key}] -- \
                              overwriting previous entry. Use the legacy per-model \
                              format with unique map keys to distinguish the same \
-                             model from different providers.",
-                            model, key
+                             model from different providers."
                         );
                     }
                     result.insert(model.clone(), expanded);
@@ -509,18 +508,16 @@ impl AppConfig {
                 single.models = None;
                 if result.contains_key(key) {
                     warn!(
-                        "Duplicate provider key \"{}\" in [providers] -- \
-                         overwriting previous entry.",
-                        key
+                        "Duplicate provider key \"{key}\" in [providers] -- \
+                         overwriting previous entry."
                     );
                 }
                 result.insert(key.clone(), single);
             } else {
                 warn!(
-                    "[providers.{}] has neither \"models\" nor \
+                    "[providers.{key}] has neither \"models\" nor \
                      \"model_name\" -- entry is ignored. Add one to \
-                     register a provider.",
-                    key
+                     register a provider."
                 );
             }
         }
@@ -995,7 +992,7 @@ impl AppConfig {
                 allow.map(|s| s.len()).unwrap_or(0)
             ));
             let agent_count = self.agent_definitions().len();
-            lines.push(format!("named_agents={}", agent_count));
+            lines.push(format!("named_agents={agent_count}"));
         }
         lines.push(format!(
             "ml_engineer_harness_enabled={}",
@@ -1024,8 +1021,7 @@ impl AppConfig {
             .and_then(|x| x.steering.as_ref())
             .is_some_and(|s| s.enabled.unwrap_or(false));
         lines.push(format!(
-            "hooks_observation_enabled={} hooks_steering_enabled={}",
-            hooks_obs, hooks_steer
+            "hooks_observation_enabled={hooks_obs} hooks_steering_enabled={hooks_steer}"
         ));
         lines
     }
@@ -1515,8 +1511,7 @@ impl ProviderConfig {
             }
         }
         Err(format!(
-            "No API key found (checked env ${} and config api_key)",
-            env_var
+            "No API key found (checked env ${env_var} and config api_key)"
         ))
     }
 

--- a/src/execution/execution_jobs.rs
+++ b/src/execution/execution_jobs.rs
@@ -640,11 +640,10 @@ impl ExecutionJobManager {
                         .filter(|s| !s.is_empty())
                     {
                         Some(d) => {
-                            format!("{} — completed (exit {}, {} ms)", d, exit_s, duration_ms)
+                            format!("{d} — completed (exit {exit_s}, {duration_ms} ms)")
                         }
                         None => format!(
-                            "Execution job {} completed (exit {}, {} ms)",
-                            job_id_for_task, exit_s, duration_ms
+                            "Execution job {job_id_for_task} completed (exit {exit_s}, {duration_ms} ms)"
                         ),
                     };
                     let notice = build_execution_job_notice(
@@ -686,8 +685,7 @@ impl ExecutionJobManager {
                         warn!("execution_jobs audit: {e}");
                     }
                     info!(
-                        "execution_job_done job={} session={} provider={} status=completed",
-                        job_id_for_task, sid_spawn, prov
+                        "execution_job_done job={job_id_for_task} session={sid_spawn} provider={prov} status=completed"
                     );
                 }
                 Err(e) => {
@@ -724,7 +722,7 @@ impl ExecutionJobManager {
                         .map(str::trim)
                         .filter(|s| !s.is_empty())
                     {
-                        Some(d) => format!("{} — {status_label} ({es})", d),
+                        Some(d) => format!("{d} — {status_label} ({es})"),
                         None => format!("Execution job {job_id_for_task}: {status_label} ({es})"),
                     };
                     let notice = build_execution_job_notice(
@@ -766,8 +764,7 @@ impl ExecutionJobManager {
                         warn!("execution_jobs audit: {log_e}");
                     }
                     info!(
-                        "execution_job_done job={} session={} provider={} status={}",
-                        job_id_for_task, sid_spawn, prov, status_label
+                        "execution_job_done job={job_id_for_task} session={sid_spawn} provider={prov} status={status_label}"
                     );
                 }
             }
@@ -1115,10 +1112,9 @@ async fn finalize_arbitrary_job(p: FinalizeArbitraryParams) {
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
             {
-                Some(d) => format!("{} - completed (exit {}, {} ms)", d, exit_s, duration_ms),
+                Some(d) => format!("{d} - completed (exit {exit_s}, {duration_ms} ms)"),
                 None => format!(
-                    "{} job {} completed (exit {}, {} ms)",
-                    tool_name, job_id, exit_s, duration_ms
+                    "{tool_name} job {job_id} completed (exit {exit_s}, {duration_ms} ms)"
                 ),
             };
             let notice = build_execution_job_notice(
@@ -1160,8 +1156,7 @@ async fn finalize_arbitrary_job(p: FinalizeArbitraryParams) {
                 warn!("execution_jobs audit: {e}");
             }
             info!(
-                "execution_job_done job={} session={} provider={} status=completed tool={}",
-                job_id, sid, provider_id, tool_name
+                "execution_job_done job={job_id} session={sid} provider={provider_id} status=completed tool={tool_name}"
             );
         }
         Err(e) => {
@@ -1198,7 +1193,7 @@ async fn finalize_arbitrary_job(p: FinalizeArbitraryParams) {
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
             {
-                Some(d) => format!("{} - {status_label} ({es})", d),
+                Some(d) => format!("{d} - {status_label} ({es})"),
                 None => format!("{tool_name} job {job_id}: {status_label} ({es})"),
             };
             let notice = build_execution_job_notice(
@@ -1240,8 +1235,7 @@ async fn finalize_arbitrary_job(p: FinalizeArbitraryParams) {
                 warn!("execution_jobs audit: {log_e}");
             }
             info!(
-                "execution_job_done job={} session={} provider={} status={} tool={}",
-                job_id, sid, provider_id, status_label, tool_name
+                "execution_job_done job={job_id} session={sid} provider={provider_id} status={status_label} tool={tool_name}"
             );
         }
     }

--- a/src/execution/harness.rs
+++ b/src/execution/harness.rs
@@ -65,8 +65,7 @@ impl ExecutionHarness {
     ) -> Self {
         debug_assert!(
             providers.contains_key(&default_provider_id),
-            "default_provider_id {} must be a key in providers",
-            default_provider_id
+            "default_provider_id {default_provider_id} must be a key in providers"
         );
         Self {
             providers,

--- a/src/execution/jupyter.rs
+++ b/src/execution/jupyter.rs
@@ -310,9 +310,7 @@ async fn connect_kernel_channels_ws(url: &str) -> Result<ExecWsStream, Execution
         }
         Err(e1) => {
             log::debug!(
-                "jupyter kernel ws connect with {} failed: {}; retrying without subprotocol",
-                JUPYTER_KERNEL_WS_SUBPROTOCOL,
-                e1
+                "jupyter kernel ws connect with {JUPYTER_KERNEL_WS_SUBPROTOCOL} failed: {e1}; retrying without subprotocol"
             );
             let (ws, _) = connect_async(url).await.map_err(|e2| {
                 ExecutionError::Provider(format!(
@@ -535,7 +533,7 @@ impl ExecutionProvider for JupyterExecutionProvider {
             )
             .await;
             if let Err(e) = r {
-                log::warn!("jupyter notebook sync {}: {}", path, e);
+                log::warn!("jupyter notebook sync {path}: {e}");
             }
         }
 

--- a/src/hooks/context.rs
+++ b/src/hooks/context.rs
@@ -46,7 +46,7 @@ impl ToolCallHookContext {
             match build_steering_engine(s, workspace_dir.to_path_buf(), sandbox_dir.to_path_buf()) {
                 Ok(e) => Some(e),
                 Err(e) => {
-                    log::error!("hooks steering init failed: {}", e);
+                    log::error!("hooks steering init failed: {e}");
                     None
                 }
             }

--- a/src/hooks/observation.rs
+++ b/src/hooks/observation.rs
@@ -75,13 +75,13 @@ pub fn start_observation_hooks(params: ObservationHooksParams) -> Option<Observa
             redactor.redact_json(&mut envelope);
             if let Some(ref path) = jsonl_path {
                 if let Err(e) = append_jsonl(path, &envelope).await {
-                    log::warn!("hooks observation jsonl: {}", e);
+                    log::warn!("hooks observation jsonl: {e}");
                 }
             }
             if let Some(ref url) = webhook_url {
                 if let Some(ref c) = client {
                     if let Err(e) = post_webhook(c, url, &hmac_secret, &envelope).await {
-                        log::warn!("hooks observation webhook: {}", e);
+                        log::warn!("hooks observation webhook: {e}");
                     }
                 }
             }
@@ -135,13 +135,13 @@ async fn append_jsonl(path: &Path, envelope: &Value) -> Result<(), String> {
         .open(path)
         .await
         .map_err(|e| format!("open {}: {}", path.display(), e))?;
-    let line = serde_json::to_string(envelope).map_err(|e| format!("encode: {}", e))?;
+    let line = serde_json::to_string(envelope).map_err(|e| format!("encode: {e}"))?;
     file.write_all(line.as_bytes())
         .await
-        .map_err(|e| format!("write: {}", e))?;
+        .map_err(|e| format!("write: {e}"))?;
     file.write_all(b"\n")
         .await
-        .map_err(|e| format!("write nl: {}", e))?;
+        .map_err(|e| format!("write nl: {e}"))?;
     Ok(())
 }
 
@@ -173,14 +173,14 @@ async fn post_webhook(
     envelope: &Value,
 ) -> Result<(), String> {
     const MAX_ATTEMPTS: usize = 3;
-    let body = serde_json::to_vec(envelope).map_err(|e| format!("encode body: {}", e))?;
+    let body = serde_json::to_vec(envelope).map_err(|e| format!("encode body: {e}"))?;
 
     for attempt in 0..MAX_ATTEMPTS {
         let mut req = client.post(url).body(body.clone());
         if let Some(secret) = hmac_secret {
             if !secret.is_empty() {
                 let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
-                    .map_err(|e| format!("hmac key: {}", e))?;
+                    .map_err(|e| format!("hmac key: {e}"))?;
                 mac.update(&body);
                 let sig = hex::encode(mac.finalize().into_bytes());
                 req = req.header("X-Isanagent-Hook-Signature", format!("sha256={sig}"));
@@ -195,7 +195,7 @@ async fn post_webhook(
             }
             Err(err) => {
                 if attempt + 1 >= MAX_ATTEMPTS {
-                    return Err(format!("webhook request: {}", err));
+                    return Err(format!("webhook request: {err}"));
                 }
             }
         }

--- a/src/hooks/steering.rs
+++ b/src/hooks/steering.rs
@@ -101,7 +101,7 @@ async fn read_bounded<R: tokio::io::AsyncRead + Unpin>(
         let n = reader
             .read(&mut chunk)
             .await
-            .map_err(|e| format!("read hook output: {}", e))?;
+            .map_err(|e| format!("read hook output: {e}"))?;
         if n == 0 {
             break;
         }
@@ -147,13 +147,13 @@ async fn run_hook_command(
         })
         .kill_on_drop(true)
         .spawn()
-        .map_err(|e| format!("spawn hook: {}", e))?;
+        .map_err(|e| format!("spawn hook: {e}"))?;
 
     let mut stdin = child
         .stdin
         .take()
         .ok_or_else(|| "hook stdin missing".to_string())?;
-    let body = serde_json::to_vec(stdin_json).map_err(|e| format!("hook stdin encode: {}", e))?;
+    let body = serde_json::to_vec(stdin_json).map_err(|e| format!("hook stdin encode: {e}"))?;
     // A hook that ignores its stdin and exits (a bare `cargo build` / `pytest`, or any verify hook
     // that reads the event from argv/env instead) closes its stdin read end before — or while — we
     // write. On Linux that surfaces here as `BrokenPipe`; on macOS the small event JSON usually fits
@@ -163,7 +163,7 @@ async fn run_hook_command(
     // fine — swallow BrokenPipe and proceed to capture its output and exit status.
     if let Err(e) = tokio::io::AsyncWriteExt::write_all(&mut stdin, &body).await {
         if e.kind() != std::io::ErrorKind::BrokenPipe {
-            return Err(format!("hook stdin write: {}", e));
+            return Err(format!("hook stdin write: {e}"));
         }
     }
     drop(stdin);
@@ -192,7 +192,7 @@ async fn run_hook_command(
     .await
     .map_err(|_| "hook timed out".to_string())?;
 
-    let status = status.map_err(|e| format!("hook wait: {}", e))?;
+    let status = status.map_err(|e| format!("hook wait: {e}"))?;
     let out = out?;
 
     // Join stdout + stderr (stderr is empty unless `capture_failure` piped it).
@@ -232,7 +232,7 @@ async fn run_hook_command(
 
 fn parse_pre_tool_stdout(text: &str) -> Result<PreToolOutcome, String> {
     let v: HookStdoutEnvelope =
-        serde_json::from_str(text).map_err(|e| format!("hook json: {}", e))?;
+        serde_json::from_str(text).map_err(|e| format!("hook json: {e}"))?;
     match v
         .decision
         .as_deref()
@@ -256,13 +256,13 @@ fn parse_pre_tool_stdout(text: &str) -> Result<PreToolOutcome, String> {
                 Ok(PreToolOutcome::Proceed(Value::Null))
             }
         }
-        Some(other) => Err(format!("unknown decision {:?}", other)),
+        Some(other) => Err(format!("unknown decision {other:?}")),
     }
 }
 
 fn parse_user_prompt_stdout(text: &str) -> Result<UserPromptHookOutcome, String> {
     let v: HookStdoutEnvelope =
-        serde_json::from_str(text).map_err(|e| format!("hook json: {}", e))?;
+        serde_json::from_str(text).map_err(|e| format!("hook json: {e}"))?;
     match v
         .decision
         .as_deref()
@@ -280,7 +280,7 @@ fn parse_user_prompt_stdout(text: &str) -> Result<UserPromptHookOutcome, String>
             Ok(UserPromptHookOutcome::InjectPrefix(msg))
         }
         Some("proceed") | Some("allow") | None => Ok(UserPromptHookOutcome::Proceed),
-        Some(other) => Err(format!("unknown decision {:?}", other)),
+        Some(other) => Err(format!("unknown decision {other:?}")),
     }
 }
 
@@ -313,7 +313,7 @@ pub async fn run_pre_tool_hooks(
         let cwd = match hook_cwd(&engine.sandbox_dir, h.cwd_relative.as_deref()) {
             Ok(p) => p,
             Err(e) => {
-                log::warn!("pre_tool hook cwd: {}", e);
+                log::warn!("pre_tool hook cwd: {e}");
                 continue;
             }
         };
@@ -344,7 +344,7 @@ pub async fn run_pre_tool_hooks(
         {
             Ok(o) => o,
             Err(e) => {
-                log::warn!("pre_tool hook failed (proceeding): {}", e);
+                log::warn!("pre_tool hook failed (proceeding): {e}");
                 continue;
             }
         };
@@ -356,7 +356,7 @@ pub async fn run_pre_tool_hooks(
                     args = new_args;
                 }
             }
-            Err(e) => log::warn!("pre_tool hook stdout parse (ignored): {}", e),
+            Err(e) => log::warn!("pre_tool hook stdout parse (ignored): {e}"),
         }
     }
     PreToolOutcome::Proceed(args)
@@ -382,7 +382,7 @@ pub async fn run_post_tool_hooks(
         let cwd = match hook_cwd(&engine.sandbox_dir, h.cwd_relative.as_deref()) {
             Ok(p) => p,
             Err(e) => {
-                log::warn!("post_tool hook cwd: {}", e);
+                log::warn!("post_tool hook cwd: {e}");
                 continue;
             }
         };
@@ -416,7 +416,7 @@ pub async fn run_post_tool_hooks(
         {
             Ok(Some(out)) => outputs.push(out),
             Ok(None) => {}
-            Err(e) => log::warn!("post_tool hook failed: {}", e),
+            Err(e) => log::warn!("post_tool hook failed: {e}"),
         }
     }
     if outputs.is_empty() {
@@ -436,7 +436,7 @@ pub async fn run_user_prompt_hooks(
         let cwd = match hook_cwd(&engine.sandbox_dir, h.cwd_relative.as_deref()) {
             Ok(p) => p,
             Err(e) => {
-                log::warn!("user_prompt hook cwd: {}", e);
+                log::warn!("user_prompt hook cwd: {e}");
                 continue;
             }
         };
@@ -465,7 +465,7 @@ pub async fn run_user_prompt_hooks(
         {
             Ok(o) => o,
             Err(e) => {
-                log::warn!("user_prompt hook failed (proceeding): {}", e);
+                log::warn!("user_prompt hook failed (proceeding): {e}");
                 continue;
             }
         };
@@ -474,12 +474,12 @@ pub async fn run_user_prompt_hooks(
             Ok(UserPromptHookOutcome::Block(m)) => return UserPromptHookOutcome::Block(m),
             Ok(UserPromptHookOutcome::InjectPrefix(prefix)) => {
                 inject = Some(match inject.take() {
-                    Some(prev) => format!("{}\n{}", prev, prefix),
+                    Some(prev) => format!("{prev}\n{prefix}"),
                     None => prefix,
                 });
             }
             Ok(UserPromptHookOutcome::Proceed) => {}
-            Err(e) => log::warn!("user_prompt hook stdout parse (ignored): {}", e),
+            Err(e) => log::warn!("user_prompt hook stdout parse (ignored): {e}"),
         }
     }
     match inject {
@@ -505,7 +505,7 @@ fn compile_hook_handlers(
                 Some(pat) => match Regex::new(pat) {
                     Ok(re) => Some(re),
                     Err(e) => {
-                        log::warn!("hooks: skip invalid matcher {:?}: {}", pat, e);
+                        log::warn!("hooks: skip invalid matcher {pat:?}: {e}");
                         None
                     }
                 },

--- a/src/host.rs
+++ b/src/host.rs
@@ -18,6 +18,7 @@ use crate::channels::terminal::{
     build_tool_progress_terminal_notice, build_tool_result_terminal_notice,
     terminal_startup_suppresses_plain_banner, TerminalChannelConfig, TerminalMode,
 };
+use crate::channels::oneshot::OneshotChannel;
 use crate::channels::{
     api::ApiChannel, email::EmailChannel, slack::SlackChannel, terminal::TerminalChannel, Channel,
 };
@@ -87,12 +88,32 @@ pub struct HostConfig {
     pub permission: Option<HostPermissionMode>,
     /// Disable ANSI foreground colors while retaining terminal structure.
     pub no_color: bool,
+    /// ALTAI terminal appearance. `no_color` / `NO_COLOR` still win.
+    pub theme: HostThemeMode,
     /// Existing terminal chat identifier to load on startup.
     pub resume: Option<String>,
     /// Files preloaded into the terminal's next composed message.
     pub files: Vec<PathBuf>,
     pub line_mode: bool,
+    /// Optional override for between-turn auto-compaction (`None` = config default).
+    pub compact_auto: Option<bool>,
+    /// Optional override for the auto-compaction token threshold.
+    pub compact_threshold_tokens: Option<usize>,
+    /// Optional override for recent-summary / tail retention.
+    pub compact_tail_turns: Option<usize>,
+    /// When set, disable the interactive terminal, inject this prompt once through
+    /// the headless `altai-cli` channel, and shut down after the run terminates.
+    pub oneshot_prompt: Option<String>,
+    /// Optional observer for raw host bus messages during interactive or oneshot runs.
+    pub observe_tx: Option<mpsc::UnboundedSender<BusMessage>>,
+    /// Deterministic in-process assistant replies for tests and CI smokes.
+    /// When set, the host skips network providers and returns these responses
+    /// in order (the last response repeats).
+    pub scripted_responses: Option<Vec<String>>,
 }
+
+pub use crate::channels::oneshot::{OneshotOutcome, OneshotResult};
+pub use crate::channels::terminal_ui::HostThemeMode;
 
 /// Interactive permission modes exposed to embedding hosts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -161,7 +182,7 @@ pub fn spawn_host(config: HostConfig) -> HostHandle {
     let (events_tx, events) = mpsc::unbounded_channel();
     let task = tokio::spawn(async move {
         let _ = events_tx.send(HostEvent::Starting);
-        let result = run_host(config, Some(shutdown_rx)).await;
+        let result = run_host(config, Some(shutdown_rx), None).await;
         let outcome = match &result {
             Ok(()) => HostExit::Completed,
             Err(error) => HostExit::Failed(error.to_string()),
@@ -180,12 +201,38 @@ pub fn spawn_host(config: HostConfig) -> HostHandle {
 /// Start the complete IsanAgent runtime, including its terminal channel when
 /// enabled by the selected configuration.
 pub async fn start_host(config: HostConfig) -> HostResult<()> {
-    run_host(config, None).await
+    let _ = run_host(config, None, None).await?;
+    Ok(())
+}
+
+/// Run a single headless prompt through the shared host runtime and shut down
+/// after the matching reasoning run terminates.
+pub async fn run_oneshot(mut config: HostConfig) -> HostResult<OneshotResult> {
+    if config
+        .oneshot_prompt
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or_default()
+        .is_empty()
+    {
+        return Err(std::io::Error::other("oneshot prompt must be non-empty").into());
+    }
+    // One-shot runs never own an interactive TTY channel.
+    config.line_mode = false;
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+    let host_result = run_host(config, None, Some(result_tx)).await;
+    match result_rx.await {
+        Ok(result) => Ok(result),
+        Err(_) => Err(host_result.err().unwrap_or_else(|| {
+            std::io::Error::other("oneshot host exited without a terminal result").into()
+        })),
+    }
 }
 
 async fn run_host(
     config: HostConfig,
     mut external_shutdown_rx: Option<mpsc::UnboundedReceiver<()>>,
+    oneshot_result_tx: Option<tokio::sync::oneshot::Sender<OneshotResult>>,
 ) -> HostResult<()> {
     let workspace_arg = config
         .workspace
@@ -232,7 +279,16 @@ async fn run_host(
             }
         })?;
 
-    println!("Starting Advanced isanagent System...");
+    let oneshot_mode = config
+        .oneshot_prompt
+        .as_ref()
+        .map(|prompt| prompt.trim())
+        .is_some_and(|prompt| !prompt.is_empty());
+    if oneshot_mode {
+        eprintln!("Starting Advanced isanagent System...");
+    } else {
+        println!("Starting Advanced isanagent System...");
+    }
     log::info!("Starting Advanced isanagent System.");
 
     let mut workspace = IsanagentWorkspace::new_with_sandbox(
@@ -241,10 +297,24 @@ async fn run_host(
         sandbox,
     )?;
     apply_host_overrides(&mut workspace.config, &config).map_err(std::io::Error::other)?;
-    println!("Loading isanagent workspace at: {:?}", workspace.dir);
+    let oneshot_prompt = config
+        .oneshot_prompt
+        .as_ref()
+        .map(|prompt| prompt.trim().to_string())
+        .filter(|prompt| !prompt.is_empty());
+    if oneshot_mode {
+        // One-shot hosts never attach the interactive terminal channel.
+        let terminal = workspace.config.terminal.get_or_insert_with(Default::default);
+        terminal.enabled = Some(false);
+        eprintln!("Loading isanagent workspace at: {:?}", workspace.dir);
+    } else {
+        println!("Loading isanagent workspace at: {:?}", workspace.dir);
+    }
     log::info!("Loading isanagent workspace at {:?}", workspace.dir);
 
-    if !workspace.config.terminal_enabled() && !workspace.config.has_non_terminal_inbound_channel()
+    if oneshot_prompt.is_none()
+        && !workspace.config.terminal_enabled()
+        && !workspace.config.has_non_terminal_inbound_channel()
     {
         return Err(std::io::Error::other(
             "Invalid config: [terminal] enabled = false requires at least one other inbound channel. \
@@ -253,7 +323,9 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         .into());
     }
 
-    maybe_prompt_uv_install_on_launch(&workspace).await;
+    if !oneshot_mode {
+        maybe_prompt_uv_install_on_launch(&workspace).await;
+    }
 
     // 1. Setup SqliteMemoryActor and SessionManager
     let db_path = workspace
@@ -602,7 +674,13 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         Box<dyn crate::traits::Provider>,
         Box<dyn crate::traits::Provider>,
         Vec<crate::agent::FallbackProviderSpec>,
-    ) = if let (Some(cfg), Some(key)) = (&provider_cfg, &api_key) {
+    ) = if let Some(responses) = config.scripted_responses.clone() {
+        (
+            Box::new(crate::provider::ScriptedProvider::new(responses.clone())),
+            Box::new(crate::provider::ScriptedProvider::new(responses)),
+            Vec::new(),
+        )
+    } else if let (Some(cfg), Some(key)) = (&provider_cfg, &api_key) {
         let base_url = cfg.resolved_base_url().map_err(std::io::Error::other)?;
         let p1 = crate::provider::create_provider(&cfg.provider_name, &base_url, key, &model_name);
         let p2 = crate::provider::create_provider(&cfg.provider_name, &base_url, key, &model_name);
@@ -727,7 +805,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
 
     // 7. Create Agent Logic
     let max_iterations = workspace.config.resolved_max_iterations().unwrap_or(50);
-    let max_recent_summaries = workspace
+    let mut max_recent_summaries = workspace
         .config
         .memory
         .as_ref()
@@ -739,12 +817,20 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         .as_ref()
         .and_then(|m| m.short_term_threshold_turns)
         .unwrap_or(20);
-    let short_term_threshold_tokens = workspace
+    let mut short_term_threshold_tokens = workspace
         .config
         .memory
         .as_ref()
         .and_then(|m| m.short_term_threshold_tokens)
         .unwrap_or(100000);
+    if config.compact_auto == Some(false) {
+        short_term_threshold_tokens = usize::MAX;
+    } else if let Some(tokens) = config.compact_threshold_tokens {
+        short_term_threshold_tokens = tokens.max(8_000);
+    }
+    if let Some(tail) = config.compact_tail_turns {
+        max_recent_summaries = tail.max(1);
+    }
     let tool_execution_activity = if multi_tenant_edge_cfg
         .activity_heartbeat_enabled
         .unwrap_or(false)
@@ -858,6 +944,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             workspace_dir: workspace.dir.clone(),
             sandbox_dir: workspace.sandbox_dir.clone(),
             status_model: model_name.clone(),
+            status_permission: host_permission_label(config.permission),
             memory_node: memory_node.clone(),
             providers: {
                 // Merge default [provider] + expanded [providers.*] into one map for /model selector
@@ -868,7 +955,8 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                 }
                 all_providers
             },
-            color_enabled: !config.no_color,
+            color_enabled: !config.no_color && config.theme != HostThemeMode::NoColor,
+            theme: config.theme,
             resume_session: config.resume.is_some(),
             initial_files: config.files.clone(),
             mode: if config.line_mode {
@@ -882,6 +970,50 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         Some(id)
     } else {
         log::info!("Terminal channel disabled via config; stdin will not be read.");
+        None
+    };
+
+    let oneshot_channel = if let Some(prompt) = oneshot_prompt.clone() {
+        let result_tx = oneshot_result_tx.ok_or_else(|| {
+            std::io::Error::other("oneshot prompt requires run_oneshot or an explicit result channel")
+        })?;
+        let id = config
+            .resume
+            .as_deref()
+            .filter(|id| !id.trim().is_empty())
+            .map(str::to_owned)
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let (attachments, attach_warnings) =
+            crate::channels::terminal_ui::load_host_file_attachments(
+                &workspace.sandbox_dir,
+                &config.files,
+            );
+        for warning in attach_warnings {
+            log::warn!("oneshot attachment: {warning}");
+            let _ = logger_bus_tx.send(BusMessage::Log(crate::bus::LogEvent::warn(
+                "altai-cli",
+                &warning,
+            )));
+        }
+        let channel = Arc::new(OneshotChannel::new(
+            id,
+            prompt,
+            config.files.clone(),
+            attachments,
+            result_tx,
+            shutdown_tx.clone(),
+            config.observe_tx.clone(),
+        ));
+        channel.start(bus_tx.clone()).await?;
+        out_channels.insert(channel.name().to_string(), channel.clone());
+        Some(channel)
+    } else {
+        if oneshot_result_tx.is_some() {
+            return Err(std::io::Error::other(
+                "oneshot result channel provided without oneshot_prompt",
+            )
+            .into());
+        }
         None
     };
 
@@ -935,7 +1067,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     }
 
     // 14. Print clean startup banner (skipped when Ratatui owns the alternate screen)
-    if !terminal_startup_suppresses_plain_banner(&workspace.config) {
+    if !oneshot_mode && !terminal_startup_suppresses_plain_banner(&workspace.config) {
         println!(
             "\n{}",
             "=============================================".blue()
@@ -989,8 +1121,16 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     let logger_tx = logger_bus_tx.clone();
     let inflight_promote = inflight_sync_outer.clone();
     let active_terminal_session_for_bus = active_terminal_session_chat.clone();
+    let oneshot_for_bus = oneshot_channel.clone();
+    let observe_tx = config.observe_tx.clone();
     tokio::spawn(async move {
         while let Some(msg) = bus_rx.recv().await {
+            if let Some(tx) = observe_tx.as_ref() {
+                let _ = tx.send(msg.clone());
+            }
+            if let Some(oneshot) = oneshot_for_bus.as_ref() {
+                oneshot.observe_bus_message(&msg);
+            }
             let _ = logger_tx.send(msg.clone());
             // Intercept /background slash commands and fire the in-flight oneshot.
             if let BusMessage::PromoteSyncToBackground(chat_id) = &msg {
@@ -1035,6 +1175,9 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                     BusMessage::Telemetry(tel) => {
                         let _ = agent_outbound_tx.send(BusMessage::Telemetry(tel)).await;
                     }
+                    lifecycle @ BusMessage::RunLifecycle(_) => {
+                        let _ = agent_outbound_tx.send(lifecycle).await;
+                    }
                     _ => {}
                 }
             }
@@ -1044,8 +1187,18 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
     let logger_tx_outbound = logger_bus_tx.clone();
     let delivery_channels = out_channels.clone();
     let active_terminal_for_outbound = active_terminal_session_chat.clone();
+    let oneshot_for_outbound = oneshot_channel.clone();
+    let observe_tx_outbound = config.observe_tx.clone();
     tokio::spawn(async move {
         while let Some(msg) = global_outbound_rx.recv().await {
+            if let Some(tx) = observe_tx_outbound.as_ref() {
+                let _ = tx.send(msg.clone());
+            }
+            if let Some(oneshot) = oneshot_for_outbound.as_ref() {
+                if !matches!(&msg, BusMessage::Outbound(_)) {
+                    oneshot.observe_bus_message(&msg);
+                }
+            }
             // Deliver user-visible terminal traffic first. `LoggerHandle::send` uses a blocking
             // `sync_channel::send`; doing it before channel delivery can stall this task and make
             // tool-call lines and agent replies appear only after the run finishes.
@@ -1073,6 +1226,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                         }
                     }
                 }
+                BusMessage::RunLifecycle(_) => {}
                 BusMessage::Telemetry(TelemetryEvent::AgentThought {
                     chat_id,
                     thought,
@@ -1331,7 +1485,9 @@ fn apply_host_overrides(config: &mut AppConfig, host: &HostConfig) -> Result<(),
         let (mode, edit_mode) = match permission {
             HostPermissionMode::Ask => ("ask", "ask"),
             HostPermissionMode::AutoEdit => ("ask", "allow"),
-            HostPermissionMode::Plan => ("deny", "deny"),
+            // Match desktop: plan keeps shell at ask (read-only inspection with
+            // approval for destructive commands) while denying file edits.
+            HostPermissionMode::Plan => ("ask", "deny"),
             HostPermissionMode::Bypass => ("allow", "allow"),
         };
         shell_policy.mode = Some(mode.to_string());
@@ -1339,6 +1495,16 @@ fn apply_host_overrides(config: &mut AppConfig, host: &HostConfig) -> Result<(),
     }
 
     Ok(())
+}
+
+fn host_permission_label(permission: Option<HostPermissionMode>) -> String {
+    match permission {
+        Some(HostPermissionMode::Ask) => "ask".into(),
+        Some(HostPermissionMode::AutoEdit) => "auto-edit".into(),
+        Some(HostPermissionMode::Plan) => "plan".into(),
+        Some(HostPermissionMode::Bypass) => "bypass".into(),
+        None => "default".into(),
+    }
 }
 
 async fn wait_for_external_shutdown(receiver: &mut Option<mpsc::UnboundedReceiver<()>>) {
@@ -1663,9 +1829,13 @@ mod tests {
         assert!(config.fallback_model.is_none());
         assert!(config.permission.is_none());
         assert!(!config.no_color);
+        assert_eq!(config.theme, HostThemeMode::Auto);
         assert!(config.resume.is_none());
         assert!(config.files.is_empty());
         assert!(!config.line_mode);
+        assert!(config.oneshot_prompt.is_none());
+        assert!(config.observe_tx.is_none());
+        assert!(config.scripted_responses.is_none());
     }
 
     #[test]
@@ -1691,7 +1861,7 @@ mod tests {
         for (permission, mode, edit_mode) in [
             (HostPermissionMode::Ask, "ask", "ask"),
             (HostPermissionMode::AutoEdit, "ask", "allow"),
-            (HostPermissionMode::Plan, "deny", "deny"),
+            (HostPermissionMode::Plan, "ask", "deny"),
             (HostPermissionMode::Bypass, "allow", "allow"),
         ] {
             let mut config = AppConfig::default();
@@ -1750,9 +1920,16 @@ mod tests {
             fallback_model: None,
             permission: None,
             no_color: false,
+            theme: HostThemeMode::Auto,
             resume: None,
             files: Vec::new(),
             line_mode: false,
+            compact_auto: None,
+            compact_threshold_tokens: None,
+            compact_tail_turns: None,
+            oneshot_prompt: None,
+            observe_tx: None,
+            scripted_responses: None,
         });
         assert_eq!(host.next_event().await, Some(HostEvent::Starting));
         assert!(host.shutdown());
@@ -1770,5 +1947,46 @@ mod tests {
             .await
             .expect("host task should join")
             .expect("host should complete cleanly");
+    }
+
+    #[tokio::test]
+    async fn run_oneshot_completes_with_scripted_provider() {
+        let temp = tempfile::tempdir().expect("temporary workspace");
+        let config_path = temp.path().join("config.toml");
+        fs::write(
+            &config_path,
+            "[terminal]\nenabled = false\n\n[logging]\nenabled = false\n",
+        )
+        .expect("write config");
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(30),
+            run_oneshot(HostConfig {
+                workspace: Some(temp.path().to_path_buf()),
+                config: Some(config_path),
+                sandbox: Some(temp.path().to_path_buf()),
+                model: None,
+                fallback_model: None,
+                permission: Some(HostPermissionMode::Plan),
+                no_color: true,
+                theme: HostThemeMode::NoColor,
+                resume: None,
+                files: Vec::new(),
+                line_mode: false,
+                compact_auto: None,
+                compact_threshold_tokens: None,
+                compact_tail_turns: None,
+                oneshot_prompt: Some("reply with oneshot-ok".to_string()),
+                observe_tx: None,
+                scripted_responses: Some(vec!["oneshot-ok".to_string()]),
+            }),
+        )
+        .await
+        .expect("oneshot should finish promptly")
+        .expect("oneshot should succeed");
+
+        assert_eq!(result.outcome, OneshotOutcome::Completed);
+        assert_eq!(result.final_text.as_deref(), Some("oneshot-ok"));
+        assert!(!result.chat_id.is_empty());
     }
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -13,12 +13,12 @@ use tokio::sync::{mpsc, watch, RwLock};
 
 use crate::agent::{AgentLogic, AgentLogicParams};
 use crate::bus::{BusMessage, InboundMessage, LoggerControlMessage, TelemetryEvent};
+use crate::channels::oneshot::OneshotChannel;
 use crate::channels::terminal::{
     build_agent_thought_terminal_notice, build_tool_call_terminal_notice,
     build_tool_progress_terminal_notice, build_tool_result_terminal_notice,
     terminal_startup_suppresses_plain_banner, TerminalChannelConfig, TerminalMode,
 };
-use crate::channels::oneshot::OneshotChannel;
 use crate::channels::{
     api::ApiChannel, email::EmailChannel, slack::SlackChannel, terminal::TerminalChannel, Channel,
 };
@@ -304,7 +304,10 @@ async fn run_host(
         .filter(|prompt| !prompt.is_empty());
     if oneshot_mode {
         // One-shot hosts never attach the interactive terminal channel.
-        let terminal = workspace.config.terminal.get_or_insert_with(Default::default);
+        let terminal = workspace
+            .config
+            .terminal
+            .get_or_insert_with(Default::default);
         terminal.enabled = Some(false);
         eprintln!("Loading isanagent workspace at: {:?}", workspace.dir);
     } else {
@@ -975,7 +978,9 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
 
     let oneshot_channel = if let Some(prompt) = oneshot_prompt.clone() {
         let result_tx = oneshot_result_tx.ok_or_else(|| {
-            std::io::Error::other("oneshot prompt requires run_oneshot or an explicit result channel")
+            std::io::Error::other(
+                "oneshot prompt requires run_oneshot or an explicit result channel",
+            )
         })?;
         let id = config
             .resume

--- a/src/host.rs
+++ b/src/host.rs
@@ -201,7 +201,7 @@ pub fn spawn_host(config: HostConfig) -> HostHandle {
 /// Start the complete IsanAgent runtime, including its terminal channel when
 /// enabled by the selected configuration.
 pub async fn start_host(config: HostConfig) -> HostResult<()> {
-    let _ = run_host(config, None, None).await?;
+    run_host(config, None, None).await?;
     Ok(())
 }
 
@@ -249,7 +249,7 @@ async fn run_host(
     let (shutdown_tx, mut shutdown_rx) = mpsc::unbounded_channel::<()>();
     let (app_shutdown_tx, app_shutdown_rx) = watch::channel(false);
     init_runtime_logger(logger_bus_tx.clone()).map_err(|e| {
-        std::io::Error::other(format!("failed to initialize runtime logger: {:?}", e))
+        std::io::Error::other(format!("failed to initialize runtime logger: {e:?}"))
     })?;
 
     let logger_factory = {
@@ -342,7 +342,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         .to_str()
         .ok_or_else(|| std::io::Error::other("workspace DB path is not valid UTF-8"))?;
     let memory_actor = crate::memory::SqliteMemoryActor::new(db_path_str).map_err(|e| {
-        std::io::Error::other(format!("Failed to initialize SqliteMemoryActor: {}", e))
+        std::io::Error::other(format!("Failed to initialize SqliteMemoryActor: {e}"))
     })?;
     let memory_node = NodeHandle::<crate::memory::MemoryMessage>::new(
         memory_actor,
@@ -390,8 +390,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             .await
             .map_err(|error| {
                 std::io::Error::other(format!(
-                    "Failed to sync cron jobs to multi-tenant-edge on startup: {}",
-                    error
+                    "Failed to sync cron jobs to multi-tenant-edge on startup: {error}"
                 ))
             })?;
         Some(scheduler)
@@ -1245,7 +1244,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                         );
                         if let Some(chan) = delivery_channels.get("terminal") {
                             if let Err(e) = chan.send(notice).await {
-                                log::error!("Failed to deliver AgentThought to terminal: {}", e);
+                                log::error!("Failed to deliver AgentThought to terminal: {e}");
                             }
                         }
                     }
@@ -1282,8 +1281,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                         if let Some(chan) = delivery_channels.get("terminal") {
                             if let Err(e) = chan.send(notice).await {
                                 log::error!(
-                                    "Failed to deliver tool-progress notice to terminal: {}",
-                                    e
+                                    "Failed to deliver tool-progress notice to terminal: {e}"
                                 );
                             }
                         }
@@ -1327,8 +1325,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                         if let Some(chan) = delivery_channels.get("terminal") {
                             if let Err(e) = chan.send(notice).await {
                                 log::error!(
-                                    "Failed to deliver tool-call notice to terminal: {}",
-                                    e
+                                    "Failed to deliver tool-call notice to terminal: {e}"
                                 );
                             }
                         }
@@ -1360,8 +1357,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                         if let Some(chan) = delivery_channels.get("terminal") {
                             if let Err(e) = chan.send(notice).await {
                                 log::error!(
-                                    "Failed to deliver tool-result notice to terminal: {}",
-                                    e
+                                    "Failed to deliver tool-result notice to terminal: {e}"
                                 );
                             }
                         }
@@ -1551,9 +1547,8 @@ provider's environment, or set default_provider=\"local\" and local_python_runti
             && io::stdout().is_terminal();
         if !interactive {
             log::warn!(
-                "Execution local runtime is uv-managed but '{}' was not found on PATH. \
-Install uv manually or run /install-python from terminal mode.",
-                uv_bin
+                "Execution local runtime is uv-managed but '{uv_bin}' was not found on PATH. \
+Install uv manually or run /install-python from terminal mode."
             );
             return;
         }
@@ -1561,8 +1556,7 @@ Install uv manually or run /install-python from terminal mode.",
         let uv_bin_owned = uv_bin.to_string();
         let prompt_result = tokio::task::spawn_blocking(move || {
             println!(
-                "\nExecution runtime is set to uv-managed, but '{}' was not found on PATH.",
-                uv_bin_owned
+                "\nExecution runtime is set to uv-managed, but '{uv_bin_owned}' was not found on PATH."
             );
             println!("Install uv now? (yes/no)");
             let _ = io::stdout().flush();
@@ -1626,7 +1620,7 @@ async fn recover_background_jobs_on_startup(
     let rows = match rx.await {
         Ok(Ok(rows)) => rows,
         Ok(Err(e)) => {
-            log::error!("Failed to list background jobs for recovery: {}", e);
+            log::error!("Failed to list background jobs for recovery: {e}");
             return;
         }
         Err(_) => {
@@ -1672,8 +1666,7 @@ async fn recover_background_jobs_on_startup(
     }
     if count > 0 {
         log::info!(
-            "Successfully resumed {} background job(s) on startup.",
-            count
+            "Successfully resumed {count} background job(s) on startup."
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -570,7 +570,7 @@ where
             sender: target.sender.clone(),
         };
         if let Err(e) = self.sender.send(msg).await {
-            log::error!("Failed to wire successor: {}", e);
+            log::error!("Failed to wire successor: {e}");
         }
     }
 
@@ -640,7 +640,7 @@ where
                 sender: target_sender,
             };
             if let Err(e) = source_sender.send(msg).await {
-                error!("Failed to wire successor: {}", e);
+                error!("Failed to wire successor: {e}");
             }
         });
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -92,9 +92,17 @@ impl Log for ActorRuntimeLogger {
 
 pub fn init_runtime_logger(sender: LoggerHandle) -> Result<(), SetLoggerError> {
     let _ = LOGGER_SENDER.set(sender);
-    log::set_logger(&ACTOR_RUNTIME_LOGGER)?;
-    log::set_max_level(LevelFilter::Trace);
-    Ok(())
+    match log::set_logger(&ACTOR_RUNTIME_LOGGER) {
+        Ok(()) => {
+            log::set_max_level(LevelFilter::Trace);
+            Ok(())
+        }
+        // A prior host/test in this process may have already installed the logger.
+        Err(_) => {
+            log::set_max_level(LevelFilter::Trace);
+            Ok(())
+        }
+    }
 }
 
 fn should_capture(target: &str, level: Level) -> bool {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -31,7 +31,7 @@ impl LoggerHandle {
         // For system logs, it's better to drop a log than to dead-lock the entire agent.
         self.sender
             .try_send(msg)
-            .map_err(|e| format!("logger error: {}", e))
+            .map_err(|e| format!("logger error: {e}"))
     }
 }
 
@@ -199,7 +199,7 @@ impl LoggingActor {
     ) -> Result<Self, String> {
         let logs_dir = workspace_dir.join(".system_generated").join("logs");
         fs::create_dir_all(&logs_dir)
-            .map_err(|e| format!("Failed to create logs directory: {}", e))?;
+            .map_err(|e| format!("Failed to create logs directory: {e}"))?;
 
         let mut actor = Self {
             conversation_writer: None,
@@ -218,7 +218,7 @@ impl LoggingActor {
                 logging_config.conversation_max_bytes,
                 logging_config.retained_generations,
             )
-            .map_err(|e| format!("Failed to open conversation log: {}", e))?,
+            .map_err(|e| format!("Failed to open conversation log: {e}"))?,
         );
         actor.runtime_writer = Some(
             RotatingLineWriter::new(
@@ -226,11 +226,11 @@ impl LoggingActor {
                 logging_config.runtime_max_bytes,
                 logging_config.retained_generations,
             )
-            .map_err(|e| format!("Failed to open runtime log: {}", e))?,
+            .map_err(|e| format!("Failed to open runtime log: {e}"))?,
         );
         actor
             .enforce_total_log_cap()
-            .map_err(|e| format!("Failed to enforce diagnostic log cap: {}", e))?;
+            .map_err(|e| format!("Failed to enforce diagnostic log cap: {e}"))?;
         Ok(actor)
     }
 
@@ -337,14 +337,13 @@ impl LoggingActor {
             BusMessage::LoggerControl(_) => return,
             BusMessage::Cancel(chat_id) => LogEvent::info(
                 "BusMessage",
-                &format!("Cancel reasoning loop for chat_id={}", chat_id),
+                &format!("Cancel reasoning loop for chat_id={chat_id}"),
             )
             .with_chat_id(chat_id),
             BusMessage::CancelRun { chat_id, run_id } => LogEvent::info(
                 "BusMessage",
                 &format!(
-                    "Cancel reasoning loop for chat_id={} run_id={}",
-                    chat_id, run_id
+                    "Cancel reasoning loop for chat_id={chat_id} run_id={run_id}"
                 ),
             )
             .with_chat_id(chat_id),
@@ -352,17 +351,17 @@ impl LoggingActor {
                 chat_id, run_id, ..
             } => LogEvent::info(
                 "BusMessage",
-                &format!("Steer active run for chat_id={} run_id={}", chat_id, run_id),
+                &format!("Steer active run for chat_id={chat_id} run_id={run_id}"),
             )
             .with_chat_id(chat_id),
             BusMessage::PromoteSyncToBackground(chat_id) => LogEvent::info(
                 "BusMessage",
-                &format!("PromoteSyncToBackground requested for chat_id={}", chat_id),
+                &format!("PromoteSyncToBackground requested for chat_id={chat_id}"),
             )
             .with_chat_id(chat_id),
             BusMessage::SetTerminalSessionChat { chat_id } => LogEvent::info(
                 "BusMessage",
-                &format!("SetTerminalSessionChat chat_id={}", chat_id),
+                &format!("SetTerminalSessionChat chat_id={chat_id}"),
             )
             .with_chat_id(chat_id),
             BusMessage::SwitchModel {
@@ -372,8 +371,7 @@ impl LoggingActor {
             } => LogEvent::info(
                 "BusMessage",
                 &format!(
-                    "SwitchModel provider={} model={}",
-                    provider_name, model_name
+                    "SwitchModel provider={provider_name} model={model_name}"
                 ),
             ),
             BusMessage::TriggerCompaction {
@@ -848,8 +846,7 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
         } => LogEvent::info(
             "Telemetry",
             &format!(
-                "SubagentFinished parent={} child={} task={} status={}",
-                parent_chat_id, child_chat_id, task_id, status
+                "SubagentFinished parent={parent_chat_id} child={child_chat_id} task={task_id} status={status}"
             ),
         )
         .with_chat_id(parent_chat_id.as_str()),
@@ -863,8 +860,7 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
         } => LogEvent::info(
             "Telemetry",
             &format!(
-                "ShellPolicyDecision channel={} mode={} decision={} command={}",
-                channel, mode, decision, command_preview
+                "ShellPolicyDecision channel={channel} mode={mode} decision={decision} command={command_preview}"
             ),
         )
         .with_chat_id(chat_id),
@@ -876,8 +872,7 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
         } => LogEvent::warn(
             "Telemetry",
             &format!(
-                "ShellGrepLikeDetected channel={} command={}",
-                channel, command_preview
+                "ShellGrepLikeDetected channel={channel} command={command_preview}"
             ),
         )
         .with_chat_id(chat_id),
@@ -888,7 +883,7 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
             ..
         } => LogEvent::info(
             "Telemetry",
-            &format!("ResearchDepthNudge channel={} reason={}", channel, reason),
+            &format!("ResearchDepthNudge channel={channel} reason={reason}"),
         )
         .with_chat_id(chat_id),
         TelemetryEvent::BackgroundJobUpdated {
@@ -921,8 +916,7 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
         } => LogEvent::info(
             "Telemetry",
             &format!(
-                "NotificationCreated channel={} id={} kind={} title={}",
-                channel, notification_id, kind, title
+                "NotificationCreated channel={channel} id={notification_id} kind={kind} title={title}"
             ),
         )
         .with_chat_id(chat_id),
@@ -935,8 +929,7 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
         } => LogEvent::info(
             "Telemetry",
             &format!(
-                "NotificationUpdated channel={} id={} state={}",
-                channel, notification_id, state
+                "NotificationUpdated channel={channel} id={notification_id} state={state}"
             ),
         )
         .with_chat_id(chat_id),
@@ -950,8 +943,7 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
         } => LogEvent::info(
             "Telemetry",
             &format!(
-                "CompactionTriggered reason={:?} tokens_before={} turns_before={} tokens_after_preprocess={}",
-                reason, tokens_before, turns_before, tokens_after_preprocess
+                "CompactionTriggered reason={reason:?} tokens_before={tokens_before} turns_before={turns_before} tokens_after_preprocess={tokens_after_preprocess}"
             ),
         )
         .with_chat_id(chat_id),
@@ -965,8 +957,7 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
         } => LogEvent::info(
             "Telemetry",
             &format!(
-                "CompactionCompleted tokens={}→{} wall_ms={} summary_bytes={} completeness={:.2}",
-                tokens_before, tokens_after, wall_ms, summary_bytes, section_completeness
+                "CompactionCompleted tokens={tokens_before}→{tokens_after} wall_ms={wall_ms} summary_bytes={summary_bytes} completeness={section_completeness:.2}"
             ),
         )
         .with_chat_id(chat_id),
@@ -977,8 +968,7 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
         } => LogEvent::warn(
             "Telemetry",
             &format!(
-                "CompactionFailed reason={} tokens_at_failure={}",
-                reason, tokens_at_failure
+                "CompactionFailed reason={reason} tokens_at_failure={tokens_at_failure}"
             ),
         )
         .with_chat_id(chat_id),
@@ -990,8 +980,7 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
             let ev = LogEvent::info(
                 "Telemetry",
                 &format!(
-                    "ReflectionStarted kind={:?} inputs_consumed={}",
-                    kind, inputs_consumed
+                    "ReflectionStarted kind={kind:?} inputs_consumed={inputs_consumed}"
                 ),
             );
             match chat_id {
@@ -1008,8 +997,7 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
             let ev = LogEvent::info(
                 "Telemetry",
                 &format!(
-                    "ReflectionCompleted kind={:?} output_bytes={} wall_ms={}",
-                    kind, output_bytes, wall_ms
+                    "ReflectionCompleted kind={kind:?} output_bytes={output_bytes} wall_ms={wall_ms}"
                 ),
             );
             match chat_id {
@@ -1022,7 +1010,7 @@ fn telemetry_to_log_event(telemetry: &TelemetryEvent) -> LogEvent {
             tool_call_id,
         } => LogEvent::info(
             "Telemetry",
-            &format!("ToolResultRefetch tool_call_id={}", tool_call_id),
+            &format!("ToolResultRefetch tool_call_id={tool_call_id}"),
         )
         .with_chat_id(chat_id),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,7 +217,7 @@ async fn run_isanagent_legacy(
     let (shutdown_tx, mut shutdown_rx) = mpsc::unbounded_channel::<()>();
     let (app_shutdown_tx, app_shutdown_rx) = watch::channel(false);
     init_runtime_logger(logger_bus_tx.clone()).map_err(|e| {
-        std::io::Error::other(format!("failed to initialize runtime logger: {:?}", e))
+        std::io::Error::other(format!("failed to initialize runtime logger: {e:?}"))
     })?;
 
     let logger_factory = {
@@ -277,7 +277,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
         .to_str()
         .ok_or_else(|| std::io::Error::other("workspace DB path is not valid UTF-8"))?;
     let memory_actor = isanagent::memory::SqliteMemoryActor::new(db_path_str).map_err(|e| {
-        std::io::Error::other(format!("Failed to initialize SqliteMemoryActor: {}", e))
+        std::io::Error::other(format!("Failed to initialize SqliteMemoryActor: {e}"))
     })?;
     let memory_node = NodeHandle::<isanagent::memory::MemoryMessage>::new(
         memory_actor,
@@ -325,8 +325,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             .await
             .map_err(|error| {
                 std::io::Error::other(format!(
-                    "Failed to sync cron jobs to multi-tenant-edge on startup: {}",
-                    error
+                    "Failed to sync cron jobs to multi-tenant-edge on startup: {error}"
                 ))
             })?;
         Some(scheduler)
@@ -1095,7 +1094,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                         );
                         if let Some(chan) = delivery_channels.get("terminal") {
                             if let Err(e) = chan.send(notice).await {
-                                log::error!("Failed to deliver AgentThought to terminal: {}", e);
+                                log::error!("Failed to deliver AgentThought to terminal: {e}");
                             }
                         }
                     }
@@ -1132,8 +1131,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                         if let Some(chan) = delivery_channels.get("terminal") {
                             if let Err(e) = chan.send(notice).await {
                                 log::error!(
-                                    "Failed to deliver tool-progress notice to terminal: {}",
-                                    e
+                                    "Failed to deliver tool-progress notice to terminal: {e}"
                                 );
                             }
                         }
@@ -1177,8 +1175,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                         if let Some(chan) = delivery_channels.get("terminal") {
                             if let Err(e) = chan.send(notice).await {
                                 log::error!(
-                                    "Failed to deliver tool-call notice to terminal: {}",
-                                    e
+                                    "Failed to deliver tool-call notice to terminal: {e}"
                                 );
                             }
                         }
@@ -1210,8 +1207,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                         if let Some(chan) = delivery_channels.get("terminal") {
                             if let Err(e) = chan.send(notice).await {
                                 log::error!(
-                                    "Failed to deliver tool-result notice to terminal: {}",
-                                    e
+                                    "Failed to deliver tool-result notice to terminal: {e}"
                                 );
                             }
                         }
@@ -1314,9 +1310,8 @@ provider's environment, or set default_provider=\"local\" and local_python_runti
             && io::stdout().is_terminal();
         if !interactive {
             log::warn!(
-                "Execution local runtime is uv-managed but '{}' was not found on PATH. \
-Install uv manually or run /install-python from terminal mode.",
-                uv_bin
+                "Execution local runtime is uv-managed but '{uv_bin}' was not found on PATH. \
+Install uv manually or run /install-python from terminal mode."
             );
             return;
         }
@@ -1324,8 +1319,7 @@ Install uv manually or run /install-python from terminal mode.",
         let uv_bin_owned = uv_bin.to_string();
         let prompt_result = tokio::task::spawn_blocking(move || {
             println!(
-                "\nExecution runtime is set to uv-managed, but '{}' was not found on PATH.",
-                uv_bin_owned
+                "\nExecution runtime is set to uv-managed, but '{uv_bin_owned}' was not found on PATH."
             );
             println!("Install uv now? (yes/no)");
             let _ = io::stdout().flush();
@@ -1389,7 +1383,7 @@ async fn recover_background_jobs_on_startup(
     let rows = match rx.await {
         Ok(Ok(rows)) => rows,
         Ok(Err(e)) => {
-            log::error!("Failed to list background jobs for recovery: {}", e);
+            log::error!("Failed to list background jobs for recovery: {e}");
             return;
         }
         Err(_) => {
@@ -1435,8 +1429,7 @@ async fn recover_background_jobs_on_startup(
     }
     if count > 0 {
         log::info!(
-            "Successfully resumed {} background job(s) on startup.",
-            count
+            "Successfully resumed {count} background job(s) on startup."
         );
     }
 }
@@ -1592,9 +1585,9 @@ async fn run_skills(
     match args.command {
         SkillCommands::Add { repo_url, skill } => {
             if let Some(ref name) = skill {
-                println!("Adding skill '{}' from {}...", name, repo_url);
+                println!("Adding skill '{name}' from {repo_url}...");
             } else {
-                println!("Adding all skills from {}...", repo_url);
+                println!("Adding all skills from {repo_url}...");
             }
             match skills
                 .install_skills_from_repo(&repo_url, skill.as_deref())
@@ -1606,12 +1599,12 @@ async fn run_skills(
                     } else {
                         println!("Successfully installed {} skills:", installed.len());
                         for name in installed {
-                            println!("  - {}", name);
+                            println!("  - {name}");
                         }
                     }
                 }
                 Err(e) => {
-                    return Err(format!("Error installing skills: {}", e).into());
+                    return Err(format!("Error installing skills: {e}").into());
                 }
             }
         }
@@ -1727,8 +1720,7 @@ fn print_onboarding_report(
     match api_key_env {
         Some(env) => {
             println!(
-                "1. Ensure {} is set in your environment (see config.toml provider.api_key_env)",
-                env
+                "1. Ensure {env} is set in your environment (see config.toml provider.api_key_env)"
             );
         }
         None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,14 +199,7 @@ async fn start_embedded_host(
     isanagent::host::start_host(isanagent::host::HostConfig {
         workspace: workspace_arg.map(std::path::PathBuf::from),
         config: config_arg.map(std::path::PathBuf::from),
-        sandbox: None,
-        model: None,
-        fallback_model: None,
-        permission: None,
-        no_color: false,
-        resume: None,
-        files: Vec::new(),
-        line_mode: false,
+        ..Default::default()
     })
     .await
     .map_err(std::io::Error::other)?;
@@ -876,6 +869,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
             workspace_dir: workspace.dir.clone(),
             sandbox_dir: workspace.sandbox_dir.clone(),
             status_model: model_name.clone(),
+            status_permission: "default".into(),
             memory_node: memory_node.clone(),
             providers: {
                 // Merge default [provider] + expanded [providers.*] into one map for /model selector
@@ -887,6 +881,7 @@ Enable [api], [slack], or [email] (with enabled = true) so the agent can receive
                 all_providers
             },
             color_enabled: !matches!(std::env::var_os("NO_COLOR"), Some(value) if !value.is_empty()),
+            theme: isanagent::host::HostThemeMode::Auto,
             resume_session: false,
             initial_files: Vec::new(),
             mode: TerminalMode::Tui,

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -169,7 +169,7 @@ fn truncate_thread_preview_line(text: &str) -> String {
     let mut iter = line.chars();
     let chunk: String = iter.by_ref().take(THREAD_PREVIEW_MAX_CHARS).collect();
     if iter.next().is_some() {
-        format!("{}…", chunk)
+        format!("{chunk}…")
     } else {
         chunk
     }
@@ -399,7 +399,7 @@ fn todo_replace_sqlite_conn(
     chat_id: &str,
     items: &[TodoRow],
 ) -> Result<(), String> {
-    let json = serde_json::to_string(items).map_err(|e| format!("serialize todo items: {}", e))?;
+    let json = serde_json::to_string(items).map_err(|e| format!("serialize todo items: {e}"))?;
     let now = Utc::now().timestamp_millis();
     conn.execute(
         "INSERT INTO harness_todos (chat_id, items_json, updated_at_ms) VALUES (?1, ?2, ?3)
@@ -408,7 +408,7 @@ fn todo_replace_sqlite_conn(
            updated_at_ms = excluded.updated_at_ms",
         params![chat_id, json, now],
     )
-    .map_err(|e| format!("upsert harness_todos: {}", e))?;
+    .map_err(|e| format!("upsert harness_todos: {e}"))?;
     Ok(())
 }
 
@@ -420,12 +420,12 @@ fn todo_load_sqlite_conn(conn: &Connection, chat_id: &str) -> Result<Option<Vec<
             |row| row.get(0),
         )
         .optional()
-        .map_err(|e| format!("select harness_todos: {}", e))?;
+        .map_err(|e| format!("select harness_todos: {e}"))?;
     match out {
         None => Ok(None),
         Some(s) => {
             let items: Vec<TodoRow> =
-                serde_json::from_str(&s).map_err(|e| format!("parse todo items: {}", e))?;
+                serde_json::from_str(&s).map_err(|e| format!("parse todo items: {e}"))?;
             Ok(Some(items))
         }
     }
@@ -871,7 +871,7 @@ impl SqliteMemoryActor {
 
             Ok(conn)
         })()
-        .map_err(|e| format!("SQLite init ({}): {}", db_path, e))?;
+        .map_err(|e| format!("SQLite init ({db_path}): {e}"))?;
 
         Ok(Self { conn })
     }
@@ -1269,7 +1269,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                          WHERE thread_id LIKE ?1 ORDER BY created_at DESC LIMIT ?2"
                     ).map_err(|e| e.to_string())?;
 
-                    let pattern = format!("{}%", thread_id);
+                    let pattern = format!("{thread_id}%");
                     let limit_i64 = limit as i64;
                     let rows = stmt
                         .query_map(params![pattern, limit_i64], |row| {
@@ -1278,8 +1278,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                             let knowledge_gaps: String = row.get(2)?;
                             let created_at: String = row.get(3)?;
                             Ok(format!(
-                                "[{}] Summary: {}\nKey Info: {}\nGaps: {}",
-                                created_at, summary, key_info, knowledge_gaps
+                                "[{created_at}] Summary: {summary}\nKey Info: {key_info}\nGaps: {knowledge_gaps}"
                             ))
                         })
                         .map_err(|e| e.to_string())?;
@@ -1333,7 +1332,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                         rows.collect::<Result<Vec<_>, _>>()
                             .map_err(|e| e.to_string())?
                     } else {
-                        let pattern = format!("{}%", thread_id);
+                        let pattern = format!("{thread_id}%");
                         let rows = stmt
                             .query_map(params![pattern, limit_i64], summary_mapper)
                             .map_err(|e| e.to_string())?;
@@ -1408,7 +1407,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                             let sid: String = row.get(0)?;
                             let sum: String = row.get(1)?;
                             let key: String = row.get(2)?;
-                            Ok(format!("Thread [{}]: {}\nKey Info: {}", sid, sum, key))
+                            Ok(format!("Thread [{sid}]: {sum}\nKey Info: {key}"))
                         })
                         .map_err(|e| e.to_string())?;
 
@@ -1441,8 +1440,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                             let key: String = row.get(2)?;
                             let created_at: String = row.get(3)?;
                             Ok(format!(
-                                "[{}] Thread: {}\nSummary: {}\nKey Info: {}",
-                                created_at, sid, sum, key
+                                "[{created_at}] Thread: {sid}\nSummary: {sum}\nKey Info: {key}"
                             ))
                         })
                         .map_err(|e| e.to_string())?;
@@ -1582,7 +1580,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                     let mut max_id = last_id;
                     for (id, sum, key) in rows.filter_map(Result::ok) {
                         summaries_content
-                            .push_str(&format!("Summary:\n{}\nKey Info:\n{}\n\n", sum, key));
+                            .push_str(&format!("Summary:\n{sum}\nKey Info:\n{key}\n\n"));
                         max_id = id;
                     }
                     Ok((should_run, summaries_content, max_id))
@@ -1636,7 +1634,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                                 now
                             ],
                         )
-                        .map_err(|e| format!("insert subagent_tasks: {}", e))?;
+                        .map_err(|e| format!("insert subagent_tasks: {e}"))?;
                     Ok(())
                 })();
                 let _ = reply.send(res);
@@ -1672,7 +1670,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                                 parent_chat_id
                             ],
                         )
-                        .map_err(|e| format!("finalize subagent_tasks: {}", e))?;
+                        .map_err(|e| format!("finalize subagent_tasks: {e}"))?;
                     if n == 0 {
                         return Err("subagent_tasks update: no matching row".to_string());
                     }
@@ -1870,7 +1868,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                             record.created_at_ms,
                             record.updated_at_ms
                         ],
-                    ).map_err(|e| format!("upsert background_jobs: {}", e))?;
+                    ).map_err(|e| format!("upsert background_jobs: {e}"))?;
                     Ok(())
                 })();
                 let _ = reply.send(res);
@@ -1947,7 +1945,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                     self.conn.execute(
                         "UPDATE background_jobs SET state = ?1, last_error = ?2, updated_at_ms = ?3 WHERE job_id = ?4",
                         params![state, last_error, now, job_id],
-                    ).map_err(|e| format!("update background_jobs: {}", e))?;
+                    ).map_err(|e| format!("update background_jobs: {e}"))?;
                     Ok(())
                 })();
                 let _ = reply.send(res);
@@ -1963,7 +1961,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                         record.kind, record.title, record.body, record.action_kind, record.action_payload,
                         record.seen_at_ms, record.resolved_at_ms, record.created_at_ms
                     ],
-                ).map_err(|e| format!("insert notifications: {}", e)).map(|_| ());
+                ).map_err(|e| format!("insert notifications: {e}")).map(|_| ());
                 let _ = reply.send(res);
             }
             MemoryMessage::ListNotifications {
@@ -2035,7 +2033,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                 let res = self.conn.execute(
                     "UPDATE notifications SET seen_at_ms = COALESCE(seen_at_ms, ?1) WHERE notification_id = ?2",
                     params![now, notification_id],
-                ).map_err(|e| format!("mark notification seen: {}", e)).map(|_| ());
+                ).map_err(|e| format!("mark notification seen: {e}")).map(|_| ());
                 let _ = reply.send(res);
             }
             MemoryMessage::ResolveNotification {
@@ -2046,7 +2044,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                 let res = self.conn.execute(
                     "UPDATE notifications SET resolved_at_ms = COALESCE(resolved_at_ms, ?1) WHERE notification_id = ?2",
                     params![now, notification_id],
-                ).map_err(|e| format!("resolve notification: {}", e)).map(|_| ());
+                ).map_err(|e| format!("resolve notification: {e}")).map(|_| ());
                 let _ = reply.send(res);
             }
             MemoryMessage::UpsertClarificationTicket { record, reply } => {
@@ -2062,7 +2060,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                         record.tool_call_id, record.prompt, record.choices_json, record.response, record.status,
                         record.created_at_ms, record.updated_at_ms
                     ],
-                ).map_err(|e| format!("upsert clarification_tickets: {}", e)).map(|_| ());
+                ).map_err(|e| format!("upsert clarification_tickets: {e}")).map(|_| ());
                 let _ = reply.send(res);
             }
             MemoryMessage::ResolveClarificationTicket {
@@ -2074,7 +2072,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                 let res = self.conn.execute(
                     "UPDATE clarification_tickets SET response = ?1, status = 'answered', updated_at_ms = ?2 WHERE ticket_id = ?3",
                     params![response, now, ticket_id],
-                ).map_err(|e| format!("resolve clarification ticket: {}", e)).map(|_| ());
+                ).map_err(|e| format!("resolve clarification ticket: {e}")).map(|_| ());
                 let _ = reply.send(res);
             }
             MemoryMessage::GetClarificationTicket { ticket_id, reply } => {
@@ -2123,7 +2121,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                             |row| row.get(0),
                         )
                         .optional()
-                        .map_err(|e| format!("load clarification ticket: {}", e))?;
+                        .map_err(|e| format!("load clarification ticket: {e}"))?;
                     let stored_job_id = stored_job_id.ok_or_else(|| {
                         "clarification ticket was not found or is no longer waiting".to_string()
                     })?;
@@ -2143,7 +2141,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                              WHERE ticket_id = ?3 AND status = 'waiting'",
                             params![response, now, ticket_id],
                         )
-                        .map_err(|e| format!("resolve clarification ticket: {}", e))?;
+                        .map_err(|e| format!("resolve clarification ticket: {e}"))?;
                     if ticket_rows != 1 {
                         return Err("clarification ticket could not be claimed".to_string());
                     }
@@ -2152,7 +2150,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                     tx.execute(
                         "UPDATE notifications SET resolved_at_ms = ?1 WHERE action_payload = ?2 AND resolved_at_ms IS NULL",
                         params![now, ticket_id],
-                    ).map_err(|e| format!("resolve related notifications: {}", e))?;
+                    ).map_err(|e| format!("resolve related notifications: {e}"))?;
 
                     // 3. Update job state to running
                     let job_rows = tx
@@ -2160,7 +2158,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                             "UPDATE background_jobs SET state = 'running', updated_at_ms = ?1 WHERE job_id = ?2",
                             params![now, job_id],
                         )
-                        .map_err(|e| format!("update job state to running: {}", e))?;
+                        .map_err(|e| format!("update job state to running: {e}"))?;
                     if job_rows != 1 {
                         return Err("background job was not found".to_string());
                     }
@@ -2204,7 +2202,7 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                     self.conn.execute(
                         "UPDATE background_jobs SET state = 'completed', updated_at_ms = ?1 WHERE job_id = ?2",
                         params![now, jid],
-                    ).map_err(|e| format!("dismiss background_job: {}", e))?;
+                    ).map_err(|e| format!("dismiss background_job: {e}"))?;
 
                     // 2. Resolve any associated clarification tickets
                     let mut stmt = self.conn.prepare(
@@ -2220,13 +2218,13 @@ impl ActorLogic<MemoryMessage> for SqliteMemoryActor {
                         self.conn.execute(
                             "UPDATE clarification_tickets SET response = 'Dismissed', status = 'answered', updated_at_ms = ?1 WHERE ticket_id = ?2",
                             params![now, tid],
-                        ).map_err(|e| format!("dismiss ticket: {}", e))?;
+                        ).map_err(|e| format!("dismiss ticket: {e}"))?;
 
                         // Resolve notifications for this ticket
                         self.conn.execute(
                             "UPDATE notifications SET resolved_at_ms = COALESCE(resolved_at_ms, ?1) WHERE action_payload = ?2 AND kind = 'clarification_ticket'",
                             params![now, tid],
-                        ).map_err(|e| format!("resolve notifications for ticket: {}", e))?;
+                        ).map_err(|e| format!("resolve notifications for ticket: {e}"))?;
                     }
 
                     Ok(())

--- a/src/multi_tenant_edge.rs
+++ b/src/multi_tenant_edge.rs
@@ -92,7 +92,7 @@ impl HeartbeatTransport for ReqwestHeartbeatTransport {
     async fn post_activity(&self, url: &str, token: &str) -> Result<StatusCode, String> {
         self.client
             .post(url)
-            .header("Authorization", format!("Bearer {}", token))
+            .header("Authorization", format!("Bearer {token}"))
             .send()
             .await
             .map(|response| response.status())
@@ -110,7 +110,7 @@ impl CronTransport for ReqwestCronTransport {
     ) -> Result<StatusCode, String> {
         self.client
             .put(url)
-            .header("Authorization", format!("Bearer {}", token))
+            .header("Authorization", format!("Bearer {token}"))
             .json(&PutCronsBody {
                 cron_rules: cron_rules.to_vec(),
             })
@@ -417,8 +417,7 @@ fn build_reqwest_client() -> Result<reqwest::Client, String> {
         .build()
         .map_err(|error| {
             format!(
-                "failed to build multi-tenant-edge reqwest client: {}",
-                error
+                "failed to build multi-tenant-edge reqwest client: {error}"
             )
         })
 }
@@ -472,12 +471,11 @@ fn normalize_internal_url(
     let url = if trimmed.ends_with(path) {
         trimmed.to_string()
     } else {
-        format!("{}{}", trimmed, path)
+        format!("{trimmed}{path}")
     };
     Url::parse(&url).map_err(|error| {
         format!(
-            "multi-tenant-edge {} enabled but MTE_PROXY_BASE_URL '{}' is invalid: {}",
-            feature_name, base_url, error
+            "multi-tenant-edge {feature_name} enabled but MTE_PROXY_BASE_URL '{base_url}' is invalid: {error}"
         )
     })?;
     Ok(url)

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -299,12 +299,11 @@ fn apply_onboard_options(cfg: &mut AppConfig, opts: &OnboardOptions) {
 fn build_config_toml(options: &OnboardOptions) -> Result<String, String> {
     let mut cfg: AppConfig = toml::from_str(CONFIG_TEMPLATE).map_err(|e| {
         format!(
-            "Internal error: embedded config template is invalid TOML: {}",
-            e
+            "Internal error: embedded config template is invalid TOML: {e}"
         )
     })?;
     apply_onboard_options(&mut cfg, options);
-    toml::to_string_pretty(&cfg).map_err(|e| format!("Failed to serialize config.toml: {}", e))
+    toml::to_string_pretty(&cfg).map_err(|e| format!("Failed to serialize config.toml: {e}"))
 }
 
 /// Same overrides as [`apply_onboard_options`], applied in-place on the embedded template with
@@ -312,7 +311,7 @@ fn build_config_toml(options: &OnboardOptions) -> Result<String, String> {
 pub fn build_interactive_config_toml(options: &OnboardOptions) -> Result<String, String> {
     let mut doc: DocumentMut = CONFIG_TEMPLATE
         .parse()
-        .map_err(|e| format!("interactive config template parse (toml_edit): {}", e))?;
+        .map_err(|e| format!("interactive config template parse (toml_edit): {e}"))?;
 
     if let Some(v) = options.restrict_to_workspace {
         doc["restrict_to_workspace"] = value(v);
@@ -437,8 +436,7 @@ pub fn build_interactive_config_toml(options: &OnboardOptions) -> Result<String,
     let out = doc.to_string();
     let _: AppConfig = toml::from_str(&out).map_err(|e| {
         format!(
-            "interactive merged config.toml failed AppConfig validation: {}",
-            e
+            "interactive merged config.toml failed AppConfig validation: {e}"
         )
     })?;
     Ok(out)
@@ -590,8 +588,7 @@ This file is created by **`isanagent onboard`**. It mirrors the policy text that
 appends to the system prompt when **`[harness.ml_engineer] enabled = true`** in `config.toml`. \
 Editing this file does **not** change runtime behavior (the live text is embedded in the \
 `isanagent` build). For workspace-specific ML rules, add or edit **`ML_POLICY.md`** in this \
-directory (merged by `compile_system_prompt`).\n\n---\n\n{}",
-        HARNESS_OVERLAY
+directory (merged by `compile_system_prompt`).\n\n---\n\n{HARNESS_OVERLAY}"
     )
 }
 
@@ -649,8 +646,7 @@ fn write_embedded_kernel_porting_tree(
     )?;
     // Symlink-style copy: gpu_to_jax plan accessible at .agents/kernel-porting/
     let plan_src = root.join(format!(
-        "{}/gpu_to_jax_plan.json",
-        KERNEL_PORTING_SKILL_REL_PREFIX
+        "{KERNEL_PORTING_SKILL_REL_PREFIX}/gpu_to_jax_plan.json"
     ));
     let plan_dest = root.join("workspace/.agents/kernel-porting/gpu_to_jax_plan.json");
     if plan_src.exists() {
@@ -664,8 +660,7 @@ fn write_embedded_kernel_porting_tree(
         }
     }
     let schema_src = root.join(format!(
-        "{}/map_elites.schema.json",
-        KERNEL_PORTING_SKILL_REL_PREFIX
+        "{KERNEL_PORTING_SKILL_REL_PREFIX}/map_elites.schema.json"
     ));
     let schema_dest = root.join("workspace/.agents/kernel-porting/map_elites.schema.json");
     if schema_src.exists() {
@@ -694,8 +689,7 @@ fn write_embedded_autotrainess_tree(
     )?;
     // Convenience copy: iteration plan accessible at .agents/autotrainess/
     let plan_src = root.join(format!(
-        "{}/iteration_plan.json",
-        AUTOTRAINESS_SKILL_REL_PREFIX
+        "{AUTOTRAINESS_SKILL_REL_PREFIX}/iteration_plan.json"
     ));
     let plan_dest = root.join("workspace/.agents/autotrainess/iteration_plan.json");
     if plan_src.exists() {
@@ -780,9 +774,9 @@ fn write_if_missing_string(
 fn validate_generated_files(layout: &WorkspaceLayout) -> Result<(), String> {
     let config_path = layout.root.join("config.toml");
     let config_str = fs::read_to_string(&config_path)
-        .map_err(|e| format!("Failed to read generated config.toml: {}", e))?;
+        .map_err(|e| format!("Failed to read generated config.toml: {e}"))?;
     toml::from_str::<AppConfig>(&config_str)
-        .map_err(|e| format!("Generated config.toml is invalid: {}", e))?;
+        .map_err(|e| format!("Generated config.toml is invalid: {e}"))?;
 
     for relative_path in [
         "workspace/AGENTS.md",

--- a/src/onboarding_interactive.rs
+++ b/src/onboarding_interactive.rs
@@ -186,7 +186,7 @@ fn normalize_custom_base_url(input: &str) -> Result<String, String> {
     if base.ends_with("/chat/completions") {
         return Ok(base.to_string());
     }
-    Ok(format!("{}/chat/completions", base))
+    Ok(format!("{base}/chat/completions"))
 }
 
 async fn fetch_model_ids(
@@ -197,26 +197,26 @@ async fn fetch_model_ids(
     let url = models_endpoint_url(chat_url);
     let res = client
         .get(&url)
-        .header("Authorization", format!("Bearer {}", api_key))
+        .header("Authorization", format!("Bearer {api_key}"))
         .timeout(Duration::from_secs(60))
         .send()
         .await
-        .map_err(|e| format!("HTTP error: {}", e))?;
+        .map_err(|e| format!("HTTP error: {e}"))?;
     let status = res.status();
     if !status.is_success() {
         let body = res
             .text()
             .await
-            .map_err(|e| format!("Failed to read response body: {}", e))?;
+            .map_err(|e| format!("Failed to read response body: {e}"))?;
         return Err(format!(
             "List models failed ({}): {}",
             status,
             body.chars().take(500).collect::<String>()
         ));
     }
-    let text = res.text().await.map_err(|e| format!("Read body: {}", e))?;
+    let text = res.text().await.map_err(|e| format!("Read body: {e}"))?;
     let parsed: ModelsListResponse =
-        serde_json::from_str(&text).map_err(|e| format!("Invalid JSON from /models: {}", e))?;
+        serde_json::from_str(&text).map_err(|e| format!("Invalid JSON from /models: {e}"))?;
     let mut ids: Vec<String> = if !parsed.data.is_empty() {
         parsed.data.into_iter().map(|m| m.id).collect()
     } else {
@@ -318,11 +318,11 @@ struct TerminalUiGuard;
 
 impl TerminalUiGuard {
     fn enter() -> Result<Self, String> {
-        enable_raw_mode().map_err(|e| format!("enable_raw_mode: {}", e))?;
+        enable_raw_mode().map_err(|e| format!("enable_raw_mode: {e}"))?;
         let mut stdout = stdout();
         if let Err(e) = execute!(stdout, EnterAlternateScreen) {
             let _ = disable_raw_mode();
-            return Err(format!("EnterAlternateScreen: {}", e));
+            return Err(format!("EnterAlternateScreen: {e}"));
         }
         Ok(Self)
     }
@@ -343,7 +343,7 @@ pub fn run_interactive_collect(handle: &Handle) -> Result<InteractiveOnboardOutc
 
 fn run_ui_loop(handle: &Handle) -> Result<InteractiveOnboardOutcome, String> {
     let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))
-        .map_err(|e| format!("terminal: {}", e))?;
+        .map_err(|e| format!("terminal: {e}"))?;
 
     let client = crate::utils::build_reqwest_client();
     let mut state = UiState::new();
@@ -351,7 +351,7 @@ fn run_ui_loop(handle: &Handle) -> Result<InteractiveOnboardOutcome, String> {
     loop {
         terminal
             .draw(|f| render(f, &state))
-            .map_err(|e| format!("draw: {}", e))?;
+            .map_err(|e| format!("draw: {e}"))?;
 
         if matches!(state.step, Step::FetchingModels) {
             let rx = match state.fetch_rx.take() {
@@ -367,7 +367,7 @@ fn run_ui_loop(handle: &Handle) -> Result<InteractiveOnboardOutcome, String> {
             loop {
                 terminal
                     .draw(|f| render(f, &state))
-                    .map_err(|e| format!("draw: {}", e))?;
+                    .map_err(|e| format!("draw: {e}"))?;
                 match rx.try_recv() {
                     Ok(Ok(models)) => {
                         state.step = Step::PickModel {
@@ -390,9 +390,9 @@ fn run_ui_loop(handle: &Handle) -> Result<InteractiveOnboardOutcome, String> {
                     Err(mpsc::TryRecvError::Empty) => {}
                 }
                 if event::poll(Duration::from_millis(50))
-                    .map_err(|e| format!("event poll: {}", e))?
+                    .map_err(|e| format!("event poll: {e}"))?
                 {
-                    let evt = event::read().map_err(|e| format!("event: {}", e))?;
+                    let evt = event::read().map_err(|e| format!("event: {e}"))?;
                     if let Event::Key(key) = evt {
                         if key.kind == KeyEventKind::Release {
                             continue;
@@ -410,7 +410,7 @@ fn run_ui_loop(handle: &Handle) -> Result<InteractiveOnboardOutcome, String> {
             continue;
         }
 
-        let evt = event::read().map_err(|e| format!("event: {}", e))?;
+        let evt = event::read().map_err(|e| format!("event: {e}"))?;
         let Event::Key(key) = evt else {
             continue;
         };
@@ -532,8 +532,7 @@ fn run_ui_loop(handle: &Handle) -> Result<InteractiveOnboardOutcome, String> {
                                     Ok(k) => k,
                                     Err(_) => {
                                         let _ = tx.send(Err(format!(
-                                            "Environment variable `{}` is not set.",
-                                            env_name
+                                            "Environment variable `{env_name}` is not set."
                                         )));
                                         return;
                                     }
@@ -547,8 +546,7 @@ fn run_ui_loop(handle: &Handle) -> Result<InteractiveOnboardOutcome, String> {
                         }
                         Err(_) => {
                             state.api_key_env_error = Some(format!(
-                                "`{}` is not set in this process. Export it first, then press Enter.",
-                                trimmed
+                                "`{trimmed}` is not set in this process. Export it first, then press Enter."
                             ));
                         }
                     }
@@ -583,7 +581,7 @@ fn run_ui_loop(handle: &Handle) -> Result<InteractiveOnboardOutcome, String> {
                 selected,
                 page,
             } => {
-                let size = terminal.size().map_err(|e| format!("size: {}", e))?;
+                let size = terminal.size().map_err(|e| format!("size: {e}"))?;
                 let area = Rect::new(0, 0, size.width, size.height);
                 let block = centered_rect(area, 85, 80);
                 let inner_h = block.height.saturating_sub(4) as usize;
@@ -653,7 +651,7 @@ fn run_ui_loop(handle: &Handle) -> Result<InteractiveOnboardOutcome, String> {
                 page,
                 values,
             } => {
-                let size = terminal.size().map_err(|e| format!("size: {}", e))?;
+                let size = terminal.size().map_err(|e| format!("size: {e}"))?;
                 let area = Rect::new(0, 0, size.width, size.height);
                 let block = centered_rect(area, 85, 80);
                 let inner_h = block.height.saturating_sub(4) as usize;
@@ -768,7 +766,7 @@ fn render(frame: &mut Frame, state: &UiState) {
             let err_line = state
                 .custom_url_error
                 .as_ref()
-                .map(|e| Line::from(format!("Error: {}", e)).style(Style::default().fg(Color::Red)))
+                .map(|e| Line::from(format!("Error: {e}")).style(Style::default().fg(Color::Red)))
                 .unwrap_or_else(|| Line::from(""));
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
@@ -796,7 +794,7 @@ fn render(frame: &mut Frame, state: &UiState) {
             let err_line = state
                 .api_key_env_error
                 .as_ref()
-                .map(|e| Line::from(format!("Error: {}", e)).style(Style::default().fg(Color::Red)))
+                .map(|e| Line::from(format!("Error: {e}")).style(Style::default().fg(Color::Red)))
                 .unwrap_or_else(|| Line::from(""));
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
@@ -834,8 +832,7 @@ fn render(frame: &mut Frame, state: &UiState) {
         }
         Step::FetchError { message } => {
             let p = Paragraph::new(format!(
-                "{}\n\nPress Enter, r, or ← to edit the env var name again. Esc quit.",
-                message
+                "{message}\n\nPress Enter, r, or ← to edit the env var name again. Esc quit."
             ))
             .alignment(Alignment::Center)
             .wrap(Wrap { trim: true })

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -93,7 +93,8 @@ impl Provider for NoKeyProvider {
         _tools: Option<Value>,
     ) -> Result<LLMResponse, LLMError> {
         Err(LLMError::ApiError(
-            "No API key configured. Use /model to select a provider, or add api_key to config.toml."
+            "No API key configured. Use /key <api_key> to set one now, /model to switch \
+             providers, or add api_key to config.toml."
                 .to_string(),
         ))
     }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -77,6 +77,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use log::debug;
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Placeholder provider used when no API key is configured at startup.
@@ -95,6 +96,55 @@ impl Provider for NoKeyProvider {
             "No API key configured. Use /model to select a provider, or add api_key to config.toml."
                 .to_string(),
         ))
+    }
+}
+
+/// Deterministic in-process provider for host/CLI smoke tests.
+#[derive(Clone)]
+pub struct ScriptedProvider {
+    responses: Arc<std::sync::Mutex<std::collections::VecDeque<String>>>,
+    fallback: String,
+}
+
+impl ScriptedProvider {
+    pub fn new(responses: Vec<String>) -> Self {
+        let fallback = responses
+            .last()
+            .cloned()
+            .unwrap_or_else(|| "scripted-ok".to_string());
+        Self {
+            responses: Arc::new(std::sync::Mutex::new(responses.into())),
+            fallback,
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for ScriptedProvider {
+    async fn chat(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: Option<Value>,
+    ) -> Result<LLMResponse, LLMError> {
+        let content = {
+            let mut queue = self
+                .responses
+                .lock()
+                .map_err(|_| LLMError::ApiError("scripted provider lock poisoned".into()))?;
+            queue.pop_front().unwrap_or_else(|| self.fallback.clone())
+        };
+        Ok(LLMResponse {
+            content,
+            tool_calls: None,
+            reasoning_content: None,
+            usage: Some(crate::utils::TokenUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+            }),
+        })
     }
 }
 

--- a/src/reflection.rs
+++ b/src/reflection.rs
@@ -71,14 +71,14 @@ impl ReflectionEngine {
             if let Err(e) = self.run_short_term_reflection().await {
                 let _ = self.logger_tx.send(BusMessage::Log(LogEvent::error(
                     "ReflectionEngine",
-                    &format!("Short-term reflection failed: {}", e),
+                    &format!("Short-term reflection failed: {e}"),
                 )));
             }
 
             if let Err(e) = self.run_long_term_reflection().await {
                 let _ = self.logger_tx.send(BusMessage::Log(LogEvent::error(
                     "ReflectionEngine",
-                    &format!("Long-term reflection failed: {}", e),
+                    &format!("Long-term reflection failed: {e}"),
                 )));
             }
         }
@@ -127,8 +127,7 @@ impl ReflectionEngine {
                 LogEvent::debug(
                     "ReflectionEngine",
                     &format!(
-                        "Thread {} reached short-term reflection threshold (idle)",
-                        session_id
+                        "Thread {session_id} reached short-term reflection threshold (idle)"
                     ),
                 )
                 .with_chat_id(&session_id),
@@ -221,7 +220,7 @@ impl ReflectionEngine {
                         let _ = self.logger_tx.send(BusMessage::Log(
                             LogEvent::info(
                                 "ReflectionEngine",
-                                &format!("Generated short-term summary for thread {}", session_id),
+                                &format!("Generated short-term summary for thread {session_id}"),
                             )
                             .with_chat_id(&session_id),
                         ));
@@ -231,7 +230,7 @@ impl ReflectionEngine {
                     let _ = self.logger_tx.send(BusMessage::Log(
                         LogEvent::error(
                             "ReflectionEngine",
-                            &format!("Failed to call provider for reflection: {}", e),
+                            &format!("Failed to call provider for reflection: {e}"),
                         )
                         .with_chat_id(&session_id),
                     ));
@@ -286,8 +285,7 @@ impl ReflectionEngine {
             "You are consolidating the agent's long-term memory. Below is the current MEMORY.md content, and a list of recent conversation summaries.\n\
             Rewrite the long-term memory to incorporate any new facts, user preferences, project context, or relationships found in the summaries.\n\
             Maintain a structured, organized markdown document.\n\n\
-            CURRENT MEMORY:\n{}\n\nRECENT SUMMARIES:\n{}",
-            current_memory, summaries_content
+            CURRENT MEMORY:\n{current_memory}\n\nRECENT SUMMARIES:\n{summaries_content}"
         );
 
         let context = vec![ChatMessage::user(&prompt)];

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -175,7 +175,7 @@ impl CronStore {
 
     pub fn insert_job(&self, job: &ActiveJob) -> Result<(), String> {
         let schedule_json = serde_json::to_string(&job.schedule)
-            .map_err(|e| format!("Failed to serialize schedule: {}", e))?;
+            .map_err(|e| format!("Failed to serialize schedule: {e}"))?;
         let conn = self.lock_conn()?;
         conn.execute(
             "INSERT INTO cron_jobs (
@@ -336,8 +336,7 @@ impl CronStore {
             .map_err(|e| e.to_string())?;
         if deleted == 0 {
             return Err(format!(
-                "Failed to finalize multi-tenant-edge one-shot cron job {} because its claim was no longer valid",
-                job_id
+                "Failed to finalize multi-tenant-edge one-shot cron job {job_id} because its claim was no longer valid"
             ));
         }
         Ok(())
@@ -362,8 +361,7 @@ impl CronStore {
             .map_err(|e| e.to_string())?;
         if updated == 0 {
             return Err(format!(
-                "Failed to mark multi-tenant-edge one-shot cron job {} as delivered because its claim was no longer valid",
-                job_id
+                "Failed to mark multi-tenant-edge one-shot cron job {job_id} as delivered because its claim was no longer valid"
             ));
         }
         Ok(())
@@ -376,7 +374,7 @@ impl CronStore {
         retry_at_ms: i64,
     ) -> Result<(), String> {
         let schedule_json = serde_json::to_string(&ScheduleKind::At { at_ms: retry_at_ms })
-            .map_err(|e| format!("Failed to serialize one-shot retry schedule: {}", e))?;
+            .map_err(|e| format!("Failed to serialize one-shot retry schedule: {e}"))?;
         let conn = self.lock_conn()?;
         let updated = conn
             .execute(
@@ -388,8 +386,7 @@ impl CronStore {
             .map_err(|e| e.to_string())?;
         if updated == 0 {
             return Err(format!(
-                "Failed to reschedule multi-tenant-edge one-shot cron job {} because its claim was no longer valid",
-                job_id
+                "Failed to reschedule multi-tenant-edge one-shot cron job {job_id} because its claim was no longer valid"
             ));
         }
         Ok(())
@@ -411,7 +408,7 @@ impl CronStore {
     ) -> Result<bool, String> {
         let conn = self.lock_conn()?;
 
-        let full_job_id = format!("cron:{}", job_id);
+        let full_job_id = format!("cron:{job_id}");
         let existing_state: Option<String> = conn
             .query_row(
                 "SELECT state FROM background_jobs WHERE job_id = ?1",
@@ -441,7 +438,7 @@ impl CronStore {
             ON CONFLICT(job_id) DO UPDATE SET
                 state = 'running', payload_json = excluded.payload_json, updated_at_ms = excluded.updated_at_ms",
             params![full_job_id, chat_id, channel, payload, now_ms],
-        ).map_err(|e| format!("insert background_jobs from cron: {}", e))?;
+        ).map_err(|e| format!("insert background_jobs from cron: {e}"))?;
         conn.execute(
             "INSERT INTO notifications (
                 notification_id, chat_id, channel, thread_id, kind, title, body, action_kind, action_payload,
@@ -456,7 +453,7 @@ impl CronStore {
                 serde_json::json!({"job_id": full_job_id}).to_string(),
                 now_ms
             ],
-        ).map_err(|e| format!("insert notifications from cron: {}", e))?;
+        ).map_err(|e| format!("insert notifications from cron: {e}"))?;
         Ok(true)
     }
 }
@@ -619,17 +616,15 @@ impl PendingCronTrigger {
                     (None, None) => Ok(PendingCronTriggerFinalize::Completed),
                     (Some(cleanup), None) => Ok(PendingCronTriggerFinalize::CompletedWithWarning(
                         format!(
-                            "Failed to clean up completed one-shot cron job {} after delivery: {}",
-                            job_id, cleanup
+                            "Failed to clean up completed one-shot cron job {job_id} after delivery: {cleanup}"
                         ),
                     )),
                     (None, Some(sync)) => Ok(PendingCronTriggerFinalize::CompletedWithWarning(
-                        format!("Failed to resync edge rules afterward: {}", sync),
+                        format!("Failed to resync edge rules afterward: {sync}"),
                     )),
                     (Some(cleanup), Some(sync)) => Ok(
                         PendingCronTriggerFinalize::CompletedWithWarning(format!(
-                            "Failed to clean up completed one-shot cron job {} after delivery: {}. Failed to resync edge rules afterward: {}",
-                            job_id, cleanup, sync
+                            "Failed to clean up completed one-shot cron job {job_id} after delivery: {cleanup}. Failed to resync edge rules afterward: {sync}"
                         )),
                     ),
                 }
@@ -716,7 +711,7 @@ impl ActorLogic<String> for CronActor {
                 self.store.insert_job(&job).map_err(ActorError::from)?;
                 if let ScheduleKind::Cron { ref cron_expr } = schedule {
                     let parsed_schedule = Schedule::from_str(cron_expr).map_err(|error| {
-                        ActorError::from(format!("Invalid cron expression: {}", error))
+                        ActorError::from(format!("Invalid cron expression: {error}"))
                     })?;
                     self.cron_schedule_cache
                         .insert(cron_expr.clone(), parsed_schedule);
@@ -727,7 +722,7 @@ impl ActorLogic<String> for CronActor {
                     self.logger_tx
                         .send(crate::bus::BusMessage::Log(crate::bus::LogEvent::info(
                             &self.name,
-                            &format!("Added job '{}' with schedule {:?}", id, schedule),
+                            &format!("Added job '{id}' with schedule {schedule:?}"),
                         )));
             }
             CronCommand::Remove { id } => {
@@ -748,7 +743,7 @@ impl ActorLogic<String> for CronActor {
                     self.logger_tx
                         .send(crate::bus::BusMessage::Log(crate::bus::LogEvent::info(
                             &self.name,
-                            &format!("Removed job '{}'", id),
+                            &format!("Removed job '{id}'"),
                         )));
             }
             CronCommand::Reload => {
@@ -879,8 +874,7 @@ impl ActorLogic<String> for CronActor {
         for job_id in jobs_to_remove {
             if let Err(error) = self.store.remove_job(&job_id) {
                 self.log_error(format!(
-                    "Failed to remove expired one-shot cron job {}: {}",
-                    job_id, error
+                    "Failed to remove expired one-shot cron job {job_id}: {error}"
                 ));
             }
         }
@@ -930,7 +924,7 @@ impl ActorLogic<String> for CronActor {
                     let _ = self.logger_tx.send(crate::bus::BusMessage::Log(
                         crate::bus::LogEvent::info(
                             &self.name,
-                            &format!("Fired local cron job {}", job_id),
+                            &format!("Fired local cron job {job_id}"),
                         ),
                     ));
                 }
@@ -939,8 +933,7 @@ impl ActorLogic<String> for CronActor {
                 }
                 Err(error) => {
                     self.log_error(format!(
-                        "Failed to record cron background job for {}: {}",
-                        job_id, error
+                        "Failed to record cron background job for {job_id}: {error}"
                     ));
                 }
             }
@@ -1004,7 +997,7 @@ pub fn validate_multi_tenant_edge_schedule(
 pub fn validate_cron_expression(expr: &str) -> Result<(), String> {
     Schedule::from_str(expr)
         .map(|_| ())
-        .map_err(|error| format!("Invalid cron expression: {}", error))
+        .map_err(|error| format!("Invalid cron expression: {error}"))
 }
 
 pub fn is_six_field_cron_expr(expr: &str) -> bool {
@@ -1044,7 +1037,7 @@ fn build_multi_tenant_edge_cron_rule(
 
 fn at_schedule_to_utc_cron(at_ms: i64) -> Result<String, String> {
     let at = DateTime::<Utc>::from_timestamp_millis(at_ms)
-        .ok_or_else(|| format!("Invalid one-shot 'at' timestamp in cron job: {}", at_ms))?;
+        .ok_or_else(|| format!("Invalid one-shot 'at' timestamp in cron job: {at_ms}"))?;
     Ok(format!(
         "{} {} {} {} {} *",
         at.second(),
@@ -1056,7 +1049,7 @@ fn at_schedule_to_utc_cron(at_ms: i64) -> Result<String, String> {
 }
 
 fn webhook_path(job_id: &str, token: &str) -> String {
-    format!("{}/{}/{}", WEBHOOK_PATH_PREFIX, job_id, token)
+    format!("{WEBHOOK_PATH_PREFIX}/{job_id}/{token}")
 }
 
 fn decode_schedule(schedule_json: &str) -> Result<ScheduleKind, rusqlite::Error> {

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -91,8 +91,7 @@ impl SkillRegistry {
         // Extremely basic frontmatter parsing: looks for --- ... ---
         if lines[0] != "---" {
             warn!(
-                "Skipping {:?}: No YAML frontmatter found (must start with '---')",
-                path
+                "Skipping {path:?}: No YAML frontmatter found (must start with '---')"
             );
             return None;
         }
@@ -106,7 +105,7 @@ impl SkillRegistry {
         }
 
         if end_idx == 0 {
-            warn!("Skipping {:?}: Unclosed YAML frontmatter", path);
+            warn!("Skipping {path:?}: Unclosed YAML frontmatter");
             return None;
         }
 
@@ -123,7 +122,7 @@ impl SkillRegistry {
                         for bin in bins {
                             if which::which(bin).is_err() {
                                 available = false;
-                                missing_reasons.push(format!("missing bin: {}", bin));
+                                missing_reasons.push(format!("missing bin: {bin}"));
                             }
                         }
                     }
@@ -131,7 +130,7 @@ impl SkillRegistry {
                         for env in envs {
                             if std::env::var(env).is_err() {
                                 available = false;
-                                missing_reasons.push(format!("missing env var: {}", env));
+                                missing_reasons.push(format!("missing env var: {env}"));
                             }
                         }
                     }
@@ -157,7 +156,7 @@ impl SkillRegistry {
                 })
             }
             Err(e) => {
-                warn!("Failed to parse YAML frontmatter for {:?}: {}", path, e);
+                warn!("Failed to parse YAML frontmatter for {path:?}: {e}");
                 None
             }
         }
@@ -184,7 +183,7 @@ impl SkillRegistry {
         }
         summary.push_str("\nTo execute a skill, use the 'load_skill_instructions' tool with the skill's name to learn how to use it contextually.\n");
 
-        format!("{}{}", summary, always_blocks)
+        format!("{summary}{always_blocks}")
     }
 
     pub fn get_skill_instructions(&self, name: &str) -> Result<String, String> {
@@ -198,7 +197,7 @@ impl SkillRegistry {
                 }
                 Ok(skill.instructions.clone())
             }
-            None => Err(format!("Skill '{}' not found", name)),
+            None => Err(format!("Skill '{name}' not found")),
         }
     }
 
@@ -227,7 +226,7 @@ impl SkillRegistry {
         let skill = self
             .skills
             .get(name)
-            .ok_or_else(|| format!("Skill '{}' not found", name))?;
+            .ok_or_else(|| format!("Skill '{name}' not found"))?;
         Ok(format!(
             "Skill: {}\nAvailable: {}\nDescription: {}\nInstruction length: {} characters\nPath: {}",
             skill.name,
@@ -253,21 +252,20 @@ impl SkillRegistry {
 
         // Support shorthand owner/repo format
         let full_repo_url = if !repo_url.contains("://") && repo_url.contains('/') {
-            format!("https://github.com/{}", repo_url)
+            format!("https://github.com/{repo_url}")
         } else {
             repo_url.to_string()
         };
 
         info!(
-            "Installing skills from repository: {} (specific: {:?})",
-            full_repo_url, specific_skill
+            "Installing skills from repository: {full_repo_url} (specific: {specific_skill:?})"
         );
 
         // 1. Create a temporary directory with a cleanup guard
         let temp_dir_path =
             std::env::temp_dir().join(format!("isanagent-skills-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(&temp_dir_path)
-            .map_err(|e| format!("Failed to create temp dir: {}", e))?;
+            .map_err(|e| format!("Failed to create temp dir: {e}"))?;
         let _guard = TempDirGuard::new(temp_dir_path.clone());
 
         // 2. Clone the repository (using git command)
@@ -280,8 +278,7 @@ impl SkillRegistry {
             .status()
             .map_err(|e| {
                 format!(
-                    "Failed to execute git clone: {}. Make sure 'git' is installed and in your PATH.",
-                    e
+                    "Failed to execute git clone: {e}. Make sure 'git' is installed and in your PATH."
                 )
             })?;
 
@@ -319,7 +316,7 @@ impl SkillRegistry {
                     }
 
                     fs::create_dir_all(&tmp_dest_dir)
-                        .map_err(|e| format!("Failed to create skill dir: {}", e))?;
+                        .map_err(|e| format!("Failed to create skill dir: {e}"))?;
 
                     // Copy everything from skill_dir to tmp_dest_dir
                     copy_dir_recursive(skill_dir, &tmp_dest_dir)?;
@@ -327,10 +324,10 @@ impl SkillRegistry {
                     // Swap: remove old and rename tmp to dest
                     if dest_dir.exists() {
                         fs::remove_dir_all(&dest_dir)
-                            .map_err(|e| format!("Failed to remove existing skill dir: {}", e))?;
+                            .map_err(|e| format!("Failed to remove existing skill dir: {e}"))?;
                     }
                     fs::rename(&tmp_dest_dir, &dest_dir)
-                        .map_err(|e| format!("Failed to finalize skill installation: {}", e))?;
+                        .map_err(|e| format!("Failed to finalize skill installation: {e}"))?;
 
                     installed_skills.push(def.name);
 
@@ -344,8 +341,7 @@ impl SkillRegistry {
 
         if let Some(skill) = specific_skill.filter(|_| installed_skills.is_empty()) {
             return Err(format!(
-                "Skill '{}' not found in repository {}",
-                skill, full_repo_url
+                "Skill '{skill}' not found in repository {full_repo_url}"
             ));
         }
 
@@ -378,16 +374,16 @@ impl Drop for TempDirGuard {
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
     if !dst.exists() {
         fs::create_dir_all(dst)
-            .map_err(|e| format!("Failed to create directory {:?}: {}", dst, e))?;
+            .map_err(|e| format!("Failed to create directory {dst:?}: {e}"))?;
     }
 
     for entry in
-        fs::read_dir(src).map_err(|e| format!("Failed to read directory {:?}: {}", src, e))?
+        fs::read_dir(src).map_err(|e| format!("Failed to read directory {src:?}: {e}"))?
     {
-        let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
+        let entry = entry.map_err(|e| format!("Failed to read entry: {e}"))?;
         let file_type = entry
             .file_type()
-            .map_err(|e| format!("Failed to get file type: {}", e))?;
+            .map_err(|e| format!("Failed to get file type: {e}"))?;
         let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());
 
@@ -396,8 +392,7 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
         } else {
             fs::copy(&src_path, &dst_path).map_err(|e| {
                 format!(
-                    "Failed to copy file {:?} to {:?}: {}",
-                    src_path, dst_path, e
+                    "Failed to copy file {src_path:?} to {dst_path:?}: {e}"
                 )
             })?;
         }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -140,7 +140,7 @@ impl ToolRegistry {
         if let Some(tool) = self.get_tool(name) {
             tool.execute(args).await
         } else {
-            Err(format!("Tool '{}' not found", name))
+            Err(format!("Tool '{name}' not found"))
         }
     }
 
@@ -168,7 +168,7 @@ impl ToolRegistry {
         self.authorize_scoped(name, allowlist, is_subagent)?;
         match self.get_tool(name) {
             Some(tool) => tool.preview_mutation(args).await,
-            None => Err(format!("Tool '{}' not found", name)),
+            None => Err(format!("Tool '{name}' not found")),
         }
     }
 
@@ -187,7 +187,7 @@ impl ToolRegistry {
                 tool.execute_with_approved_mutation(args, approved_preview)
                     .await
             }
-            None => Err(format!("Tool '{}' not found", name)),
+            None => Err(format!("Tool '{name}' not found")),
         }
     }
 
@@ -221,15 +221,13 @@ impl ToolRegistry {
     ) -> Result<(), String> {
         if is_subagent && Self::is_subagent_restricted_tool(name) {
             return Err(format!(
-                "Tool '{}' is not available inside a sub-agent run",
-                name
+                "Tool '{name}' is not available inside a sub-agent run"
             ));
         }
         if let Some(set) = allowlist {
             if !set.is_empty() && !set.contains(name) {
                 return Err(format!(
-                    "Tool '{}' is not allowed for this sub-agent (allowlist)",
-                    name
+                    "Tool '{name}' is not allowed for this sub-agent (allowlist)"
                 ));
             }
         }

--- a/src/tools/builtin.rs
+++ b/src/tools/builtin.rs
@@ -263,20 +263,14 @@ ranges (e.g. 1–100, then 101–200). Prefer absolute or workspace-relative pat
             ));
         }
 
-        let start_line = args
-            .get("start_line")
-            .and_then(|v| v.as_u64())
-            .ok_or(
-                "Missing required 'start_line'. Every read_file call must pass start_line and \
+        let start_line = args.get("start_line").and_then(|v| v.as_u64()).ok_or(
+            "Missing required 'start_line'. Every read_file call must pass start_line and \
 end_line (1-indexed, inclusive); max 100 lines per call — e.g. start_line=1, end_line=100.",
-            )?;
-        let end_line = args
-            .get("end_line")
-            .and_then(|v| v.as_u64())
-            .ok_or(
-                "Missing required 'end_line'. Every read_file call must pass start_line and \
+        )?;
+        let end_line = args.get("end_line").and_then(|v| v.as_u64()).ok_or(
+            "Missing required 'end_line'. Every read_file call must pass start_line and \
 end_line (1-indexed, inclusive); max 100 lines per call — e.g. start_line=1, end_line=100.",
-            )?;
+        )?;
 
         let content = fs::read_to_string(&actual_path).map_err(|e| e.to_string())?;
 

--- a/src/tools/builtin.rs
+++ b/src/tools/builtin.rs
@@ -47,7 +47,7 @@ pub fn resolve_path(path: &str, workspace_dir: &Path, restrict: bool) -> Result<
     // If it doesn't exist yet (e.g., writing a new file), we canonicalize the nearest existing parent
     // and append the remainder.
     let canonical = if resolved.exists() {
-        std::fs::canonicalize(&resolved).map_err(|e| format!("Path normalization error: {}", e))?
+        std::fs::canonicalize(&resolved).map_err(|e| format!("Path normalization error: {e}"))?
     } else {
         // Find nearest existing parent
         let mut parent = resolved.parent();
@@ -61,7 +61,7 @@ pub fn resolve_path(path: &str, workspace_dir: &Path, restrict: bool) -> Result<
         }
 
         let mut safe_base = std::fs::canonicalize(parent.unwrap_or_else(|| Path::new(".")))
-            .map_err(|e| format!("Base path normalization error: {}", e))?;
+            .map_err(|e| format!("Base path normalization error: {e}"))?;
 
         for comp in missing_components.into_iter().rev() {
             safe_base.push(comp);
@@ -75,7 +75,7 @@ pub fn resolve_path(path: &str, workspace_dir: &Path, restrict: bool) -> Result<
     // 3. Enforce sandbox boundary if restricted.
     if restrict {
         let canonical_workspace = std::fs::canonicalize(workspace_dir)
-            .map_err(|e| format!("Workspace normalization error: {}", e))?;
+            .map_err(|e| format!("Workspace normalization error: {e}"))?;
 
         if !canonical.starts_with(&canonical_workspace) {
             return Err(format!(
@@ -345,7 +345,7 @@ impl Tool for WriteFileTool {
 
         if let Some(parent) = actual_path.parent() {
             fs::create_dir_all(parent)
-                .map_err(|e| format!("Failed to create parent directories: {}", e))?;
+                .map_err(|e| format!("Failed to create parent directories: {e}"))?;
         }
 
         crate::checkpoint::snapshot_before(&actual_path, "write_file");
@@ -475,7 +475,7 @@ impl Tool for EditFileTool {
         let actual_path = resolve_path(path_str, &self.workspace_dir, self.restrict_to_workspace)?;
 
         let content =
-            fs::read_to_string(&actual_path).map_err(|e| format!("Error reading file: {}", e))?;
+            fs::read_to_string(&actual_path).map_err(|e| format!("Error reading file: {e}"))?;
 
         if !content.contains(old_text) {
             return Ok("Error: old_text not found in file.".to_string());
@@ -484,8 +484,7 @@ impl Tool for EditFileTool {
         let count = content.matches(old_text).count();
         if count > 1 && !replace_all {
             return Ok(format!(
-                "Error: old_text appears {} times. Provide more surrounding context to make it unique, or set replace_all to true.",
-                count
+                "Error: old_text appears {count} times. Provide more surrounding context to make it unique, or set replace_all to true."
             ));
         }
 
@@ -497,7 +496,7 @@ impl Tool for EditFileTool {
         };
 
         crate::checkpoint::snapshot_before(&actual_path, "edit_file");
-        fs::write(&actual_path, &new_content).map_err(|e| format!("Error saving edits: {}", e))?;
+        fs::write(&actual_path, &new_content).map_err(|e| format!("Error saving edits: {e}"))?;
 
         let diff = unified_diff_snippet(&old_content, &new_content);
         let replacements = if replace_all { count } else { 1 };
@@ -620,7 +619,7 @@ impl Tool for ListDirTool {
 
         let mut entries = match fs::read_dir(&actual_path) {
             Ok(iter) => iter,
-            Err(e) => return Ok(format!("Error reading dir: {}", e)),
+            Err(e) => return Ok(format!("Error reading dir: {e}")),
         };
 
         let mut items = Vec::new();
@@ -657,12 +656,12 @@ fn compile_glob_single(pattern: &str) -> Result<GlobSet, String> {
     let glob = GlobBuilder::new(pattern)
         .literal_separator(true)
         .build()
-        .map_err(|e| format!("Invalid glob pattern: {}", e))?;
+        .map_err(|e| format!("Invalid glob pattern: {e}"))?;
     let mut builder = GlobSetBuilder::new();
     builder.add(glob);
     builder
         .build()
-        .map_err(|e| format!("Invalid glob pattern: {}", e))
+        .map_err(|e| format!("Invalid glob pattern: {e}"))
 }
 
 #[async_trait]
@@ -764,8 +763,7 @@ impl Tool for GlobFilesTool {
 
         if truncated {
             out.push_str(&format!(
-                "\n... (glob results capped at {} paths; refine the pattern or base path)",
-                MAX_GLOB_RESULTS
+                "\n... (glob results capped at {MAX_GLOB_RESULTS} paths; refine the pattern or base path)"
             ));
         }
 
@@ -825,8 +823,8 @@ async fn search_text_ripgrep(
     let fut = cmd.output();
     let output = tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), fut)
         .await
-        .map_err(|_| format!("Search timed out after {} seconds.", timeout_secs))?
-        .map_err(|e| format!("Failed to run ripgrep: {}", e))?;
+        .map_err(|_| format!("Search timed out after {timeout_secs} seconds."))?
+        .map_err(|e| format!("Failed to run ripgrep: {e}"))?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let code = output.status.code();
@@ -840,7 +838,7 @@ async fn search_text_ripgrep(
         if stderr.is_empty() {
             return Ok("No matches found.".to_string());
         }
-        return Err(format!("ripgrep error: {}", stderr));
+        return Err(format!("ripgrep error: {stderr}"));
     }
 
     if stdout.is_empty() {
@@ -860,8 +858,7 @@ fn truncate_search_output(mut s: String) -> String {
     }
     s.truncate(end);
     s.push_str(&format!(
-        "\n... (truncated, output exceeded {} characters)",
-        MAX_SEARCH_TEXT_CHARS
+        "\n... (truncated, output exceeded {MAX_SEARCH_TEXT_CHARS} characters)"
     ));
     s
 }
@@ -1081,7 +1078,7 @@ impl Tool for SearchTextTool {
         let regex = regex::RegexBuilder::new(pattern)
             .case_insensitive(case_insensitive)
             .build()
-            .map_err(|e| format!("Invalid regex: {}", e))?;
+            .map_err(|e| format!("Invalid regex: {e}"))?;
 
         let search_root = search_target;
         let mode = output_mode.to_string();
@@ -1091,7 +1088,7 @@ impl Tool for SearchTextTool {
             search_text_native(&regex_owned, &search_root, glob_set.as_ref(), &mode)
         })
         .await
-        .map_err(|e| format!("search task failed: {}", e))?
+        .map_err(|e| format!("search task failed: {e}"))?
     }
 }
 
@@ -1125,8 +1122,7 @@ impl ShellExecTool {
         for pattern in blocked_patterns.iter() {
             if lower_cmd.contains(pattern) {
                 return Err(format!(
-                    "Command blocked by safety guard (detected dangerous pattern: {})",
-                    pattern
+                    "Command blocked by safety guard (detected dangerous pattern: {pattern})"
                 ));
             }
         }
@@ -1293,11 +1289,11 @@ fn web_http_client(timeout_secs: u64) -> Result<reqwest::Client, String> {
         .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0")
         .timeout(std::time::Duration::from_secs(timeout_secs))
         .build()
-        .map_err(|e| format!("Failed to build HTTP client: {}", e))
+        .map_err(|e| format!("Failed to build HTTP client: {e}"))
 }
 
 fn parse_scraper_selector(sel: &str) -> Result<scraper::Selector, String> {
-    scraper::Selector::parse(sel).map_err(|e| format!("Invalid CSS selector {:?}: {}", sel, e))
+    scraper::Selector::parse(sel).map_err(|e| format!("Invalid CSS selector {sel:?}: {e}"))
 }
 
 fn truncate_web_output(text: String, max_chars: usize) -> String {
@@ -1321,7 +1317,7 @@ fn apply_jina_bearer(
 ) -> reqwest::RequestBuilder {
     if let Some(j) = jina {
         if let Some(key) = j.api_key.as_deref() {
-            return req.header("Authorization", format!("Bearer {}", key));
+            return req.header("Authorization", format!("Bearer {key}"));
         }
     }
     req
@@ -1404,7 +1400,7 @@ async fn web_fetch_direct(url: &str, max_output_chars: usize) -> Result<String, 
         .get(url)
         .send()
         .await
-        .map_err(|e| format!("Failed to fetch URL: {}", e))?;
+        .map_err(|e| format!("Failed to fetch URL: {e}"))?;
 
     if !res.status().is_success() {
         return Err(format!("HTTP Error: {}", res.status()));
@@ -1420,7 +1416,7 @@ async fn web_fetch_direct(url: &str, max_output_chars: usize) -> Result<String, 
         let json_body: Value = res
             .json()
             .await
-            .map_err(|e| format!("Invalid JSON: {}", e))?;
+            .map_err(|e| format!("Invalid JSON: {e}"))?;
         let s = serde_json::to_string_pretty(&json_body).unwrap_or_default();
         return Ok(truncate_web_output(s, max_output_chars));
     }
@@ -1428,7 +1424,7 @@ async fn web_fetch_direct(url: &str, max_output_chars: usize) -> Result<String, 
     let body = res
         .text()
         .await
-        .map_err(|e| format!("Failed to decode text: {}", e))?;
+        .map_err(|e| format!("Failed to decode text: {e}"))?;
 
     let document = scraper::Html::parse_document(&body);
     let mut text_output = String::new();
@@ -1509,7 +1505,7 @@ async fn web_fetch_jina(
     let res = req
         .send()
         .await
-        .map_err(|e| format!("Failed to fetch URL via Jina: {}", e))?;
+        .map_err(|e| format!("Failed to fetch URL via Jina: {e}"))?;
     if !res.status().is_success() {
         return Err(format!("HTTP Error (Jina reader): {}", res.status()));
     }
@@ -1524,7 +1520,7 @@ async fn web_fetch_jina(
         let json_body: Value = res
             .json()
             .await
-            .map_err(|e| format!("Invalid JSON: {}", e))?;
+            .map_err(|e| format!("Invalid JSON: {e}"))?;
         let s = serde_json::to_string_pretty(&json_body).unwrap_or_default();
         return Ok(truncate_web_output(s, max_output_chars));
     }
@@ -1532,7 +1528,7 @@ async fn web_fetch_jina(
     let body = res
         .text()
         .await
-        .map_err(|e| format!("Failed to decode text: {}", e))?;
+        .map_err(|e| format!("Failed to decode text: {e}"))?;
     Ok(truncate_web_output(body, max_output_chars))
 }
 
@@ -1781,7 +1777,7 @@ impl Tool for CronTool {
                         format!("Every: {}s", every_ms / 1000)
                     }
                     crate::scheduler::ScheduleKind::Cron { cron_expr } => {
-                        format!("Cron: {}", cron_expr)
+                        format!("Cron: {cron_expr}")
                     }
                 };
                 out.push_str(&format!(
@@ -1811,9 +1807,9 @@ impl Tool for CronTool {
             if let Some(scheduler) = self.mte_cron_scheduler.as_ref() {
                 let removed = scheduler.remove_job(job_id, Utc::now()).await?;
                 return if removed {
-                    Ok(format!("Removed job {}", job_id))
+                    Ok(format!("Removed job {job_id}"))
                 } else {
-                    Ok(format!("Job {} was not found", job_id))
+                    Ok(format!("Job {job_id} was not found"))
                 };
             }
             let cmd = crate::scheduler::CronCommand::Remove {
@@ -1824,7 +1820,7 @@ impl Tool for CronTool {
                 .send_packet(json_str)
                 .await
                 .map_err(|e| e.to_string())?;
-            return Ok(format!("Requested removal of job {}", job_id));
+            return Ok(format!("Requested removal of job {job_id}"));
         }
 
         if action == "add" {
@@ -1892,8 +1888,7 @@ impl Tool for CronTool {
                     )
                     .await?;
                 return Ok(format!(
-                    "Successfully scheduled job {} with action '{}'",
-                    id, message
+                    "Successfully scheduled job {id} with action '{message}'"
                 ));
             }
 
@@ -1911,12 +1906,11 @@ impl Tool for CronTool {
                 .await
                 .map_err(|e| e.to_string())?;
             return Ok(format!(
-                "Successfully scheduled job {} with action '{}'",
-                id, message
+                "Successfully scheduled job {id} with action '{message}'"
             ));
         }
 
-        Err(format!("Unknown action '{}'", action))
+        Err(format!("Unknown action '{action}'"))
     }
 }
 
@@ -2065,8 +2059,8 @@ impl Tool for MessageTool {
         });
 
         match self.outbound_tx.send(msg).await {
-            Ok(_) => Ok(format!("Message sent to {}:{}", channel, chat_id)),
-            Err(e) => Err(format!("Failed to send message: {}", e)),
+            Ok(_) => Ok(format!("Message sent to {channel}:{chat_id}")),
+            Err(e) => Err(format!("Failed to send message: {e}")),
         }
     }
 }
@@ -2113,7 +2107,7 @@ fn truncate_git_worktree_output(mut s: String) -> String {
     }
     let rest = s.len() - end;
     s.truncate(end);
-    s.push_str(&format!("\n... (truncated, {} more chars)", rest));
+    s.push_str(&format!("\n... (truncated, {rest} more chars)"));
     s
 }
 
@@ -2130,8 +2124,8 @@ async fn run_git_output(
     let fut = cmd.output();
     match timeout(Duration::from_secs(timeout_secs), fut).await {
         Ok(Ok(output)) => Ok(output),
-        Ok(Err(e)) => Err(format!("failed to spawn git: {}", e)),
-        Err(_) => Err(format!("git command timed out after {}s", timeout_secs)),
+        Ok(Err(e)) => Err(format!("failed to spawn git: {e}")),
+        Err(_) => Err(format!("git command timed out after {timeout_secs}s")),
     }
 }
 
@@ -2175,7 +2169,7 @@ async fn git_rev_parse_show_toplevel(cwd: &Path) -> Result<PathBuf, String> {
         return Err("git rev-parse --show-toplevel returned empty output".to_string());
     }
     let p = PathBuf::from(line);
-    fs::canonicalize(&p).map_err(|e| format!("could not canonicalize git root: {}", e))
+    fs::canonicalize(&p).map_err(|e| format!("could not canonicalize git root: {e}"))
 }
 
 async fn git_common_dir_abs(wt_path: &Path) -> Result<PathBuf, String> {
@@ -2217,7 +2211,7 @@ async fn git_common_dir_abs(wt_path: &Path) -> Result<PathBuf, String> {
     } else {
         wt_path.join(line)
     };
-    fs::canonicalize(p).map_err(|e| format!("could not canonicalize git common dir: {}", e))
+    fs::canonicalize(p).map_err(|e| format!("could not canonicalize git common dir: {e}"))
 }
 
 fn main_repo_dir_from_common_git_dir(common_dir: &Path) -> PathBuf {
@@ -2325,7 +2319,7 @@ impl GitWorktreeTool {
         }
         if let Some(parent) = wt.parent() {
             fs::create_dir_all(parent)
-                .map_err(|e| format!("failed to create parent directories: {}", e))?;
+                .map_err(|e| format!("failed to create parent directories: {e}"))?;
         }
         let branch_name = if let Some(b) = branch.filter(|s| !s.is_empty()) {
             validate_optional_branch_name(b)?;
@@ -2442,8 +2436,7 @@ impl Tool for GitWorktreeTool {
                 self.action_remove(path, force).await
             }
             _ => Err(format!(
-                "Unknown action {:?}; expected list, add, or remove",
-                action
+                "Unknown action {action:?}; expected list, add, or remove"
             )),
         }
     }
@@ -2499,7 +2492,7 @@ impl Tool for SearchMemoryTool {
             .map_err(|_| "Memory Actor Channel Closed".to_string())??;
 
         if results.is_empty() {
-            Ok(format!("No memory results found for '{}'.", query))
+            Ok(format!("No memory results found for '{query}'."))
         } else {
             Ok(format!(
                 "Memory Search Results:\n\n{}",
@@ -2565,8 +2558,7 @@ impl Tool for FetchMemoryByDateTool {
 
         if results.is_empty() {
             Ok(format!(
-                "No memory results found in the last {} days.",
-                days_ago
+                "No memory results found in the last {days_ago} days."
             ))
         } else {
             Ok(format!(
@@ -2614,7 +2606,7 @@ impl Tool for GetEnvTool {
             } else {
                 v
             };
-            result.push_str(&format!("{}={}\n", k, masked));
+            result.push_str(&format!("{k}={masked}\n"));
         }
         Ok(result)
     }
@@ -2666,21 +2658,21 @@ impl Tool for PythonRunTool {
 
         let mut child = cmd
             .spawn()
-            .map_err(|e| format!("Failed to spawn python: {}", e))?;
+            .map_err(|e| format!("Failed to spawn python: {e}"))?;
 
         if let Some(mut stdin) = child.stdin.take() {
             use tokio::io::AsyncWriteExt;
             stdin
                 .write_all(code.as_bytes())
                 .await
-                .map_err(|e| format!("Failed to write to python stdin: {}", e))?;
+                .map_err(|e| format!("Failed to write to python stdin: {e}"))?;
         }
 
         let output =
             tokio::time::timeout(std::time::Duration::from_secs(60), child.wait_with_output())
                 .await
                 .map_err(|_| "Python execution timed out after 60 seconds")?
-                .map_err(|e| format!("Failed to wait for python: {}", e))?;
+                .map_err(|e| format!("Failed to wait for python: {e}"))?;
 
         let mut result = String::new();
         let stdout = String::from_utf8_lossy(&output.stdout);

--- a/src/tools/compact.rs
+++ b/src/tools/compact.rs
@@ -80,7 +80,7 @@ impl Tool for CompactContextTool {
                 trigger: Some(CompactionTrigger::AgentSelf),
             })
             .await
-            .map_err(|e| format!("Failed to enqueue compaction request: {}", e))?;
+            .map_err(|e| format!("Failed to enqueue compaction request: {e}"))?;
 
         Ok(
             "Compaction scheduled. It will run between this turn and the next user message, \

--- a/src/tools/ml_domain.rs
+++ b/src/tools/ml_domain.rs
@@ -61,8 +61,7 @@ impl Tool for ArxivSearchTool {
 
         let q = urlencoding::encode(query);
         let url = format!(
-            "https://export.arxiv.org/api/query?search_query=all:{}&start=0&max_results={}",
-            q, max_results
+            "https://export.arxiv.org/api/query?search_query=all:{q}&start=0&max_results={max_results}"
         );
 
         let client = reqwest::Client::builder()
@@ -74,7 +73,7 @@ impl Tool for ArxivSearchTool {
             .get(&url)
             .send()
             .await
-            .map_err(|e| format!("arxiv_search request: {}", e))?;
+            .map_err(|e| format!("arxiv_search request: {e}"))?;
 
         if !resp.status().is_success() {
             return Err(format!("arxiv_search HTTP {}", resp.status()));
@@ -83,7 +82,7 @@ impl Tool for ArxivSearchTool {
         let body = resp
             .text()
             .await
-            .map_err(|e| format!("arxiv_search body: {}", e))?;
+            .map_err(|e| format!("arxiv_search body: {e}"))?;
 
         let mut out = String::new();
         let entry_re = regex::Regex::new(r"(?s)<entry>.*?</entry>").map_err(|e| e.to_string())?;
@@ -115,8 +114,7 @@ impl Tool for ArxivSearchTool {
             let id_clean = id.split('/').next_back().unwrap_or(id);
 
             out.push_str(&format!(
-                "ID: {}\nTitle: {}\nSummary: {}\n\n---\n",
-                id_clean, title, summary
+                "ID: {id_clean}\nTitle: {title}\nSummary: {summary}\n\n---\n"
             ));
         }
 
@@ -165,7 +163,7 @@ impl Tool for ArxivFetchTool {
             return Err("invalid arxiv_id".to_string());
         }
 
-        let arxiv2md_url = format!("https://arxiv2md.org/api/markdown?url={}", id);
+        let arxiv2md_url = format!("https://arxiv2md.org/api/markdown?url={id}");
 
         let client = reqwest::Client::builder()
             .user_agent(HF_USER_AGENT)
@@ -186,12 +184,12 @@ impl Tool for ArxivFetchTool {
         }
 
         let full_content = if html_markdown_content.is_empty() {
-            let pdf_url = format!("https://arxiv.org/pdf/{}.pdf", id);
+            let pdf_url = format!("https://arxiv.org/pdf/{id}.pdf");
             let pdf_resp = client
                 .get(&pdf_url)
                 .send()
                 .await
-                .map_err(|e| format!("arxiv_fetch pdf request: {}", e))?;
+                .map_err(|e| format!("arxiv_fetch pdf request: {e}"))?;
 
             if !pdf_resp.status().is_success() {
                 return Err(format!(
@@ -204,7 +202,7 @@ impl Tool for ArxivFetchTool {
             let pdf_bytes = pdf_resp
                 .bytes()
                 .await
-                .map_err(|e| format!("arxiv_fetch pdf body: {}", e))?
+                .map_err(|e| format!("arxiv_fetch pdf body: {e}"))?
                 .to_vec();
 
             crate::utils::extract_markdown_from_pdf_bytes(&pdf_bytes)?
@@ -305,8 +303,7 @@ impl Tool for HfHubFileFetchTool {
             .collect::<Vec<_>>()
             .join("/");
         let url = format!(
-            "https://huggingface.co/{}/resolve/{}/{}",
-            repo, revision, enc_path
+            "https://huggingface.co/{repo}/resolve/{revision}/{enc_path}"
         );
 
         let client = reqwest::Client::builder()
@@ -318,14 +315,14 @@ impl Tool for HfHubFileFetchTool {
         if let Ok(token) = std::env::var("HF_TOKEN") {
             let t = token.trim();
             if !t.is_empty() {
-                req = req.header(AUTHORIZATION, format!("Bearer {}", t));
+                req = req.header(AUTHORIZATION, format!("Bearer {t}"));
             }
         }
 
         let resp = req
             .send()
             .await
-            .map_err(|e| format!("hf_hub_file_fetch request: {}", e))?;
+            .map_err(|e| format!("hf_hub_file_fetch request: {e}"))?;
 
         if !resp.status().is_success() {
             return Err(format!(
@@ -359,7 +356,7 @@ impl Tool for HfHubFileFetchTool {
         let mut body = resp
             .text()
             .await
-            .map_err(|e| format!("hf_hub_file_fetch body: {}", e))?;
+            .map_err(|e| format!("hf_hub_file_fetch body: {e}"))?;
         crate::utils::truncate_utf8_safe(&mut body, self.max_output_chars, "\n... [TRUNCATED]");
         Ok(body)
     }

--- a/src/tools/recall.rs
+++ b/src/tools/recall.rs
@@ -70,11 +70,11 @@ impl Tool for RecallToolResultTool {
                 reply: SharedReply::new(tx),
             })
             .await
-            .map_err(|e| format!("memory bus send: {}", e))?;
+            .map_err(|e| format!("memory bus send: {e}"))?;
         let fetched = rx
             .await
             .map_err(|_| "memory actor channel closed".to_string())?
-            .map_err(|e| format!("fetch tool result: {}", e))?;
+            .map_err(|e| format!("fetch tool result: {e}"))?;
 
         match fetched {
             Some(full_content) => {

--- a/src/tools/workflow.rs
+++ b/src/tools/workflow.rs
@@ -31,8 +31,7 @@ fn normalize_todo_status(s: &str) -> Result<(), String> {
     match s {
         "pending" | "in_progress" | "completed" => Ok(()),
         _ => Err(format!(
-            "Invalid status {:?}; use pending, in_progress, or completed.",
-            s
+            "Invalid status {s:?}; use pending, in_progress, or completed."
         )),
     }
 }
@@ -129,13 +128,13 @@ impl Tool for TodoWriteTool {
             let content = item
                 .get("content")
                 .and_then(|v| v.as_str())
-                .ok_or_else(|| format!("items[{}]: missing content", i))?
+                .ok_or_else(|| format!("items[{i}]: missing content"))?
                 .to_string();
             let status_raw = item
                 .get("status")
                 .and_then(|v| v.as_str())
-                .ok_or_else(|| format!("items[{}]: missing status", i))?;
-            normalize_todo_status(status_raw).map_err(|e| format!("items[{}]: {}", i, e))?;
+                .ok_or_else(|| format!("items[{i}]: missing status"))?;
+            normalize_todo_status(status_raw).map_err(|e| format!("items[{i}]: {e}"))?;
             rows.push(TodoRow {
                 content,
                 status: status_raw.to_string(),
@@ -151,10 +150,10 @@ impl Tool for TodoWriteTool {
                 reply: SharedReply::new(tx),
             })
             .await
-            .map_err(|e| format!("todo_write: memory actor: {}", e))?;
+            .map_err(|e| format!("todo_write: memory actor: {e}"))?;
         rx.await
             .map_err(|_| "Memory actor channel closed".to_string())?
-            .map_err(|e| format!("Failed to save todos: {}", e))?;
+            .map_err(|e| format!("Failed to save todos: {e}"))?;
         Ok(summary)
     }
 }
@@ -206,7 +205,7 @@ impl Tool for ToolSearchTool {
         let entries = self
             .catalog
             .read()
-            .map_err(|e| format!("catalog lock: {}", e))?
+            .map_err(|e| format!("catalog lock: {e}"))?
             .clone();
 
         let hits = search_tool_index(&entries, query, limit);
@@ -224,8 +223,7 @@ impl Tool for ToolSearchTool {
             let snippet: String = desc.chars().take(160).collect();
             let ellipses = if desc.len() > 160 { "…" } else { "" };
             out.push_str(&format!(
-                "- **{}** (score {})\n  {}{}\n\n",
-                name, score, snippet, ellipses
+                "- **{name}** (score {score})\n  {snippet}{ellipses}\n\n"
             ));
         }
         Ok(out.trim_end().to_string())
@@ -368,10 +366,10 @@ impl Tool for AskUserTool {
             for (i, v) in arr.iter().enumerate() {
                 let s = v
                     .as_str()
-                    .ok_or_else(|| format!("choices[{}]: expected string", i))?
+                    .ok_or_else(|| format!("choices[{i}]: expected string"))?
                     .trim();
                 if s.is_empty() {
-                    return Err(format!("choices[{}]: must be non-empty", i));
+                    return Err(format!("choices[{i}]: must be non-empty"));
                 }
                 choices.push(s.to_string());
             }
@@ -409,7 +407,7 @@ impl Tool for AskUserTool {
                             } else {
                                 Some(
                                     serde_json::to_string(&choices)
-                                        .map_err(|e| format!("serialize choices: {}", e))?,
+                                        .map_err(|e| format!("serialize choices: {e}"))?,
                                 )
                             },
                             response: None,
@@ -420,10 +418,10 @@ impl Tool for AskUserTool {
                         reply: SharedReply::new(tx),
                     })
                     .await
-                    .map_err(|e| format!("clarification ticket enqueue: {}", e))?;
+                    .map_err(|e| format!("clarification ticket enqueue: {e}"))?;
                 rx.await
                     .map_err(|_| "clarification ticket actor channel closed".to_string())?
-                    .map_err(|e| format!("clarification ticket: {}", e))?;
+                    .map_err(|e| format!("clarification ticket: {e}"))?;
 
                 let notification_id = uuid::Uuid::new_v4().to_string();
                 let (ntx, nrx) = tokio::sync::oneshot::channel();
@@ -446,10 +444,10 @@ impl Tool for AskUserTool {
                         reply: SharedReply::new(ntx),
                     })
                     .await
-                    .map_err(|e| format!("notification enqueue: {}", e))?;
+                    .map_err(|e| format!("notification enqueue: {e}"))?;
                 nrx.await
                     .map_err(|_| "notification actor channel closed".to_string())?
-                    .map_err(|e| format!("notification: {}", e))?;
+                    .map_err(|e| format!("notification: {e}"))?;
                 let _ = self
                     .outbound_tx
                     .send(BusMessage::Telemetry(
@@ -490,15 +488,14 @@ impl Tool for AskUserTool {
                 chat_id: ctx.chat_id.clone(),
                 thread_id: ctx.thread_id.clone(),
                 content: format!(
-                    "Background task needs input and has been paused.\n\nQuestion: {}\nTicket: {}",
-                    prompt, ticket_id
+                    "Background task needs input and has been paused.\n\nQuestion: {prompt}\nTicket: {ticket_id}"
                 ),
                 metadata,
             };
             self.outbound_tx
                 .send(BusMessage::Outbound(outbound))
                 .await
-                .map_err(|e| format!("failed to send clarification ticket notification: {}", e))?;
+                .map_err(|e| format!("failed to send clarification ticket notification: {e}"))?;
 
             // Update job state to waiting
             let (tx, rx) = tokio::sync::oneshot::channel();
@@ -560,7 +557,7 @@ impl Tool for AskUserTool {
         self.outbound_tx
             .send(BusMessage::Outbound(outbound))
             .await
-            .map_err(|e| format!("failed to send clarification prompt: {}", e))?;
+            .map_err(|e| format!("failed to send clarification prompt: {e}"))?;
 
         let reply = match timeout_secs {
             Some(timeout_secs) => {
@@ -568,8 +565,7 @@ impl Tool for AskUserTool {
                 match tokio::time::timeout(wait, rx).await {
                     Err(_) => {
                         return Err(format!(
-                            "Timed out after {}s waiting for a user reply to ask_user.",
-                            timeout_secs
+                            "Timed out after {timeout_secs}s waiting for a user reply to ask_user."
                         ));
                     }
                     Ok(Err(_)) => {
@@ -603,14 +599,13 @@ impl Tool for AskUserTool {
                 Some(s) => s,
                 None => {
                     return Ok(format!(
-                        "User reply (not among listed choices): {}\n\nListed options were: {:?}",
-                        reply, choices
+                        "User reply (not among listed choices): {reply}\n\nListed options were: {choices:?}"
                     ));
                 }
             }
         };
 
-        Ok(format!("User reply:\n{}", canonical_reply))
+        Ok(format!("User reply:\n{canonical_reply}"))
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -369,7 +369,7 @@ pub fn format_api_error(status: u16, body: &str, base_url: &str, model: &str) ->
 
     let code_tag = error_code
         .as_deref()
-        .map(|c| format!(" [{}]", c))
+        .map(|c| format!(" [{c}]"))
         .unwrap_or_default();
 
     match status {
@@ -388,37 +388,31 @@ pub fn format_api_error(status: u16, body: &str, base_url: &str, model: &str) ->
                 "Check that the correct API key is set for this provider."
             };
             format!(
-                "({}{}) Authentication failed for model '{}'. {}",
-                status, code_tag, model, hint
+                "({status}{code_tag}) Authentication failed for model '{model}'. {hint}"
             )
         }
         403 => {
             let detail = msg
                 .as_deref()
-                .map(|m| format!(" {}", m))
+                .map(|m| format!(" {m}"))
                 .unwrap_or_default();
             format!(
-                "({}{}) Access denied for model '{}'.{} Your API key may not have permission to use this model.",
-                status, code_tag, model, detail
+                "({status}{code_tag}) Access denied for model '{model}'.{detail} Your API key may not have permission to use this model."
             )
         }
         404 => format!(
-            "({}{}) Model '{}' not found at {}. It may not exist or is not available on your plan.",
-            status, code_tag, model, base_url
+            "({status}{code_tag}) Model '{model}' not found at {base_url}. It may not exist or is not available on your plan."
         ),
         429 => format!(
-            "({}{}) Rate limit exceeded for model '{}'. Try again in a moment.",
-            status, code_tag, model
+            "({status}{code_tag}) Rate limit exceeded for model '{model}'. Try again in a moment."
         ),
         _ if status >= 500 => format!(
-            "({}{}) Server error from provider while using model '{}'. Try again later.",
-            status, code_tag, model
+            "({status}{code_tag}) Server error from provider while using model '{model}'. Try again later."
         ),
         _ => {
             let detail = msg.unwrap_or_else(|| body.chars().take(200).collect());
             format!(
-                "({}{}) API error for model '{}': {}",
-                status, code_tag, model, detail
+                "({status}{code_tag}) API error for model '{model}': {detail}"
             )
         }
     }
@@ -590,7 +584,7 @@ impl LLMClient {
             match serde_json::from_value::<Vec<ToolCallRequest>>(tc_json) {
                 Ok(calls) => Some(calls),
                 Err(e) => {
-                    warn!("Failed to parse tool_calls from provider response: {}", e);
+                    warn!("Failed to parse tool_calls from provider response: {e}");
                     None
                 }
             }
@@ -871,7 +865,7 @@ pub fn extract_json_from_llm_response(text: &str) -> Option<serde_json::Value> {
 /// Extracts text from a PDF file byte payload into Markdown format.
 pub fn extract_markdown_from_pdf_bytes(pdf_bytes: &[u8]) -> Result<String, String> {
     let doc = pdf_oxide::PdfDocument::from_bytes(pdf_bytes.to_vec())
-        .map_err(|e| format!("pdf_oxide error: {:?}", e))?;
+        .map_err(|e| format!("pdf_oxide error: {e:?}"))?;
 
     let mut extracted = String::new();
     let options = pdf_oxide::converters::ConversionOptions::default();

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -19,19 +19,19 @@ pub fn resolve_workspace_root(path_override: Option<&str>) -> PathBuf {
 
 pub fn ensure_workspace_layout(root: &Path) -> Result<WorkspaceLayout, String> {
     if !root.exists() {
-        info!("Creating workspace directory at {:?}", root);
+        info!("Creating workspace directory at {root:?}");
     }
-    fs::create_dir_all(root).map_err(|e| format!("Failed to create workspace dir: {}", e))?;
+    fs::create_dir_all(root).map_err(|e| format!("Failed to create workspace dir: {e}"))?;
 
     let system_dir = root.join(".system_generated");
     fs::create_dir_all(&system_dir)
-        .map_err(|e| format!("Failed to create .system_generated dir: {}", e))?;
+        .map_err(|e| format!("Failed to create .system_generated dir: {e}"))?;
 
     let sandbox_dir = root.join("workspace");
-    fs::create_dir_all(&sandbox_dir).map_err(|e| format!("Failed to create sandbox dir: {}", e))?;
+    fs::create_dir_all(&sandbox_dir).map_err(|e| format!("Failed to create sandbox dir: {e}"))?;
 
     let skills_dir = sandbox_dir.join("skills");
-    fs::create_dir_all(&skills_dir).map_err(|e| format!("Failed to create skills dir: {}", e))?;
+    fs::create_dir_all(&skills_dir).map_err(|e| format!("Failed to create skills dir: {e}"))?;
 
     Ok(WorkspaceLayout {
         root: root.to_path_buf(),
@@ -88,8 +88,8 @@ impl IsanagentWorkspace {
 
         let config = if config_path.exists() {
             let toml_str = fs::read_to_string(&config_path)
-                .map_err(|e| format!("Failed to read config.toml: {}", e))?;
-            toml::from_str(&toml_str).map_err(|e| format!("Failed to parse config.toml: {}", e))?
+                .map_err(|e| format!("Failed to read config.toml: {e}"))?;
+            toml::from_str(&toml_str).map_err(|e| format!("Failed to parse config.toml: {e}"))?
         } else {
             AppConfig::default()
         };
@@ -116,11 +116,11 @@ impl IsanagentWorkspace {
         if file_path.exists() {
             match fs::read_to_string(&file_path) {
                 Ok(content) => {
-                    info!("Loaded {}", filename);
+                    info!("Loaded {filename}");
                     Some(content)
                 }
                 Err(e) => {
-                    warn!("Failed to read {}: {}", filename, e);
+                    warn!("Failed to read {filename}: {e}");
                     None
                 }
             }
@@ -134,21 +134,20 @@ impl IsanagentWorkspace {
         let mut prompt_parts = Vec::new();
 
         if let Some(agent) = self.read_md_file("AGENTS.md") {
-            prompt_parts.push(format!("--- AGENT INSTRUCTIONS ---\n{}\n", agent));
+            prompt_parts.push(format!("--- AGENT INSTRUCTIONS ---\n{agent}\n"));
         }
         if let Some(soul) = self.read_md_file("SOUL.md") {
-            prompt_parts.push(format!("--- AGENT PERSONA (SOUL) ---\n{}\n", soul));
+            prompt_parts.push(format!("--- AGENT PERSONA (SOUL) ---\n{soul}\n"));
         }
         if let Some(user) = self.read_md_file("USER.md") {
-            prompt_parts.push(format!("--- USER PROFILE ---\n{}\n", user));
+            prompt_parts.push(format!("--- USER PROFILE ---\n{user}\n"));
         }
         if let Some(memory) = self.read_md_file("MEMORY.md") {
-            prompt_parts.push(format!("--- LONG TERM MEMORY ---\n{}\n", memory));
+            prompt_parts.push(format!("--- LONG TERM MEMORY ---\n{memory}\n"));
         }
         if let Some(ml) = self.read_md_file("ML_POLICY.md") {
             prompt_parts.push(format!(
-                "--- ML / TRAINING POLICY (ML_POLICY.md) ---\n{}\n",
-                ml
+                "--- ML / TRAINING POLICY (ML_POLICY.md) ---\n{ml}\n"
             ));
         }
 


### PR DESCRIPTION
## Summary
Re-opens the #99 host API work for Monatis review/merge after #100 reverted the premature merge.

- Public host additions for ALTAI CLI: `run_oneshot`, `oneshot_prompt`, `observe_tx`, `scripted_responses`
- `HostThemeMode` (auto/dark/light/no-color) wired into TUI/line mode
- Four-way approvals (approve/deny/always/abort) + edit-diff metadata; plan-mode shell/edit policy
- Real `--file` / `@path` attachments (text/image/PDF) with fuzzy basename resolve
- `compact_auto` / `compact_threshold_tokens` / `compact_tail_turns` host overrides
- Line-mode `/context` + `/compact`
- Oneshot `/dev/tty` approval resume; logger re-init fix for multi-host tests

Please **only Monatis** merge this PR.

## Test plan
- [ ] `cargo test --lib host::`
- [ ] `cargo test --lib channels::terminal_ui::attachments`
- [ ] `cargo test --lib channels::terminal_ui::approval`
- [ ] `cargo check --all-targets --locked`
- [ ] Smoke: scripted oneshot completes; interactive approval hotkeys y/n/a/x


Made with [Cursor](https://cursor.com)